### PR TITLE
make rebuildState public so it can be called externally, most notably

### DIFF
--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -58,6 +58,8 @@ func repositorySnapshots(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	lrepository.RebuildState()
+
 	snapshotIDs, err := lrepository.GetSnapshots()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -52,13 +52,13 @@ func New(store *storage.Store, secret []byte) (*Repository, error) {
 		configuration: store.Configuration(),
 		secret:        secret,
 	}
-	if err := r.rebuildState(); err != nil {
+	if err := r.RebuildState(); err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-func (r *Repository) rebuildState() error {
+func (r *Repository) RebuildState() error {
 	t0 := time.Now()
 	defer func() {
 		profiler.RecordEvent("repository.rebuildState", time.Since(t0))


### PR DESCRIPTION
by any long-standing command to catch up on new snapshots that happened since the command was launched