### PR TITLE
don't check update at every invocation

### DIFF
--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -142,7 +142,7 @@ func entryPoint() int {
 	ctx.SetCacheDir(cacheDir)
 
 	// best effort check if security or reliability fix have been issued
-	if rus, err := utils.CheckUpdate(); err == nil {
+	if rus, err := utils.CheckUpdate(ctx.GetCacheDir()); err == nil {
 		if rus.SecurityFix || rus.ReliabilityFix {
 			concerns := ""
 			if rus.SecurityFix {

--- a/cmd/plakar/utils/utils.go
+++ b/cmd/plakar/utils/utils.go
@@ -289,10 +289,10 @@ type ReleaseUpdateSummary struct {
 	ReliabilityFix bool
 }
 
-func CheckUpdate() (ReleaseUpdateSummary, error) {
+func CheckUpdate() (update ReleaseUpdateSummary, err error) {
 	req, err := http.NewRequest("GET", "https://plakar.io/api/releases.atom", nil)
 	if err != nil {
-		return ReleaseUpdateSummary{}, err
+		return
 	}
 
 	req.Header.Set("User-Agent", fmt.Sprintf("plakar/%s (%s/%s)", VERSION, runtime.GOOS, runtime.GOARCH))
@@ -300,50 +300,44 @@ func CheckUpdate() (ReleaseUpdateSummary, error) {
 	client := http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		return ReleaseUpdateSummary{}, err
+		return
 	}
 	defer res.Body.Close()
 
 	var feed []atom.Feed
 	err = xml.NewDecoder(res.Body).Decode(&feed)
 	if err != nil {
-		return ReleaseUpdateSummary{}, err
+		return
 	}
 
-	found := false
-	foundCount := 0
 	var latestEntry *atom.Entry
-	sawSecurityFix := false
-	sawReliabilityFix := false
 	for _, entry := range feed[0].Entry {
 		if !semver.IsValid(entry.Title) {
 			continue
 		}
-		if semver.Compare(VERSION, entry.Title) < 0 {
-			found = true
-			foundCount++
-			if latestEntry == nil {
-				latestEntry = entry
-			} else {
-				if semver.Compare(latestEntry.Title, entry.Title) < 0 {
-					latestEntry = entry
-				}
-			}
-			if latestEntry.Content != nil {
-				if strings.Contains(latestEntry.Content.Body, "SECURITY") {
-					sawSecurityFix = true
-				}
-				if strings.Contains(latestEntry.Content.Body, "RELIABILITY") {
-					sawReliabilityFix = true
-				}
-			}
+		if semver.Compare(VERSION, entry.Title) >= 0 {
+			continue
+		}
+
+		update.FoundCount++
+
+		if latestEntry == nil || semver.Compare(latestEntry.Title, entry.Title) < 0 {
+			latestEntry = entry
+		}
+
+		if latestEntry.Content == nil {
+			continue
+		}
+
+		body := latestEntry.Content.Body
+		if strings.Contains(body, "SECURITY") {
+			update.SecurityFix = true
+		}
+		if strings.Contains(body, "RELIABILITY") {
+			update.ReliabilityFix = true
 		}
 	}
-	if !found {
-		return ReleaseUpdateSummary{FoundCount: 0, Latest: VERSION}, nil
-	} else {
-		return ReleaseUpdateSummary{FoundCount: foundCount, Latest: latestEntry.Title, SecurityFix: sawSecurityFix, ReliabilityFix: sawReliabilityFix}, nil
-	}
+	return
 }
 
 func PathIsWithin(pathname string, within string) bool {


### PR DESCRIPTION
Instead of checking for updates at every invocation, try to check at most daily.

Not a fan of the stat + open TOCTOU, but I don't know a better way around.  We could `open(O_RDWR|O_CREATE)` but then we don't know if we're the ones that created the file or it was created by someone else very recently.

This means that concurrent plakar processes with the wrong timing could all end up checking for update, but at least it's only an issue for concurrent invocations.

I've also tried to simplify CheckUpdate a bit.  it's probably easier to read the two commits one by one instead of the cumulative diff.