### PR TITLE
errors are no longer stored as an array below DirEntry, instead

### DIFF
--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"sort"
 	"strconv"
 	"syscall"
 
@@ -336,36 +335,61 @@ func snapshotVFSErrors(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not a directory", http.StatusBadRequest)
 		return
 	} else {
-		errors := make([]vfs.ErrorEntry, 0, len(dirEntry.Errors))
-		errors = append(errors, dirEntry.Errors...)
-		if limit == 0 {
-			limit = int64(len(errors))
-		}
-
-		if sortKeysStr == "Name" {
-			sort.Slice(errors, func(i, j int) bool {
-				return errors[i].Filename < errors[j].Filename
-			})
-		} else if sortKeysStr == "-Name" {
-			sort.Slice(errors, func(i, j int) bool {
-				return errors[i].Filename > errors[j].Filename
-			})
-		}
-
-		if offset > int64(len(dirEntry.Children)) {
-			errors = []vfs.ErrorEntry{}
-		} else if offset+limit > int64(len(dirEntry.Children)) {
-			errors = errors[offset:]
-		} else {
-			errors = errors[offset : offset+limit]
-		}
-
 		items := Items{
-			Total: len(dirEntry.Errors),
-			Items: make([]interface{}, len(errors)),
+			Total: 0,
+			Items: make([]interface{}, 0),
 		}
-		for i, ee := range errors {
-			items.Items[i] = ee
+		if dirEntry.ErrorFirst != nil {
+
+			if sortKeysStr == "Name" {
+				iter := dirEntry.ErrorFirst
+				for i := 0; i < int(limit+offset) && iter != nil; i++ {
+					errorEntryBytes, err := snap.GetError(*iter)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+
+					errorEntry, err := vfs.ErrorEntryFromBytes(errorEntryBytes)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					iter = errorEntry.Successor
+
+					if i < int(offset) {
+						continue
+					}
+
+					items.Total += 1
+					errorEntry.Predecessor = nil
+					errorEntry.Successor = nil
+					items.Items = append(items.Items, errorEntry)
+				}
+			} else if sortKeysStr == "-Name" {
+				iter := dirEntry.ErrorLast
+				for i := 0; i < int(limit+offset) && iter != nil; i++ {
+					errorEntryBytes, err := snap.GetError(*iter)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+
+					errorEntry, err := vfs.ErrorEntryFromBytes(errorEntryBytes)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					iter = errorEntry.Predecessor
+					if i < int(offset) {
+						continue
+					}
+					items.Total += 1
+					errorEntry.Predecessor = nil
+					errorEntry.Successor = nil
+					items.Items = append(items.Items, errorEntry)
+				}
+			}
 		}
 		json.NewEncoder(w).Encode(items)
 	}

--- a/cmd/plakar/subcommands/info/info.go
+++ b/cmd/plakar/subcommands/info/info.go
@@ -578,9 +578,9 @@ func info_vfs(repo *repository.Repository, snapshotPath string) error {
 			fmt.Printf("Child[%d].FileInfo.Nlink(): %d\n", offset, child.Stat().Nlink())
 		}
 
-		for offset, errentry := range dirEntry.Errors {
-			fmt.Printf("Error[%d]: %s: %s\n", offset, errentry.Filename, errentry.Error)
-		}
+		//for offset, errentry := range dirEntry.Errors {
+		//	fmt.Printf("Error[%d]: %s: %s\n", offset, errentry.Name, errentry.Error)
+		//}
 
 	} else if fileEntry, isFile := fsinfo.(*vfs.FileEntry); isFile {
 		fmt.Printf("[FileEntry]\n")

--- a/packfile/packfile.go
+++ b/packfile/packfile.go
@@ -22,6 +22,7 @@ const (
 	TYPE_DIRECTORY = 4
 	TYPE_DATA      = 5
 	TYPE_SIGNATURE = 6
+	TYPE_ERROR     = 7
 )
 
 type Blob struct {
@@ -47,6 +48,8 @@ func (b Blob) TypeName() string {
 		return "data"
 	case TYPE_SIGNATURE:
 		return "signature"
+	case TYPE_ERROR:
+		return "error"
 	default:
 		return "unknown"
 	}

--- a/snapshot/vfs/dirEntry.go
+++ b/snapshot/vfs/dirEntry.go
@@ -8,11 +8,6 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-type ErrorEntry struct {
-	Filename string `msgpack:"filename" json:"filename"`
-	Error    string `msgpack:"error" json:"error"`
-}
-
 type ChildEntry struct {
 	Lchecksum objects.Checksum `msgpack:"checksum" json:"Checksum"`
 	LfileInfo objects.FileInfo `msgpack:"fileInfo" json:"FileInfo"`
@@ -50,7 +45,8 @@ type DirEntry struct {
 	Tags           []string         `msgpack:"tags,omitempty"`
 
 	/* Errors */
-	Errors []ErrorEntry `msgpack:"errors,omitempty"`
+	ErrorFirst *objects.Checksum `msgpack:"errorFirst,omitempty"`
+	ErrorLast  *objects.Checksum `msgpack:"errorLast,omitempty"`
 }
 
 func (*DirEntry) fsEntry() {}
@@ -101,13 +97,6 @@ func DirEntryFromBytes(serialized []byte) (*DirEntry, error) {
 		d.Tags = make([]string, 0)
 	}
 	return &d, nil
-}
-
-func (d *DirEntry) AddError(filename, error string) {
-	d.Errors = append(d.Errors, ErrorEntry{
-		Filename: filename,
-		Error:    error,
-	})
 }
 
 func (d *DirEntry) AddFileChild(checksum [32]byte, fileInfo objects.FileInfo) {

--- a/snapshot/vfs/errorEntry.go
+++ b/snapshot/vfs/errorEntry.go
@@ -1,0 +1,26 @@
+package vfs
+
+import (
+	"github.com/PlakarKorp/plakar/objects"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type ErrorEntry struct {
+	Predecessor *objects.Checksum `msgpack:"predecessor,omitempty" json:"predecessor,omitempty"`
+	Successor   *objects.Checksum `msgpack:"successor,omitempty" json:"successor,omitempty"`
+	Name        string            `msgpack:"name" json:"name"`
+	Error       string            `msgpack:"error" json:"error"`
+}
+
+func ErrorEntryFromBytes(data []byte) (*ErrorEntry, error) {
+	entry := &ErrorEntry{}
+	err := msgpack.Unmarshal(data, entry)
+	if err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+func (e *ErrorEntry) ToBytes() ([]byte, error) {
+	return msgpack.Marshal(e)
+}


### PR DESCRIPTION
they are stored unitarily in packfiles and DirEntry can use the error entry checksum as a list head.