### PR TITLE
Set CORS Allowed-Headers

### DIFF
--- a/ui/v2/ui.go
+++ b/ui/v2/ui.go
@@ -117,7 +117,9 @@ func Ui(repo *repository.Repository, addr string, opts *UiOptions) error {
 	}
 
 	if opts.Cors {
-		return http.ListenAndServe(addr, handlers.CORS()(r))
+		return http.ListenAndServe(addr, handlers.CORS(
+			handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}),
+		)(r))
 	}
 	return http.ListenAndServe(addr, r)
 }


### PR DESCRIPTION
For requests containing a Authorization header, the browser generates a pre-flight request that requires the response to contain a header Access-Control-Allowed-Headers containing Content-Type and Authorization.