### PR TITLE
the wrong record type is recorded in file summaries leading to

### DIFF
--- a/cmd/plakar/subcommands/info/info.go
+++ b/cmd/plakar/subcommands/info/info.go
@@ -605,10 +605,12 @@ func info_vfs(repo *repository.Repository, snapshotPath string) error {
 		}
 		fmt.Printf("CustomMetadata: %s\n", fileEntry.CustomMetadata)
 		fmt.Printf("Tags: %s\n", fileEntry.Tags)
-		fmt.Printf("Checksum: %x\n", fileEntry.Object.Checksum)
-		for offset, chunk := range fileEntry.Object.Chunks {
-			fmt.Printf("Chunk[%d].Checksum: %x\n", offset, chunk.Checksum)
-			fmt.Printf("Chunk[%d].Length: %d\n", offset, chunk.Length)
+		if fileEntry.Object != nil {
+			fmt.Printf("Checksum: %x\n", fileEntry.Object.Checksum)
+			for offset, chunk := range fileEntry.Object.Chunks {
+				fmt.Printf("Chunk[%d].Checksum: %x\n", offset, chunk.Checksum)
+				fmt.Printf("Chunk[%d].Length: %d\n", offset, chunk.Length)
+			}
 		}
 	}
 	return nil

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -654,7 +654,7 @@ func (snap *Snapshot) Backup(scanDir string, options *PushOptions) error {
 				}
 
 				fileSummary := &vfs.FileSummary{
-					Type:    importer.RecordTypeFile,
+					Type:    record.Type,
 					Size:    uint64(record.FileInfo.Size()),
 					Mode:    record.FileInfo.Mode(),
 					ModTime: record.FileInfo.ModTime().Unix(),

--- a/snapshot/vfs/fileEntry.go
+++ b/snapshot/vfs/fileEntry.go
@@ -36,7 +36,7 @@ func (*FileEntry) fsEntry() {}
 
 func NewFileEntry(parentPath string, record *importer.ScanRecord) *FileEntry {
 	target := ""
-	if record.Type == importer.RecordTypeSymlink {
+	if record.Target != "" {
 		target = record.Target
 	}
 


### PR DESCRIPTION
broken symlinks in the VFS