### PR TITLE
use go-cdc-chunkers from PlakarKorp

### DIFF
--- a/chunking/chunking_test.go
+++ b/chunking/chunking_test.go
@@ -3,7 +3,7 @@ package chunking
 import (
 	"testing"
 
-	chunkers "github.com/PlakarLabs/go-cdc-chunkers"
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
 )
 
 func TestDefaultAlgorithm(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/PlakarKorp/plakar
 go 1.22.2
 
 require (
-	github.com/PlakarLabs/go-cdc-chunkers v0.0.7
 	github.com/alecthomas/chroma v0.10.0
 	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/anacrolix/fuse v0.4.0
@@ -35,6 +34,7 @@ require (
 )
 
 require (
+	github.com/PlakarKorp/go-cdc-chunkers v0.0.8 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/Julusian/godocdown v0.0.0-20170816220326-6d19f8ff2df8/go.mod h1:INZr5t32rG59/5xeltqoCJoNY7e5x/3xoY9WSWVWg74=
-github.com/PlakarLabs/go-cdc-chunkers v0.0.7 h1:lfDPsxoSHEGDxXNFpOb1Tr6wtOKkm8pleBCgF9p0p4s=
-github.com/PlakarLabs/go-cdc-chunkers v0.0.7/go.mod h1:BWr615Ldhjf2OpNy8lNMjrqiL8d0C3+naItVybDfXXU=
+github.com/PlakarKorp/go-cdc-chunkers v0.0.8 h1:k1sH+OIsBVY24wMJvnR0vMR6zwjUtOWOlIj9E8mdDjc=
+github.com/PlakarKorp/go-cdc-chunkers v0.0.8/go.mod h1:2HDU7VZeHUpTRviOHSGIrliMQgBnsBAAW8NoZIyW9qY=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
 github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -17,9 +17,9 @@ import (
 	"github.com/PlakarKorp/plakar/packfile"
 	"github.com/PlakarKorp/plakar/repository/state"
 	"github.com/PlakarKorp/plakar/storage"
-	chunkers "github.com/PlakarLabs/go-cdc-chunkers"
-	_ "github.com/PlakarLabs/go-cdc-chunkers/chunkers/fastcdc"
-	_ "github.com/PlakarLabs/go-cdc-chunkers/chunkers/ultracdc"
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fastcdc"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/ultracdc"
 )
 
 var (


### PR DESCRIPTION
noticed after the typo on the readme; we were still using go-cdc-chunkers from PlakarLabs.