### PR TITLE
remove explicit comparer from ScanFrom

### DIFF
--- a/btree/btree.go
+++ b/btree/btree.go
@@ -74,7 +74,7 @@ func (n *Node[K, P, V]) isleaf() bool {
 	return len(n.Pointers) == 0
 }
 
-func (b *BTree[K, P, V]) findleaf(key K, cmp func(K, K) int) (node Node[K, P, V], path []P, err error) {
+func (b *BTree[K, P, V]) findleaf(key K) (node Node[K, P, V], path []P, err error) {
 	ptr := b.Root
 
 	for {
@@ -88,7 +88,7 @@ func (b *BTree[K, P, V]) findleaf(key K, cmp func(K, K) int) (node Node[K, P, V]
 			return
 		}
 
-		idx, found := slices.BinarySearchFunc(node.Keys, key, cmp)
+		idx, found := slices.BinarySearchFunc(node.Keys, key, b.compare)
 		if found {
 			idx++
 		}
@@ -101,7 +101,7 @@ func (b *BTree[K, P, V]) findleaf(key K, cmp func(K, K) int) (node Node[K, P, V]
 }
 
 func (b *BTree[K, P, V]) Find(key K) (val V, found bool, err error) {
-	leaf, _, err := b.findleaf(key, b.compare)
+	leaf, _, err := b.findleaf(key)
 	if err != nil {
 		return
 	}
@@ -158,7 +158,7 @@ func (n *Node[K, P, V]) split() (new Node[K, P, V]) {
 }
 
 func (b *BTree[K, P, V]) Insert(key K, val V) error {
-	node, path, err := b.findleaf(key, b.compare)
+	node, path, err := b.findleaf(key)
 	if err != nil {
 		return err
 	}

--- a/btree/btree_test.go
+++ b/btree/btree_test.go
@@ -224,7 +224,7 @@ func TestScanFrom(t *testing.T) {
 		}
 	}
 
-	iter, err := tree.ScanFrom(rune('e'), nil)
+	iter, err := tree.ScanFrom(rune('e'))
 	if err != nil {
 		t.Fatalf("ScanAll failed: %v", err)
 	}

--- a/btree/iter.go
+++ b/btree/iter.go
@@ -84,12 +84,8 @@ func (b *BTree[K, P, V]) ScanAll() (Iterator[K, P, V], error) {
 // ScanFrom returns an iterator that visits all the values starting
 // from the given key, or the first key larger than the given one,
 // onwards.
-func (b *BTree[K, P, V]) ScanFrom(key K, cmp func(K, K) int) (Iterator[K, P, V], error) {
-	if cmp == nil {
-		cmp = b.compare
-	}
-
-	node, path, err := b.findleaf(key, cmp)
+func (b *BTree[K, P, V]) ScanFrom(key K) (Iterator[K, P, V], error) {
+	node, path, err := b.findleaf(key)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +97,7 @@ func (b *BTree[K, P, V]) ScanFrom(key K, cmp func(K, K) int) (Iterator[K, P, V],
 		found bool
 	)
 	for idx = range node.Keys {
-		if cmp(key, node.Keys[idx]) <= 0 {
+		if b.compare(key, node.Keys[idx]) <= 0 {
 			found = true
 			break
 		}

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -485,7 +485,7 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 		}
 		dirEntry.Children = lastChecksum
 
-		iter, err := backupCtx.tree.ScanFrom(record.Pathname, pathCmp)
+		iter, err := backupCtx.tree.ScanFrom(record.Pathname)
 		if err != nil {
 			return err
 		}

--- a/snapshot/errors.go
+++ b/snapshot/errors.go
@@ -14,13 +14,6 @@ type ErrorItem struct {
 	Error string `msgpack:"error" json:"error"`
 }
 
-func pathCmp(a, b string) int {
-	if strings.HasPrefix(a, b) {
-		return -1
-	}
-	return strings.Compare(a, b)
-}
-
 func (snapshot *Snapshot) Errors(beneath string) (<-chan ErrorItem, error) {
 	if !strings.HasSuffix(beneath, "/") {
 		beneath += "/"
@@ -47,7 +40,7 @@ func (snapshot *Snapshot) Errors(beneath string) (<-chan ErrorItem, error) {
 		}
 		tree := btree.FromStorage(root.Root, &storage, strings.Compare, root.Order)
 
-		iter, err := tree.ScanFrom(beneath, pathCmp)
+		iter, err := tree.ScanFrom(beneath)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
it was a bad idea.  I've introduced because I thought it could have been handy for customizing the start of the iteration, but in practice it's just a footgun in the btree API.