### PR TITLE
fix cross-OS path handling

### DIFF
--- a/cmd/plakar/subcommands/checksum/checksum.go
+++ b/cmd/plakar/subcommands/checksum/checksum.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 
 	"github.com/PlakarKorp/plakar/cmd/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/cmd/plakar/utils"
@@ -86,7 +86,7 @@ func displayChecksums(fs *vfs.Filesystem, repo *repository.Repository, snap *sna
 			return err
 		}
 		for child := range children {
-			if err := displayChecksums(fs, repo, snap, filepath.Join(pathname, child.Stat().Name()), fastcheck); err != nil {
+			if err := displayChecksums(fs, repo, snap, path.Join(pathname, child.Stat().Name()), fastcheck); err != nil {
 				return err
 			}
 		}

--- a/cmd/plakar/subcommands/diff/diff.go
+++ b/cmd/plakar/subcommands/diff/diff.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/PlakarKorp/plakar/cmd/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/cmd/plakar/utils"
@@ -155,13 +155,13 @@ func diff_files(snap1 *snapshot.Snapshot, fileEntry1 *vfs.FileEntry, snap2 *snap
 
 	if fileEntry1.Object.Checksum == fileEntry2.Object.Checksum {
 		fmt.Printf("%s:%s and %s:%s are identical\n",
-			fmt.Sprintf("%x", snap1.Header.GetIndexShortID()), filepath.Join(fileEntry1.ParentPath, fileEntry1.Stat().Name()),
-			fmt.Sprintf("%x", snap2.Header.GetIndexShortID()), filepath.Join(fileEntry2.ParentPath, fileEntry2.Stat().Name()))
+			fmt.Sprintf("%x", snap1.Header.GetIndexShortID()), path.Join(fileEntry1.ParentPath, fileEntry1.Stat().Name()),
+			fmt.Sprintf("%x", snap2.Header.GetIndexShortID()), path.Join(fileEntry2.ParentPath, fileEntry2.Stat().Name()))
 		return "", nil
 	}
 
-	filename1 := filepath.Join(fileEntry1.ParentPath, fileEntry1.Stat().Name())
-	filename2 := filepath.Join(fileEntry2.ParentPath, fileEntry2.Stat().Name())
+	filename1 := path.Join(fileEntry1.ParentPath, fileEntry1.Stat().Name())
+	filename2 := path.Join(fileEntry2.ParentPath, fileEntry2.Stat().Name())
 
 	buf1 := make([]byte, 0)
 	rd1, err := snap1.NewReader(filename1)

--- a/snapshot/check.go
+++ b/snapshot/check.go
@@ -3,7 +3,7 @@ package snapshot
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sync"
 
 	"github.com/PlakarKorp/plakar/events"
@@ -33,7 +33,7 @@ func snapshotCheckPath(snap *Snapshot, fs *vfs.Filesystem, pathname string, opts
 			return false, err
 		}
 		for child := range children {
-			ok, err := snapshotCheckPath(snap, fs, filepath.Join(pathname, child.Stat().Name()), opts, concurrency, wg)
+			ok, err := snapshotCheckPath(snap, fs, path.Join(pathname, child.Stat().Name()), opts, concurrency, wg)
 			if err != nil || !ok {
 				complete = false
 			}

--- a/snapshot/restore.go
+++ b/snapshot/restore.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -34,9 +33,9 @@ func snapshotRestorePath(snap *Snapshot, fs *vfs.Filesystem, exp exporter.Export
 
 	var dest string
 	if opts.Rebase && strings.HasPrefix(pathname, base) {
-		dest = filepath.Join(target, pathname[len(base):])
+		dest = path.Join(target, pathname[len(base):])
 	} else {
-		dest = filepath.Join(target, pathname)
+		dest = path.Join(target, pathname)
 	}
 
 	if dirEntry, isDir := fsinfo.(*vfs.DirEntry); isDir {
@@ -57,7 +56,7 @@ func snapshotRestorePath(snap *Snapshot, fs *vfs.Filesystem, exp exporter.Export
 			return err
 		}
 		for child := range children {
-			err = snapshotRestorePath(snap, fs, exp, target, base, filepath.Join(pathname, child.Stat().Name()), opts, restoreContext, &subwg)
+			err = snapshotRestorePath(snap, fs, exp, target, base, path.Join(pathname, child.Stat().Name()), opts, restoreContext, &subwg)
 			if err != nil {
 				complete = false
 			}

--- a/snapshot/vfs/dirEntry.go
+++ b/snapshot/vfs/dirEntry.go
@@ -1,7 +1,7 @@
 package vfs
 
 import (
-	"path/filepath"
+	"path"
 	"sort"
 
 	"github.com/PlakarKorp/plakar/objects"
@@ -108,7 +108,7 @@ func (d *DirEntry) Name() string {
 }
 
 func (d *DirEntry) Path() string {
-	return filepath.Join(d.ParentPath, d.Name())
+	return path.Join(d.ParentPath, d.Name())
 }
 
 func (d *DirEntry) AddClassification(analyzer string, classes []string) {

--- a/snapshot/vfs/fileEntry.go
+++ b/snapshot/vfs/fileEntry.go
@@ -1,7 +1,7 @@
 package vfs
 
 import (
-	"path/filepath"
+	"path"
 	"sort"
 
 	"github.com/PlakarKorp/plakar/objects"
@@ -112,7 +112,7 @@ func (f *FileEntry) Name() string {
 }
 
 func (f *FileEntry) Path() string {
-	return filepath.Join(f.ParentPath, f.Name())
+	return path.Join(f.ParentPath, f.Name())
 }
 
 func (f *FileEntry) Size() int64 {

--- a/snapshot/vfs/vfilep.go
+++ b/snapshot/vfs/vfilep.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"time"
 
 	"github.com/PlakarKorp/plakar/packfile"
@@ -154,7 +154,7 @@ func (vf *VFilep) ReadDir(count int) ([]fs.DirEntry, error) {
 		}
 		offset++
 
-		st, err := vf.vfs.Stat(filepath.Join(vf.vfsEntry.Path(), childname))
+		st, err := vf.vfs.Stat(path.Join(vf.vfsEntry.Path(), childname))
 		if err != nil {
 			continue
 		} else {


### PR DESCRIPTION
filepath is a package that "implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths", as such it may use for e.g. forward or backward slashes depending on the OS.

path, instead, manipulates paths such as URLs that always use forward slashes, and it's what should be used when we handle backup paths internally.

lightly tested, and only on linux, but should help with Windows :)