### PR TITLE
retire btree.VisitLevelOrder

### DIFF
--- a/btree/btree_test.go
+++ b/btree/btree_test.go
@@ -2,7 +2,6 @@ package btree
 
 import (
 	"errors"
-	"log"
 	"slices"
 	"strings"
 	"testing"
@@ -61,15 +60,6 @@ func cmp(a, b rune) int {
 	return +1
 }
 
-func printtree[K any, P any, V any](b *BTree[K, P, V]) {
-	n := -1
-	b.VisitLevelOrder(func(ptr P, node *Node[K, P, V]) bool {
-		n++
-		log.Printf("%v keys: %+v (ptrs: %+v)", n, node.Keys, node.Pointers)
-		return true
-	})
-}
-
 func TestBTree(t *testing.T) {
 	store := InMemoryStore[rune, int]{}
 	tree, err := New(&store, cmp, 3)
@@ -79,11 +69,6 @@ func TestBTree(t *testing.T) {
 
 	alphabet := []rune("abcdefghijklmnopqrstuvwxyz")
 	for i, r := range alphabet {
-		// log.Println("==== tree dump ====")
-		// printtree(tree)
-		// log.Println("==== tree dump ====")
-		// log.Println("-> inserting", r, i)
-
 		if err := tree.Insert(r, i); err != nil {
 			t.Fatalf("Failed to insert(%v, %v): %v", r, i, err)
 		}
@@ -96,10 +81,6 @@ func TestBTree(t *testing.T) {
 			t.Fatalf("insertion of (%v, %v) failed with unexpected succeeded", r, i)
 		}
 	}
-
-	// log.Println("==== done; now querying ====")
-	// printtree(tree)
-	// log.Println("====")
 
 	for i, r := range alphabet {
 		v, found, err := tree.Find(r)
@@ -147,10 +128,6 @@ func TestInsert(t *testing.T) {
 
 	items := []string{"e", "z", "a", "b", "a", "a", "b", "b", "a", "c", "d"}
 	for i, r := range items {
-		// log.Println("==== tree dump ====")
-		// printtree(tree)
-		// log.Println("==== tree dump ====")
-		// log.Println("-> inserting", r, i)
 		if err := tree.Insert(r, i); err != nil && err != ErrExists {
 			t.Fatalf("Failed to insert(%v, %v): %v", r, i, err)
 		}
@@ -316,9 +293,6 @@ func TestPersist(t *testing.T) {
 	}
 
 	tree2 := FromStorage(root, &store2, cmp, order)
-	// printtree(tree)
-	// log.Println("===")
-	// printtree(tree2)
 	for i, r := range alphabet {
 		v, found, err := tree2.Find(r)
 		if err != nil {

--- a/btree/iter.go
+++ b/btree/iter.go
@@ -236,26 +236,3 @@ func (b *BTree[K, P, V]) VisitDFS(cb func(P, *Node[K, P, V]) error) error {
 	}
 	return nil
 }
-
-func (b *BTree[K, P, V]) VisitLevelOrder(cb func(P, *Node[K, P, V]) bool) error {
-	stack := []P{b.Root}
-
-	for {
-		if len(stack) == 0 {
-			return nil
-		}
-		ptr := stack[0]
-		stack = stack[1:]
-
-		node, err := b.store.Get(ptr)
-		if err != nil {
-			return err
-		}
-
-		if !cb(ptr, node) {
-			return nil
-		}
-
-		stack = append(stack, node.Pointers...)
-	}
-}

--- a/btree/verify.go
+++ b/btree/verify.go
@@ -158,15 +158,15 @@ func (b *BTree[K, P, V]) verifyNode(cur, parent *Node[K, P, V], ptrIdx int, stat
 	return nil
 }
 
-func (b *BTree[K, P, V]) Dot(w io.Writer) error {
+func (b *BTree[K, P, V]) Dot(w io.Writer, showNextPtrs bool) error {
 	return b.VisitDFS(func(ptr P, n *Node[K, P, V]) error {
 		fmt.Fprintf(w, "%v [label=%q]\n", ptr, fmt.Sprintf("%v %v", ptr, n.Keys))
 		for _, cptr := range n.Pointers {
 			fmt.Fprintf(w, "%v -> %v\n", ptr, cptr)
 		}
-		// if n.Next != nil {
-		// 	fmt.Fprintf(w, "%v -> %v\n", ptr, *n.Next)
-		// }
+		if showNextPtrs && n.Next != nil {
+			fmt.Fprintf(w, "%v -> %v\n", ptr, *n.Next)
+		}
 		return nil
 	})
 }

--- a/btree/verify.go
+++ b/btree/verify.go
@@ -159,7 +159,7 @@ func (b *BTree[K, P, V]) verifyNode(cur, parent *Node[K, P, V], ptrIdx int, stat
 }
 
 func (b *BTree[K, P, V]) Dot(w io.Writer) error {
-	return b.VisitLevelOrder(func(ptr P, n *Node[K, P, V]) bool {
+	return b.VisitDFS(func(ptr P, n *Node[K, P, V]) error {
 		fmt.Fprintf(w, "%v [label=%q]\n", ptr, fmt.Sprintf("%v %v", ptr, n.Keys))
 		for _, cptr := range n.Pointers {
 			fmt.Fprintf(w, "%v -> %v\n", ptr, cptr)
@@ -167,6 +167,6 @@ func (b *BTree[K, P, V]) Dot(w io.Writer) error {
 		// if n.Next != nil {
 		// 	fmt.Fprintf(w, "%v -> %v\n", ptr, *n.Next)
 		// }
-		return true
+		return nil
 	})
 }


### PR DESCRIPTION
was added as a quick way to debug the tree, but Dot is better in that regard, and `VisitLevelOrder` just needs a lot of memory for nothing.

While here, improve the Dot method a tiny bit.