### PR TITLE
convert existing channels to proper iterators

### DIFF
--- a/caching/scan.go
+++ b/caching/scan.go
@@ -147,19 +147,14 @@ func (c *ScanCache) EnumerateKeysWithPrefixReverse(prefix string, isDirectory bo
 	}
 }
 
-func (c *ScanCache) EnumerateImmediateChildPathnames(directory string, reverse bool) (<-chan importer.ScanRecord, error) {
+func (c *ScanCache) EnumerateImmediateChildPathnames(directory string, reverse bool) iter.Seq2[importer.ScanRecord, error] {
 	// Ensure directory ends with a trailing slash for consistency
 	if !strings.HasSuffix(directory, "/") {
 		directory += "/"
 	}
 
-	// Create a channel to return the keys
-	keyChan := make(chan importer.ScanRecord)
-
 	// Start a goroutine to perform the iteration
-	go func() {
-		defer close(keyChan) // Ensure the channel is closed when the function exits
-
+	return func(yield func(importer.ScanRecord, error) bool) {
 		iter := c.db.NewIterator(nil, nil)
 		defer iter.Release()
 
@@ -209,18 +204,9 @@ func (c *ScanCache) EnumerateImmediateChildPathnames(directory string, reverse b
 
 					var record importer.ScanRecord
 					err := msgpack.Unmarshal(value, &record)
-					if err != nil {
-						fmt.Printf("Error unmarshaling value: %v\n", err)
-						if reverse {
-							iter.Prev()
-						} else {
-							iter.Next()
-						}
-						continue
+					if !yield(record, err) {
+						return
 					}
-
-					// Send the immediate child key through the channel
-					keyChan <- record
 				}
 			} else {
 				// Stop if the key is no longer within the expected prefix
@@ -234,8 +220,5 @@ func (c *ScanCache) EnumerateImmediateChildPathnames(directory string, reverse b
 				iter.Next()
 			}
 		}
-	}()
-
-	// Return the channel for the caller to consume
-	return keyChan, nil
+	}
 }

--- a/caching/scan.go
+++ b/caching/scan.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"fmt"
+	"iter"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,14 +110,8 @@ func (c *ScanCache) GetSummary(pathname string) ([]byte, error) {
 
 // / BELOW IS THE OLD CODE FROM BACKUP LAYER, NEEDS TO BE CLEANED UP
 
-func (c *ScanCache) EnumerateKeysWithPrefixReverse(prefix string, isDirectory bool) (<-chan importer.ScanRecord, error) {
-	// Create a channel to return the keys
-	keyChan := make(chan importer.ScanRecord)
-
-	// Start a goroutine to perform the iteration
-	go func() {
-		defer close(keyChan) // Ensure the channel is closed when the function exits
-
+func (c *ScanCache) EnumerateKeysWithPrefixReverse(prefix string, isDirectory bool) iter.Seq2[importer.ScanRecord, error] {
+	return func(yield func(importer.ScanRecord, error) bool) {
 		// Use LevelDB's iterator
 		iter := c.db.NewIterator(nil, nil)
 		defer iter.Release()
@@ -145,18 +140,11 @@ func (c *ScanCache) EnumerateKeysWithPrefixReverse(prefix string, isDirectory bo
 
 			var record importer.ScanRecord
 			err := msgpack.Unmarshal(value, &record)
-			if err != nil {
-				fmt.Printf("Error unmarshaling value: %v\n", err)
-				continue
+			if !yield(record, err) {
+				return
 			}
-
-			// Send the record through the channel
-			keyChan <- record
 		}
-	}()
-
-	// Return the channel for the caller to consume
-	return keyChan, nil
+	}
 }
 
 func (c *ScanCache) EnumerateImmediateChildPathnames(directory string, reverse bool) (<-chan importer.ScanRecord, error) {

--- a/cmd/plakar/subcommands/archive/archive.go
+++ b/cmd/plakar/subcommands/archive/archive.go
@@ -126,7 +126,10 @@ func archiveTarball(snap *snapshot.Snapshot, out io.Writer, vfs *vfs.Filesystem,
 	tarWriter := tar.NewWriter(out)
 	defer tarWriter.Close()
 
-	for file := range vfs.Pathnames() {
+	for file, err := range vfs.Pathnames() {
+		if err != nil {
+			return err
+		}
 		if path != "" && !utils.PathIsWithin(file, path) {
 			continue
 		}
@@ -189,7 +192,10 @@ func archiveZip(snap *snapshot.Snapshot, out io.Writer, vfs *vfs.Filesystem, pat
 	zipWriter := zip.NewWriter(out)
 	defer zipWriter.Close()
 
-	for file := range vfs.Pathnames() {
+	for file, err := range vfs.Pathnames() {
+		if err != nil {
+			return err
+		}
 		if path != "" {
 			if !utils.PathIsWithin(file, path) {
 				continue

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -197,11 +197,14 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 
 	dstSnapshot.Header = srcSnapshot.Header
 
-	c, err := srcSnapshot.ListChunks()
+	iter, err := srcSnapshot.ListChunks()
 	if err != nil {
 		return err
 	}
-	for chunkID := range c {
+	for chunkID, err := range iter {
+		if err != nil {
+			return err
+		}
 		if !dstRepository.BlobExists(packfile.TYPE_CHUNK, chunkID) {
 			chunkData, err := srcSnapshot.GetBlob(packfile.TYPE_CHUNK, chunkID)
 			if err != nil {
@@ -211,7 +214,7 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 		}
 	}
 
-	c, err = srcSnapshot.ListObjects()
+	c, err := srcSnapshot.ListObjects()
 	if err != nil {
 		return err
 	}

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -214,11 +214,14 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 		}
 	}
 
-	c, err := srcSnapshot.ListObjects()
+	iter, err = srcSnapshot.ListObjects()
 	if err != nil {
 		return err
 	}
-	for objectID := range c {
+	for objectID, err := range iter {
+		if err != nil {
+			return err
+		}
 		if !dstRepository.BlobExists(packfile.TYPE_OBJECT, objectID) {
 			objectData, err := srcSnapshot.GetBlob(packfile.TYPE_OBJECT, objectID)
 			if err != nil {
@@ -243,7 +246,7 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 		return nil
 	})
 
-	c, err = srcSnapshot.ListDatas()
+	c, err := srcSnapshot.ListDatas()
 	if err != nil {
 		return err
 	}

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -246,11 +246,8 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 		return nil
 	})
 
-	c, err := srcSnapshot.ListDatas()
-	if err != nil {
-		return err
-	}
-	for dataID := range c {
+	iter = srcSnapshot.ListDatas()
+	for dataID := range iter {
 		if !dstRepository.BlobExists(packfile.TYPE_DATA, dataID) {
 			dataData, err := srcSnapshot.GetBlob(packfile.TYPE_DATA, dataID)
 			if err != nil {

--- a/plakarfs/dir.go
+++ b/plakarfs/dir.go
@@ -137,7 +137,10 @@ func (d *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	}
 
 	dirDirs := make([]fuse.Dirent, 0)
-	for child := range children {
+	for child, err := range children {
+		if err != nil {
+			return nil, err
+		}
 		cleanpath := filepath.Clean(d.fullpath + "/" + child)
 		entry, err := d.vfs.GetEntry(cleanpath)
 		if err != nil {

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"hash"
 	"io"
+	"iter"
 	"strings"
 	"time"
 
@@ -469,7 +470,7 @@ func (r *Repository) BlobExists(Type packfile.Type, checksum objects.Checksum) b
 	return r.state.BlobExists(Type, checksum)
 }
 
-func (r *Repository) ListSnapshots() <-chan objects.Checksum {
+func (r *Repository) ListSnapshots() iter.Seq[objects.Checksum] {
 	t0 := time.Now()
 	defer func() {
 		r.Logger().Trace("repository", "ListSnapshots(): %s", time.Since(t0))

--- a/repository/state/state.go
+++ b/repository/state/state.go
@@ -653,9 +653,8 @@ func (st *State) ListBlobs(Type packfile.Type) iter.Seq[objects.Checksum] {
 	}
 }
 
-func (st *State) ListSnapshots() <-chan objects.Checksum {
-	ch := make(chan objects.Checksum)
-	go func() {
+func (st *State) ListSnapshots() iter.Seq[objects.Checksum] {
+	return func(yield func(objects.Checksum) bool) {
 		snapshotsList := make([]objects.Checksum, 0)
 		st.muSnapshots.Lock()
 		for k := range st.Snapshots {
@@ -669,9 +668,9 @@ func (st *State) ListSnapshots() <-chan objects.Checksum {
 		st.muSnapshots.Unlock()
 
 		for _, checksum := range snapshotsList {
-			ch <- checksum
+			if !yield(checksum) {
+				return
+			}
 		}
-		close(ch)
-	}()
-	return ch
+	}
 }

--- a/snapshot/search.go
+++ b/snapshot/search.go
@@ -236,7 +236,10 @@ func (snap *Snapshot) searchMatch(fileEntry *vfs.Entry, q search.Query) (bool, e
 }
 
 func (snap *Snapshot) search(fs *vfs.Filesystem, prefix string, q search.Query, c chan search.Result) error {
-	for f := range fs.Pathnames() {
+	for f, err := range fs.Pathnames() {
+		if err != nil {
+			return err
+		}
 		if !strings.HasPrefix(f, prefix) {
 			continue
 		}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -196,7 +196,11 @@ func (snap *Snapshot) ListChunks() (iter.Seq2[objects.Checksum, error], error) {
 		return nil, err
 	}
 	return func(yield func(objects.Checksum, error) bool) {
-		for filename := range fs.Files() {
+		for filename, err := range fs.Files() {
+			if err != nil {
+				yield(objects.Checksum{}, err)
+				return
+			}
 			fsentry, err := fs.GetEntry(filename)
 			if err != nil {
 				yield(objects.Checksum{}, err)
@@ -220,7 +224,11 @@ func (snap *Snapshot) ListObjects() (iter.Seq2[objects.Checksum, error], error) 
 		return nil, err
 	}
 	return func(yield func(objects.Checksum, error) bool) {
-		for filename := range fs.Files() {
+		for filename, err := range fs.Files() {
+			if err != nil {
+				yield(objects.Checksum{}, err)
+				return
+			}
 			fsentry, err := fs.GetEntry(filename)
 			if err != nil {
 				yield(objects.Checksum{}, err)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -214,26 +214,26 @@ func (snap *Snapshot) ListChunks() (iter.Seq2[objects.Checksum, error], error) {
 	}, nil
 }
 
-func (snap *Snapshot) ListObjects() (<-chan objects.Checksum, error) {
+func (snap *Snapshot) ListObjects() (iter.Seq2[objects.Checksum, error], error) {
 	fs, err := snap.Filesystem()
 	if err != nil {
 		return nil, err
 	}
-	c := make(chan objects.Checksum)
-	go func() {
+	return func(yield func(objects.Checksum, error) bool) {
 		for filename := range fs.Files() {
 			fsentry, err := fs.GetEntry(filename)
 			if err != nil {
-				break
+				yield(objects.Checksum{}, err)
+				return
 			}
 			if fsentry.Object == nil {
 				continue
 			}
-			c <- fsentry.Object.Checksum
+			if !yield(fsentry.Object.Checksum, nil) {
+				return
+			}
 		}
-		close(c)
-	}()
-	return c, nil
+	}, nil
 }
 
 func (snap *Snapshot) ListDatas() (<-chan objects.Checksum, error) {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -236,15 +236,10 @@ func (snap *Snapshot) ListObjects() (iter.Seq2[objects.Checksum, error], error) 
 	}, nil
 }
 
-func (snap *Snapshot) ListDatas() (<-chan objects.Checksum, error) {
-	c := make(chan objects.Checksum)
-
-	go func() {
-		c <- snap.Header.Metadata
-		close(c)
-	}()
-
-	return c, nil
+func (snap *Snapshot) ListDatas() iter.Seq2[objects.Checksum, error] {
+	return func(yield func(objects.Checksum, error) bool) {
+		yield(snap.Header.Metadata, nil)
+	}
 }
 
 func (snap *Snapshot) Logger() *logging.Logger {


### PR DESCRIPTION
The only drawback is that now we don't pre-compute the next element in a different goroutine while the consumer handles the previous one, but the advantage is that we're no longer leaking goroutines when a consumer `break`s out of a loop.  I converted everything except the importers and `ListStates` since Mathieu is working on that area.