### PR TITLE
fix total error accounting

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -473,6 +473,9 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 			if !strings.HasPrefix(errentry.Name, prefix) {
 				break
 			}
+			if !vfs.IsEntryBelow(prefix, errentry.Name) {
+				continue
+			}
 			dirEntry.Summary.Below.Errors++
 		}
 		if err := erriter.Err(); err != nil {

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -427,7 +427,10 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 
 		for childiter.Next() {
 			childPath, childEntry := childiter.Current()
-			if !vfs.IsEntryBelow(prefix, childPath) {
+			if !strings.HasPrefix(childPath, prefix) {
+				break
+			}
+			if strings.Index(childPath[len(prefix):], "/") != -1 {
 				break
 			}
 
@@ -473,8 +476,8 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 			if !strings.HasPrefix(errentry.Name, prefix) {
 				break
 			}
-			if !vfs.IsEntryBelow(prefix, errentry.Name) {
-				continue
+			if strings.Index(errentry.Name[len(prefix):], "/") != -1 {
+				break
 			}
 			dirEntry.Summary.Below.Errors++
 		}

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -427,10 +427,7 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 
 		for childiter.Next() {
 			childPath, childEntry := childiter.Current()
-			if !strings.HasPrefix(childPath, dirPath) {
-				break
-			}
-			if strings.Index(childPath[len(prefix):], "/") != -1 {
+			if !vfs.IsEntryBelow(prefix, childPath) {
 				break
 			}
 

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -150,7 +150,7 @@ func (e *Entry) Getdents(fsc *Filesystem) (iter.Seq2[*Entry, error], error) {
 			if prefix == path {
 				continue
 			}
-			if !IsEntryBelow(prefix, path) {
+			if !isEntryBelow(prefix, path) {
 				break
 			}
 			if !yield(&entry, nil) {
@@ -423,7 +423,7 @@ func (vf *vdir) ReadDir(n int) (entries []fs.DirEntry, err error) {
 		if path == prefix {
 			continue
 		}
-		if !IsEntryBelow(prefix, path) {
+		if !isEntryBelow(prefix, path) {
 			break
 		}
 

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -150,10 +150,7 @@ func (e *Entry) Getdents(fsc *Filesystem) (iter.Seq2[*Entry, error], error) {
 			if prefix == path {
 				continue
 			}
-			if !strings.HasPrefix(path, prefix) {
-				break
-			}
-			if strings.Index(path[len(prefix):], "/") != -1 {
+			if !IsEntryBelow(prefix, path) {
 				break
 			}
 			if !yield(&entry, nil) {
@@ -426,11 +423,7 @@ func (vf *vdir) ReadDir(n int) (entries []fs.DirEntry, err error) {
 		if path == prefix {
 			continue
 		}
-
-		if !strings.HasPrefix(path, prefix) {
-			break
-		}
-		if strings.Index(path[len(prefix):], "/") != -1 {
+		if !IsEntryBelow(prefix, path) {
 			break
 		}
 

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -56,6 +56,10 @@ func PathCmp(a, b string) int {
 // of parent from a filesystem perspective.  Parent has to have a
 // trailing slash.
 func IsEntryBelow(parent, entry string) bool {
+	if !strings.HasSuffix(parent, "/") {
+		parent += "/"
+	}
+
 	if !strings.HasPrefix(entry, parent) {
 		return false
 	}

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -53,8 +53,7 @@ func PathCmp(a, b string) int {
 }
 
 // IsEntryBelow returns true when the entry string is a direct child
-// of parent from a filesystem perspective.  Parent has to have a
-// trailing slash.
+// of parent from a filesystem perspective.
 func IsEntryBelow(parent, entry string) bool {
 	if !strings.HasSuffix(parent, "/") {
 		parent += "/"

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -52,6 +52,19 @@ func PathCmp(a, b string) int {
 	return strings.Compare(a, b)
 }
 
+// IsEntryBelow returns true when the entry string is a direct child
+// of parent from a filesystem perspective.  Parent has to have a
+// trailing slash.
+func IsEntryBelow(parent, entry string) bool {
+	if !strings.HasPrefix(entry, parent) {
+		return false
+	}
+	if strings.Index(entry[len(parent):], "/") != -1 {
+		return false
+	}
+	return true
+}
+
 func NewFilesystem(repo *repository.Repository, root objects.Checksum) (*Filesystem, error) {
 	rd, err := repo.GetBlob(packfile.TYPE_VFS, root)
 	if err != nil {

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -52,13 +52,7 @@ func PathCmp(a, b string) int {
 	return strings.Compare(a, b)
 }
 
-// IsEntryBelow returns true when the entry string is a direct child
-// of parent from a filesystem perspective.
-func IsEntryBelow(parent, entry string) bool {
-	if !strings.HasSuffix(parent, "/") {
-		parent += "/"
-	}
-
+func isEntryBelow(parent, entry string) bool {
 	if !strings.HasPrefix(entry, parent) {
 		return false
 	}


### PR DESCRIPTION
The issue is that basically we're summing not only the errors of a given directory, but also all the errors in its subdirectories.

A better fix would be to restructure a bit how we backup: assuming we record the intermediate directories before their children, we wouldn't have to do this second pass but just grab the temporary directory entry and update the stats there, but for now this should do it.

While here, also factor out that bit of code to avoid some repetition.