### PR TITLE
Stop using gorilla/mux in the API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -92,7 +92,8 @@ func SetupRoutes(server *http.ServeMux, repo *repository.Repository, token strin
 	authToken := TokenAuthMiddleware(token)
 	urlSigner := NewSnapshotReaderURLSigner(token)
 
-	server.Handle("/api/{path...}", APIView(func(w http.ResponseWriter, r *http.Request) error {
+	// Catch all API endpoint, called if no more specific API endpoint is found
+	server.Handle("/api/", APIView(func(w http.ResponseWriter, r *http.Request) error {
 		return &ApiError{
 			HttpCode: 404,
 			ErrCode:  "not-found",

--- a/api/api.go
+++ b/api/api.go
@@ -92,6 +92,14 @@ func SetupRoutes(server *http.ServeMux, repo *repository.Repository, token strin
 	authToken := TokenAuthMiddleware(token)
 	urlSigner := NewSnapshotReaderURLSigner(token)
 
+	server.Handle("/api/{path...}", APIView(func(w http.ResponseWriter, r *http.Request) error {
+		return &ApiError{
+			HttpCode: 404,
+			ErrCode:  "not-found",
+			Message:  "API endpoint not found",
+		}
+	}))
+
 	server.Handle("GET /api/storage/configuration", authToken(APIView(storageConfiguration)))
 	server.Handle("GET /api/storage/states", authToken(APIView(storageStates)))
 	server.Handle("GET /api/storage/state/{state}", authToken(APIView(storageState)))

--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -10,14 +10,13 @@ import (
 
 func TestPathParamToID(t *testing.T) {
 	req, err := http.NewRequest("GET", "/path/{id}", nil)
+	req.Pattern = "/path/{id}"
+
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	vars := map[string]string{
-		"id": "7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c",
-	}
-	req = mux.SetURLVars(req, vars)
+	req.SetPathValue("id", "7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c")
 
 	id, err := PathParamToID(req, "id")
 	if err != nil {

--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/PlakarKorp/plakar/snapshot"
 	"github.com/PlakarKorp/plakar/snapshot/header"
-	"github.com/gorilla/mux"
 )
 
 func repositoryConfiguration(w http.ResponseWriter, r *http.Request) error {
@@ -72,9 +71,6 @@ func repositorySnapshots(w http.ResponseWriter, r *http.Request) error {
 }
 
 func repositoryStates(w http.ResponseWriter, r *http.Request) error {
-	vars := mux.Vars(r)
-	_ = vars
-
 	states, err := lrepository.GetStates()
 	if err != nil {
 		return err

--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -143,14 +143,15 @@ type SnapshotSignedURLClaims struct {
 }
 
 func (signer SnapshotReaderURLSigner) Sign(w http.ResponseWriter, r *http.Request) error {
-	_, path, err := SnapshotPathParam(r, lrepository, "snapshot_path")
+	snapshotID32, path, err := SnapshotPathParam(r, lrepository, "snapshot_path")
 	if err != nil {
 		return err
 	}
+	snapshotId := fmt.Sprintf("%0x", snapshotID32[:])
 
 	now := time.Now()
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, SnapshotSignedURLClaims{
-		SnapshotID: r.PathValue("snapshot"),
+		SnapshotID: snapshotId,
 		Path:       path,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(2 * time.Hour)),

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-
-	"github.com/gorilla/mux"
 )
 
 func storageConfiguration(w http.ResponseWriter, r *http.Request) error {
@@ -15,8 +13,6 @@ func storageConfiguration(w http.ResponseWriter, r *http.Request) error {
 }
 
 func storageStates(w http.ResponseWriter, r *http.Request) error {
-	vars := mux.Vars(r)
-	_ = vars
 
 	states, err := lstore.GetStates()
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -17,10 +17,10 @@ import (
 func TestNewRouter(t *testing.T) {
 	repo := &repository.Repository{}
 	token := "test-token"
-	router := NewRouter(repo, token)
-	if router == nil {
-		t.Errorf("NewRouter returned a nil router")
-	}
+	mux := http.NewServeMux()
+	// Make sure SetupRoutes doesn't panic, which happens when invalid routes
+	// are registered
+	SetupRoutes(mux, repo, token)
 }
 
 func TestAuthMiddleware(t *testing.T) {
@@ -36,10 +36,8 @@ func TestAuthMiddleware(t *testing.T) {
 		t.Fatal(err)
 	}
 	token := "test-token"
-	router := NewRouter(repo, token)
-	if router == nil {
-		t.Errorf("NewRouter returned a nil router")
-	}
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, token)
 
 	req, err := http.NewRequest("GET", "/api/storage/configuration", nil)
 	if err != nil {
@@ -47,14 +45,14 @@ func TestAuthMiddleware(t *testing.T) {
 	}
 	req.Header.Set("Authorization", "Invalid Token")
 	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+	mux.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("Expected status code 401, got %d", w.Code)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	w2 := httptest.NewRecorder()
-	router.ServeHTTP(w2, req)
+	mux.ServeHTTP(w2, req)
 
 	if w2.Code != http.StatusOK {
 		t.Errorf("Expected status code 200, got %d", w2.Code)

--- a/ui/v2/ui.go
+++ b/ui/v2/ui.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/PlakarKorp/plakar/api"
 	"github.com/PlakarKorp/plakar/repository"
-	"github.com/gorilla/handlers"
 )
 
 type UiOptions struct {
@@ -44,12 +43,12 @@ type UiOptions struct {
 var content embed.FS
 
 func Ui(repo *repository.Repository, addr string, opts *UiOptions) error {
-	r := api.NewRouter(repo, opts.Token)
+	server := http.NewServeMux()
+	api.SetupRoutes(server, repo, opts.Token)
 
 	// Serve files from the ./frontend directory
-	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Join internally call path.Clean to prevent directory traversal
-		path := filepath.Join("frontend", r.URL.Path)
+	server.HandleFunc("/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		path := filepath.Join("frontend", r.PathValue("path"))
 
 		_, err := content.Open(path)
 		if os.IsNotExist(err) {
@@ -116,9 +115,24 @@ func Ui(repo *repository.Repository, addr string, opts *UiOptions) error {
 	}
 
 	if opts.Cors {
-		return http.ListenAndServe(addr, handlers.CORS(
-			handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}),
-		)(r))
+		return http.ListenAndServe(addr, corsMiddleware(server))
 	}
-	return http.ListenAndServe(addr, r)
+	return http.ListenAndServe(addr, server)
+}
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+		// Handle preflight OPTIONS request
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		// Pass the request to the next handler
+		next.ServeHTTP(w, r)
+	})
 }

--- a/ui/v2/ui.go
+++ b/ui/v2/ui.go
@@ -123,7 +123,7 @@ func Ui(repo *repository.Repository, addr string, opts *UiOptions) error {
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
 		// Handle preflight OPTIONS request


### PR DESCRIPTION
gorilla/mux is not maintained anymore, and the routing enhancements of go 1.22 (https://go.dev/blog/routing-enhancements) make it possible to only use the stdlib.

mux is still used in server/httpd/httpd.go so the dependency can't be removed yet.