### PR TITLE
Avoid generic interface{} and use generic types instead

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,13 +14,13 @@ import (
 var lstore storage.Store
 var lrepository *repository.Repository
 
-type Item struct {
-	Item interface{} `json:"item"`
+type Item[T any] struct {
+	Item T `json:"item"`
 }
 
-type Items struct {
-	Total int           `json:"total"`
-	Items []interface{} `json:"items"`
+type Items[T any] struct {
+	Total int `json:"total"`
+	Items []T `json:"items"`
 }
 
 type ApiErrorRes struct {

--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/snapshot"
 	"github.com/PlakarKorp/plakar/snapshot/header"
 )
@@ -59,9 +60,9 @@ func repositorySnapshots(w http.ResponseWriter, r *http.Request) error {
 		headers = headers[offset : offset+limit]
 	}
 
-	items := Items{
+	items := Items[header.Header]{
 		Total: len(snapshotIDs),
-		Items: make([]interface{}, len(headers)),
+		Items: make([]header.Header, len(headers)),
 	}
 	for i, header := range headers {
 		items.Items[i] = header
@@ -76,9 +77,9 @@ func repositoryStates(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	items := Items{
+	items := Items[objects.Checksum]{
 		Total: len(states),
-		Items: make([]interface{}, len(states)),
+		Items: make([]objects.Checksum, len(states)),
 	}
 	for i, state := range states {
 		items.Items[i] = state
@@ -110,9 +111,9 @@ func repositoryPackfiles(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	items := Items{
+	items := Items[objects.Checksum]{
 		Total: len(packfiles),
-		Items: make([]interface{}, len(packfiles)),
+		Items: make([]objects.Checksum, len(packfiles)),
 	}
 	for i, packfile := range packfiles {
 		items.Items[i] = packfile

--- a/api/api_storage.go
+++ b/api/api_storage.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/PlakarKorp/plakar/objects"
 )
 
 func storageConfiguration(w http.ResponseWriter, r *http.Request) error {
@@ -13,15 +15,14 @@ func storageConfiguration(w http.ResponseWriter, r *http.Request) error {
 }
 
 func storageStates(w http.ResponseWriter, r *http.Request) error {
-
 	states, err := lstore.GetStates()
 	if err != nil {
 		return err
 	}
 
-	items := Items{
+	items := Items[objects.Checksum]{
 		Total: len(states),
-		Items: make([]interface{}, len(states)),
+		Items: make([]objects.Checksum, len(states)),
 	}
 	for i, state := range states {
 		items.Items[i] = state
@@ -53,9 +54,9 @@ func storagePackfiles(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	items := Items{
+	items := Items[objects.Checksum]{
 		Total: len(packfiles),
-		Items: make([]interface{}, len(packfiles)),
+		Items: make([]objects.Checksum, len(packfiles)),
 	}
 	for i, packfile := range packfiles {
 		items.Items[i] = packfile


### PR DESCRIPTION
This is nitpicking. The types Item and Items used to return a single object and a list of objects in the API were holding a reference to an interface.

Now, instead, the structs take a generic type as a parameter.