### PR TITLE
vfs: provide a WalkDir implementation

### DIFF
--- a/cmd/plakar/subcommands/ls/ls.go
+++ b/cmd/plakar/subcommands/ls/ls.go
@@ -32,6 +32,7 @@ import (
 	"github.com/PlakarKorp/plakar/cmd/plakar/utils"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
+	"github.com/PlakarKorp/plakar/snapshot/vfs"
 	"github.com/dustin/go-humanize"
 )
 
@@ -115,7 +116,7 @@ func list_snapshot(repo *repository.Repository, snapshotPath string, recursive b
 		log.Fatal(err)
 	}
 
-	return fs.WalkDir(pvfs, pathname, func(path string, d fs.DirEntry, err error) error {
+	return pvfs.WalkDir(pathname, func(path string, d *vfs.Entry, err error) error {
 		if err != nil {
 			log.Println("error at", path, ":", err)
 			return err

--- a/snapshot/vfs/walk.go
+++ b/snapshot/vfs/walk.go
@@ -1,0 +1,52 @@
+package vfs
+
+import (
+	"io/fs"
+)
+
+type WalkDirFunc func(path string, entry *Entry, err error) error
+
+func (fsc *Filesystem) walkdir(entry *Entry, fn WalkDirFunc) error {
+	path := entry.Path()
+	if err := fn(path, entry, nil); err != nil {
+		return err
+	}
+
+	if !entry.FileInfo.Mode().IsDir() {
+		return nil
+	}
+
+	iter, err := entry.Getdents(fsc)
+	if err != nil {
+		return fn(path, nil, err)
+	}
+
+	for entry, err := range iter {
+		if err != nil {
+			return fn(path, nil, err)
+		}
+
+		if err := fsc.walkdir(entry, fn); err != nil {
+			if err == fs.SkipDir {
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fsc *Filesystem) WalkDir(root string, fn WalkDirFunc) error {
+	entry, err := fsc.GetEntry(root)
+	if err != nil {
+		return err
+	}
+
+	if err = fsc.walkdir(entry, fn); err != nil {
+		if err == fs.SkipDir || err == fs.SkipAll {
+			err = nil
+		}
+	}
+	return err
+}


### PR DESCRIPTION
This works similarly to fs.WalkDir, but it's slightly more optimized for our use case: the std one has to read all the child entries in memory before processing them, while this implementation relies on the fact that the VFS layer returns the child entries already sorted.