### PR TITLE
update the btree even when the file was found in the cache

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -331,14 +331,6 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 					fileEntry.AddClassification(result.Analyzer, result.Classes)
 				}
 
-				backupCtx.mufileidx.Lock()
-				err := backupCtx.fileidx.Update(record.Pathname, *fileEntry)
-				backupCtx.mufileidx.Unlock()
-				if err != nil {
-					backupCtx.recordError(record.Pathname, err)
-					return
-				}
-
 				serialized, err := fileEntry.ToBytes()
 				if err != nil {
 					backupCtx.recordError(record.Pathname, err)
@@ -383,6 +375,15 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 					backupCtx.recordError(record.Pathname, err)
 					return
 				}
+			}
+
+			// Update the file since we may have set its Object field
+			backupCtx.mufileidx.Lock()
+			err := backupCtx.fileidx.Update(record.Pathname, *fileEntry)
+			backupCtx.mufileidx.Unlock()
+			if err != nil {
+				backupCtx.recordError(record.Pathname, err)
+				return
 			}
 
 			// Record the checksum of the FileEntry in the cache


### PR DESCRIPTION
when we scan the files we first put a Entry structure in the index and only later we consult the cache to see if we've already chunkified it.

The issues is that we have to update it even in the case the entry was found in the cache, otherwise we leave the Objects field to nil in the backup and the file content are not available.