### PR TITLE
use SplitN in ParseSnapshotID

### DIFF
--- a/cmd/plakar/utils/utils.go
+++ b/cmd/plakar/utils/utils.go
@@ -44,12 +44,11 @@ import (
 )
 
 func ParseSnapshotID(id string) (string, string) {
-	tmp := strings.Split(id, ":")
+	tmp := strings.SplitN(id, ":", 2)
 	prefix := id
 	pattern := ""
-	if len(tmp) != 0 {
-		prefix = tmp[0]
-		pattern = strings.Join(tmp[1:], ":")
+	if len(tmp) == 2 {
+		prefix, pattern = tmp[0], tmp[1]
 		if runtime.GOOS != "windows" {
 			if !strings.HasPrefix(pattern, "/") {
 				pattern = "/" + pattern

--- a/cmd/plakar/utils/utils.go
+++ b/cmd/plakar/utils/utils.go
@@ -43,6 +43,8 @@ import (
 	"golang.org/x/tools/blog/atom"
 )
 
+// ParseSnapshotID parses a string in the form checksum[:pattern] and
+// returns the two strings.
 func ParseSnapshotID(id string) (string, string) {
 	tmp := strings.SplitN(id, ":", 2)
 	prefix := id


### PR DESCRIPTION
nit i spotted while investigating something else.  At first I thought we could `path.Clean` in here, but the second part after the `:` is not guaranteed to be a path (e.g. see `plakar find` whose manpage could use an update :P).