### PR TITLE
simplify importer selection logic

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -148,7 +148,7 @@ func (snap *Snapshot) importerJob(backupCtx *BackupContext, options *BackupOptio
 	return filesChannel, nil
 }
 
-func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
+func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *BackupOptions) error {
 	snap.Event(events.StartEvent())
 	defer snap.Event(events.DoneEvent())
 
@@ -157,12 +157,6 @@ func (snap *Snapshot) Backup(scanDir string, options *BackupOptions) error {
 		return err
 	}
 	defer sc2.Close()
-
-	imp, err := importer.NewImporter(scanDir)
-	if err != nil {
-		return err
-	}
-	defer imp.Close()
 
 	vfsCache, err := snap.AppContext().GetCache().VFS(imp.Type(), imp.Origin())
 	if err != nil {


### PR DESCRIPTION
We always try first with what was given on the command line (or the current working directory); if that fails, maybe because it looks like like a URI but we don't support its "protocol", we still try to resolve it as a filesystem path.