### PR TITLE
Fix extended attributes

### DIFF
--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -55,7 +55,7 @@ func NewEntry(parentPath string, record *importer.ScanRecord) *Entry {
 		target = record.Target
 	}
 
-	ExtendedAttributes := make([]ExtendedAttribute, len(record.ExtendedAttributes))
+	ExtendedAttributes := make([]ExtendedAttribute, 0, len(record.ExtendedAttributes))
 	for name, value := range record.ExtendedAttributes {
 		ExtendedAttributes = append(ExtendedAttributes, ExtendedAttribute{
 			Name:  name,


### PR DESCRIPTION
To initialize a slice, the capacity should use the third argument of make and not the second one.