### PR TITLE
Add omitempty to JSON outputs

### DIFF
--- a/objects/objects.go
+++ b/objects/objects.go
@@ -36,11 +36,11 @@ type Object struct {
 }
 
 // Return empty lists for nil slices.
-func (o Object) MarshalJSON() ([]byte, error) {
+func (o *Object) MarshalJSON() ([]byte, error) {
 	// Create an alias to avoid recursive MarshalJSON calls
 	type Alias Object
 
-	ret := Alias(o)
+	ret := (*Alias)(o)
 
 	if ret.Chunks == nil {
 		ret.Chunks = []Chunk{}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -35,6 +35,31 @@ type Object struct {
 	Flags           uint32           `msgpack:"flags" json:"flags"`
 }
 
+// Return empty lists for nil slices.
+func (o Object) MarshalJSON() ([]byte, error) {
+	// Create an alias to avoid recursive MarshalJSON calls
+	type Alias Object
+
+	ret := Alias(o)
+
+	if ret.Chunks == nil {
+		ret.Chunks = []Chunk{}
+	}
+	if ret.Classifications == nil {
+		ret.Classifications = []Classification{}
+	}
+	if ret.CustomMetadata == nil {
+		ret.CustomMetadata = []CustomMetadata{}
+	}
+	if ret.Tags == nil {
+		ret.Tags = []string{}
+	}
+	if ret.Distribution == [256]byte{} {
+		ret.Distribution = [256]byte{}
+	}
+	return json.Marshal(ret)
+}
+
 func NewObject() *Object {
 	return &Object{
 		CustomMetadata: make([]CustomMetadata, 0),

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -51,11 +51,11 @@ type Entry struct {
 }
 
 // Return empty lists for nil slices.
-func (e Entry) MarshalJSON() ([]byte, error) {
+func (e *Entry) MarshalJSON() ([]byte, error) {
 	// Create an alias to avoid recursive MarshalJSON calls
 	type Alias Entry
 
-	ret := Alias(e)
+	ret := (*Alias)(e)
 
 	if ret.AlternateDataStreams == nil {
 		ret.AlternateDataStreams = []AlternateDataStream{}


### PR DESCRIPTION
I'm not 100% sure this is enough. I believe we need to review all the API endpoints to make sure omitempty is set where it should, and not set where it shouldn't.

This will break the UI, but the branch jcastets/fix-omitempty is prepared to be merged.