### PR TITLE
add missing tests for fileinfo

### DIFF
--- a/objects/fileinfo.go
+++ b/objects/fileinfo.go
@@ -120,7 +120,7 @@ func NewFileInfo(name string, size int64, mode os.FileMode, modTime time.Time, d
 		Lino:     ino,
 		Luid:     uid,
 		Lgid:     gid,
-		Lnlink:   1,
+		Lnlink:   nlink,
 	}
 }
 

--- a/objects/fileinfo_test.go
+++ b/objects/fileinfo_test.go
@@ -1,8 +1,11 @@
 package objects
 
 import (
+	"syscall"
 	"testing"
 	"time"
+
+	mocked_fileinfo "github.com/PlakarKorp/plakar/testing/fileinfo"
 )
 
 func TestParseFileInfoSortKeys(t *testing.T) {
@@ -60,7 +63,7 @@ func TestSortFileInfos(t *testing.T) {
 		{Lname: "file1", Lsize: 300, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: 0, Lnlink: 1},
 		{Lname: "file2", Lsize: 400, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: 0, Lnlink: 1},
 		{Lname: "file3", Lsize: 100, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: 0, Lnlink: 1},
-		{Lname: "file4", Lsize: 100, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: 0, Lnlink: 1},
+		{Lname: "file4", Lsize: 100, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: uint64(42), Lnlink: 1},
 	}
 
 	for _, test := range []struct {
@@ -83,6 +86,14 @@ func TestSortFileInfos(t *testing.T) {
 			Sort:     "Size,-Name",
 			Expected: []FileInfo{infos[3], infos[2], infos[0], infos[1]},
 		},
+		{
+			Sort:     "Gid",
+			Expected: []FileInfo{infos[2], infos[0], infos[1], infos[3]},
+		},
+		{
+			Sort:     "-Gid",
+			Expected: []FileInfo{infos[3], infos[2], infos[0], infos[1]},
+		},
 	} {
 		t.Run(test.Sort, func(t *testing.T) {
 			keys, err := ParseFileInfoSortKeys(test.Sort)
@@ -99,5 +110,127 @@ func TestSortFileInfos(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSortFileInfosErrors(t *testing.T) {
+	infos := []FileInfo{
+		{Lname: "file1", Lsize: 300, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: 0, Lnlink: 1},
+		{Lname: "file2", Lsize: 400, Lmode: 0644, LmodTime: time.Now(), Ldev: 0, Lino: 0, Luid: 0, Lgid: 0, Lnlink: 1},
+	}
+
+	for _, test := range []struct {
+		name     string
+		SortKeys []string
+		Error    string
+	}{
+		{
+			name:     "should fail for unknown field",
+			SortKeys: []string{"Unknown"},
+			Error:    "invalid sort key: Unknown",
+		},
+		{
+			name:     "should fail to default because of type",
+			SortKeys: []string{"ModTime"},
+			Error:    "unsupported field type for sorting: ModTime",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := SortFileInfos(infos, test.SortKeys)
+			if err == nil {
+				t.Fatalf("Expected error but got %v", err)
+			}
+			if err.Error() != test.Error {
+				t.Fatalf("Expected %v but got %v", test.Error, err)
+			}
+		})
+	}
+}
+
+func TestNewFileInfo(t *testing.T) {
+	now := time.Now().Local()
+
+	file := NewFileInfo("file1", 300000, 0644, now, 1, 2, 3, 4, 5)
+	reference := FileInfo{
+		Lname:    "file1",
+		Lsize:    300000,
+		Lmode:    0644,
+		LmodTime: now,
+		Ldev:     1,
+		Lino:     2,
+		Luid:     3,
+		Lgid:     4,
+		Lnlink:   5,
+	}
+
+	if !file.Equal(&reference) {
+		t.Errorf("expected %#v but got %#v", reference, file)
+	}
+
+	if file.HumanSize() != "300 kB" {
+		t.Errorf("expected %#v but got %#v", "300 kB", file.HumanSize())
+	}
+
+}
+
+func TestFileInfoFromStat(t *testing.T) {
+	stat := mocked_fileinfo.New()
+
+	username := "plakar"
+	groupname := "plakarkorp"
+	fileInfo := FileInfoFromStat(stat)
+	fileInfo.Lusername = username
+	fileInfo.Lgroupname = groupname
+
+	if fileInfo.Name() != stat.Name() {
+		t.Errorf("expected name %q, got %q", stat.Name(), fileInfo.Lname)
+	}
+
+	if fileInfo.Size() != stat.Size() {
+		t.Errorf("expected size %d, got %d", stat.Size(), fileInfo.Lsize)
+	}
+
+	if fileInfo.Mode() != stat.Mode() {
+		t.Errorf("expected mode %o, got %o", stat.Mode(), fileInfo.Lmode)
+	}
+
+	if fileInfo.ModTime() != stat.ModTime() {
+		t.Errorf("expected mod time %v, got %v", stat.ModTime(), fileInfo.LmodTime)
+	}
+
+	if fileInfo.Dev() != stat.Sys().(*syscall.Stat_t).Dev {
+		t.Errorf("expected dev %d, got %d", stat.Sys().(*syscall.Stat_t).Dev, fileInfo.Ldev)
+	}
+
+	if fileInfo.Ino() != stat.Sys().(*syscall.Stat_t).Ino {
+		t.Errorf("expected ino %d, got %d", stat.Sys().(*syscall.Stat_t).Ino, fileInfo.Lino)
+	}
+
+	if fileInfo.IsDir() != stat.IsDir() {
+		t.Errorf("expected IsDir %v, got %v", stat.IsDir(), fileInfo.Lmode)
+	}
+
+	if fileInfo.Uid() != uint64(stat.Sys().(*syscall.Stat_t).Uid) {
+		t.Errorf("expected uid %d, got %d", stat.Sys().(*syscall.Stat_t).Uid, fileInfo.Luid)
+	}
+
+	if fileInfo.Gid() != uint64(stat.Sys().(*syscall.Stat_t).Gid) {
+		t.Errorf("expected gid %d, got %d", stat.Sys().(*syscall.Stat_t).Gid, fileInfo.Lgid)
+	}
+
+	if fileInfo.Nlink() != uint16(stat.Sys().(*syscall.Stat_t).Nlink) {
+		t.Errorf("expected nlink %d, got %d", stat.Sys().(*syscall.Stat_t).Nlink, fileInfo.Lnlink)
+	}
+
+	if fileInfo.Username() != username {
+		t.Errorf("expected Username %v, got %v", username, fileInfo.Lusername)
+	}
+
+	if fileInfo.Groupname() != groupname {
+		t.Errorf("expected Groupname %v, got %v", groupname, fileInfo.Lgroupname)
+	}
+
+	if fileInfo.Sys() != nil {
+		t.Errorf("expected nil, got %v", fileInfo.Sys())
 	}
 }

--- a/objects/fileinfo_windows.go
+++ b/objects/fileinfo_windows.go
@@ -113,7 +113,7 @@ func NewFileInfo(name string, size int64, mode os.FileMode, modTime time.Time, d
 		Lino:     ino,
 		Luid:     uid,
 		Lgid:     gid,
-		Lnlink:   1,
+		Lnlink:   nlink,
 	}
 }
 

--- a/testing/fileinfo/fileinfo.go
+++ b/testing/fileinfo/fileinfo.go
@@ -1,0 +1,50 @@
+package fileinfo
+
+import (
+	"io/fs"
+	"syscall"
+	"time"
+)
+
+type MockFileInfo struct {
+	name    string      // base name of the file
+	size    int64       // length in bytes for regular files; system-dependent for others
+	mode    fs.FileMode // file mode bits
+	modTime time.Time   // modification time
+	isDir   bool        // abbreviation for Mode().IsDir()
+	sys     any         // underlying data source (can return nil)
+}
+
+func New() MockFileInfo {
+	return MockFileInfo{
+		name:    "test",
+		size:    100,
+		mode:    0644,
+		modTime: time.Now(),
+		sys:     &syscall.Stat_t{},
+	}
+}
+
+func (m MockFileInfo) Name() string {
+	return m.name
+}
+
+func (m MockFileInfo) Size() int64 {
+	return m.size
+}
+
+func (m MockFileInfo) Mode() fs.FileMode {
+	return m.mode
+}
+
+func (m MockFileInfo) ModTime() time.Time {
+	return m.modTime
+}
+
+func (m MockFileInfo) IsDir() bool {
+	return m.isDir
+}
+
+func (m MockFileInfo) Sys() any {
+	return m.sys
+}


### PR DESCRIPTION
+ fix an issue with nlink not using the constructor value

before
```
github.com/PlakarKorp/plakar/objects/fileinfo.go:33:	Name			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:37:	Size			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:41:	Mode			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:45:	ModTime			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:49:	Dev			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:53:	Ino			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:57:	Uid			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:61:	Gid			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:65:	IsDir			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:69:	Nlink			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:73:	Sys			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:77:	Username		0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:81:	Groupname		0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:85:	FileInfoFromStat	0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:113:	NewFileInfo		0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:127:	HumanSize		0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:131:	Equal			0.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:157:	ParseFileInfoSortKeys	100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:185:	SortFileInfos		73.3%
```

after
```
github.com/PlakarKorp/plakar/objects/fileinfo.go:33:	Name			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:37:	Size			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:41:	Mode			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:45:	ModTime			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:49:	Dev			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:53:	Ino			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:57:	Uid			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:61:	Gid			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:65:	IsDir			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:69:	Nlink			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:73:	Sys			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:77:	Username		100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:81:	Groupname		100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:85:	FileInfoFromStat	100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:113:	NewFileInfo		100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:127:	HumanSize		100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:131:	Equal			100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:157:	ParseFileInfoSortKeys	100.0%
github.com/PlakarKorp/plakar/objects/fileinfo.go:185:	SortFileInfos		100.0%
```