### PR TITLE
rework the VFS so the BTree stores only the checksum of the entry

### DIFF
--- a/btree/btree_test.go
+++ b/btree/btree_test.go
@@ -287,7 +287,7 @@ func TestPersist(t *testing.T) {
 	}
 
 	store2 := InMemoryStore[rune, int]{}
-	root, err := Persist(tree1, &store2)
+	root, err := Persist(tree1, &store2, func (e int) (int, error) { return e, nil })
 	if err != nil {
 		t.Fatalf("Failed to persist the tree: %v", err)
 	}

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -243,12 +243,12 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 		if err != nil {
 			return err
 		}
-		if !dstRepository.BlobExists(packfile.TYPE_INODE, entryID) {
-			entryData, err := srcSnapshot.GetBlob(packfile.TYPE_INODE, entryID)
+		if !dstRepository.BlobExists(packfile.TYPE_VFS_ENTRY, entryID) {
+			entryData, err := srcSnapshot.GetBlob(packfile.TYPE_VFS_ENTRY, entryID)
 			if err != nil {
 				return err
 			}
-			dstSnapshot.PutBlob(packfile.TYPE_INODE, entryID, entryData)
+			dstSnapshot.PutBlob(packfile.TYPE_VFS_ENTRY, entryID, entryData)
 		}
 	}
 

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -32,7 +32,6 @@ import (
 	"github.com/PlakarKorp/plakar/packfile"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/snapshot"
-	"github.com/PlakarKorp/plakar/snapshot/vfs"
 	"github.com/PlakarKorp/plakar/storage"
 	"github.com/vmihailenco/msgpack/v5"
 )
@@ -235,7 +234,25 @@ func synchronize(srcRepository *repository.Repository, dstRepository *repository
 	if err != nil {
 		return err
 	}
-	fs.VisitNodes(func(csum objects.Checksum, node *btree.Node[string, objects.Checksum, vfs.Entry]) error {
+
+	iter, err = fs.FileChecksums()
+	if err != nil {
+		return err
+	}
+	for entryID, err := range iter {
+		if err != nil {
+			return err
+		}
+		if !dstRepository.BlobExists(packfile.TYPE_INODE, entryID) {
+			entryData, err := srcSnapshot.GetBlob(packfile.TYPE_INODE, entryID)
+			if err != nil {
+				return err
+			}
+			dstSnapshot.PutBlob(packfile.TYPE_INODE, entryID, entryData)
+		}
+	}
+
+	fs.VisitNodes(func(csum objects.Checksum, node *btree.Node[string, objects.Checksum, objects.Checksum]) error {
 		if !dstRepository.BlobExists(packfile.TYPE_VFS, csum) {
 			bytes, err := msgpack.Marshal(node)
 			if err != nil {

--- a/packfile/packfile.go
+++ b/packfile/packfile.go
@@ -18,10 +18,11 @@ const (
 	TYPE_CHUNK     Type = 1
 	TYPE_OBJECT    Type = 2
 	TYPE_VFS       Type = 3
-	TYPE_CHILD     Type = 4
-	TYPE_DATA      Type = 5
-	TYPE_SIGNATURE Type = 6
-	TYPE_ERROR     Type = 7
+	TYPE_INODE     Type = 4
+	TYPE_CHILD     Type = 5
+	TYPE_DATA      Type = 6
+	TYPE_SIGNATURE Type = 7
+	TYPE_ERROR     Type = 8
 )
 
 type Blob struct {
@@ -32,7 +33,7 @@ type Blob struct {
 }
 
 func Types() []Type {
-	return []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}
+	return []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_INODE, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}
 }
 
 func (b Blob) TypeName() string {
@@ -45,6 +46,8 @@ func (b Blob) TypeName() string {
 		return "object"
 	case TYPE_VFS:
 		return "vfs"
+	case TYPE_INODE:
+		return "inode"
 	case TYPE_CHILD:
 		return "directory"
 	case TYPE_DATA:

--- a/packfile/packfile.go
+++ b/packfile/packfile.go
@@ -18,7 +18,7 @@ const (
 	TYPE_CHUNK     Type = 1
 	TYPE_OBJECT    Type = 2
 	TYPE_VFS       Type = 3
-	TYPE_INODE     Type = 4
+	TYPE_VFS_ENTRY Type = 4
 	TYPE_CHILD     Type = 5
 	TYPE_DATA      Type = 6
 	TYPE_SIGNATURE Type = 7
@@ -33,7 +33,7 @@ type Blob struct {
 }
 
 func Types() []Type {
-	return []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_INODE, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}
+	return []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_VFS_ENTRY, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}
 }
 
 func (b Blob) TypeName() string {
@@ -46,8 +46,8 @@ func (b Blob) TypeName() string {
 		return "object"
 	case TYPE_VFS:
 		return "vfs"
-	case TYPE_INODE:
-		return "inode"
+	case TYPE_VFS_ENTRY:
+		return "vfs_entry"
 	case TYPE_CHILD:
 		return "directory"
 	case TYPE_DATA:

--- a/packfile/packfile_test.go
+++ b/packfile/packfile_test.go
@@ -189,7 +189,7 @@ func TestTypes(t *testing.T) {
 	list := Types()
 
 	require.Equal(t, 9, len(list))
-	require.Equal(t, []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_INODE, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}, list)
+	require.Equal(t, []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_VFS_ENTRY, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}, list)
 }
 
 func TestBlobTypeName(t *testing.T) {
@@ -201,7 +201,7 @@ func TestBlobTypeName(t *testing.T) {
 		{TYPE_CHUNK, "chunk"},
 		{TYPE_OBJECT, "object"},
 		{TYPE_VFS, "vfs"},
-		{TYPE_INODE, "inode"},
+		{TYPE_VFS_ENTRY, "vfs_entry"},
 		{TYPE_CHILD, "directory"},
 		{TYPE_DATA, "data"},
 		{TYPE_SIGNATURE, "signature"},

--- a/packfile/packfile_test.go
+++ b/packfile/packfile_test.go
@@ -188,8 +188,8 @@ func TestDefaultConfiguration(t *testing.T) {
 func TestTypes(t *testing.T) {
 	list := Types()
 
-	require.Equal(t, 8, len(list))
-	require.Equal(t, []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}, list)
+	require.Equal(t, 9, len(list))
+	require.Equal(t, []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_INODE, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}, list)
 }
 
 func TestBlobTypeName(t *testing.T) {
@@ -201,6 +201,7 @@ func TestBlobTypeName(t *testing.T) {
 		{TYPE_CHUNK, "chunk"},
 		{TYPE_OBJECT, "object"},
 		{TYPE_VFS, "vfs"},
+		{TYPE_INODE, "inode"},
 		{TYPE_CHILD, "directory"},
 		{TYPE_DATA, "data"},
 		{TYPE_SIGNATURE, "signature"},

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -538,8 +538,8 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 			return
 		}
 		csum = snap.repository.Checksum(serialized)
-		if !snap.BlobExists(packfile.TYPE_INODE, csum) {
-			err = snap.PutBlob(packfile.TYPE_INODE, csum, serialized)
+		if !snap.BlobExists(packfile.TYPE_VFS_ENTRY, csum) {
+			err = snap.PutBlob(packfile.TYPE_VFS_ENTRY, csum, serialized)
 		}
 		return
 	})

--- a/snapshot/store.go
+++ b/snapshot/store.go
@@ -55,17 +55,17 @@ func (s *SnapshotStore[K, V]) Put(node *btree.Node[K, objects.Checksum, V]) (obj
 
 // persistIndex saves a btree[K, P, V] index to the snapshot.  The
 // pointer type P is converted to a checksum.
-func persistIndex[K, P, V any](snap *Snapshot, tree *btree.BTree[K, P, V], t packfile.Type) (csum objects.Checksum, err error) {
-	root, err := btree.Persist(tree, &SnapshotStore[K, V]{
+func persistIndex[K, P, VA, VB any](snap *Snapshot, tree *btree.BTree[K, P, VA], t packfile.Type, conv func(VA) (VB, error)) (csum objects.Checksum, err error) {
+	root, err := btree.Persist(tree, &SnapshotStore[K, VB]{
 		readonly: false,
 		blobtype: t,
 		snap:     snap,
-	})
+	}, conv)
 	if err != nil {
 		return
 	}
 
-	bytes, err := msgpack.Marshal(&btree.BTree[K, objects.Checksum, V]{
+	bytes, err := msgpack.Marshal(&btree.BTree[K, objects.Checksum, VB]{
 		Order: tree.Order,
 		Root:  root,
 	})

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -105,7 +105,7 @@ func (fsc *Filesystem) lookup(entrypath string) (*Entry, error) {
 }
 
 func (fsc *Filesystem) resolveEntry(csum objects.Checksum) (*Entry, error) {
-	rd, err := fsc.repo.GetBlob(packfile.TYPE_INODE, csum)
+	rd, err := fsc.repo.GetBlob(packfile.TYPE_VFS_ENTRY, csum)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"io"
 	"io/fs"
 	"iter"
 	"path"
@@ -35,7 +36,7 @@ type AlternateDataStream struct {
 }
 
 type Filesystem struct {
-	tree *btree.BTree[string, objects.Checksum, Entry]
+	tree *btree.BTree[string, objects.Checksum, objects.Checksum]
 	repo *repository.Repository
 }
 
@@ -68,7 +69,7 @@ func NewFilesystem(repo *repository.Repository, root objects.Checksum) (*Filesys
 		return nil, err
 	}
 
-	storage := repository.NewRepositoryStore[string, Entry](repo, packfile.TYPE_VFS)
+	storage := repository.NewRepositoryStore[string, objects.Checksum](repo, packfile.TYPE_VFS)
 	tree, err := btree.Deserialize(rd, storage, PathCmp)
 	if err != nil {
 		return nil, err
@@ -92,14 +93,29 @@ func (fsc *Filesystem) lookup(entrypath string) (*Entry, error) {
 		entrypath = "/"
 	}
 
-	entry, found, err := fsc.tree.Find(entrypath)
+	csum, found, err := fsc.tree.Find(entrypath)
 	if err != nil {
 		return nil, err
 	}
 	if !found {
 		return nil, fs.ErrNotExist
 	}
-	return &entry, nil
+
+	return fsc.resolveEntry(csum)
+}
+
+func (fsc *Filesystem) resolveEntry(csum objects.Checksum) (*Entry, error) {
+	rd, err := fsc.repo.GetBlob(packfile.TYPE_INODE, csum)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := io.ReadAll(rd)
+	if err != nil {
+		return nil, err
+	}
+
+	return EntryFromBytes(bytes)	
 }
 
 func (fsc *Filesystem) Open(path string) (fs.File, error) {
@@ -133,7 +149,14 @@ func (fsc *Filesystem) Files() iter.Seq2[string, error] {
 		}
 
 		for iter.Next() {
-			path, entry := iter.Current()
+			path, csum := iter.Current()
+			entry, err := fsc.resolveEntry(csum)
+			if err != nil {
+				if !yield(path, err) {
+					return
+				}
+				continue
+			}
 			if entry.FileInfo.Lmode.IsRegular() {
 				if !yield(path, nil) {
 					return
@@ -201,6 +224,30 @@ func (fsc *Filesystem) Children(path string) (iter.Seq2[string, error], error) {
 	}, nil
 }
 
-func (fsc *Filesystem) VisitNodes(cb func(objects.Checksum, *btree.Node[string, objects.Checksum, Entry]) error) error {
+func (fsc *Filesystem) VisitNodes(cb func(objects.Checksum, *btree.Node[string, objects.Checksum, objects.Checksum]) error) error {
 	return fsc.tree.VisitDFS(cb)
+}
+
+func (fsc *Filesystem) FileChecksums() (iter.Seq2[objects.Checksum, error], error) {
+	iter, err := fsc.tree.ScanAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return func(yield func(objects.Checksum, error) bool) {
+		for iter.Next() {
+			_, csum := iter.Current()
+			if err != nil {
+				yield(objects.Checksum{}, err)
+				return
+			}
+			if !yield(csum, nil) {
+				return
+			}
+		}
+		if err := iter.Err(); err != nil {
+			yield(objects.Checksum{}, err)
+			return
+		}
+	}, nil
 }


### PR DESCRIPTION
For this, and to avoid changing too much the structure of backup.go, `btree.Persist` needs to learn how to convert the values: it allows to build the BTree as we're doing now, and deal with the checksums only when we have to persist the entries too.