### PR TITLE
add storage tests

### DIFF
--- a/testing/backend.go
+++ b/testing/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/PlakarKorp/plakar/compression"
@@ -137,7 +138,14 @@ type MockBackend struct {
 	behavior string
 }
 
+func NewMockBackend(location string) *MockBackend {
+	return &MockBackend{location: location}
+}
+
 func (mb *MockBackend) Create(repository string, configuration storage.Configuration) error {
+	if strings.Contains(repository, "musterror") {
+		return errors.New("creating error")
+	}
 	mb.configuration = configuration
 
 	mb.behavior = "default"
@@ -157,6 +165,9 @@ func (mb *MockBackend) Create(repository string, configuration storage.Configura
 }
 
 func (mb *MockBackend) Open(repository string) error {
+	if strings.Contains(repository, "musterror") {
+		return errors.New("opening error")
+	}
 	return nil
 }
 


### PR DESCRIPTION
before
```
ok  	github.com/PlakarKorp/plakar/storage	0.003s	coverage: 38.6% of statements
```

after
```
ok  	github.com/PlakarKorp/plakar/storage	0.007s	coverage: 96.5% of statements
```