### PR TITLE
remove commit method from storage backends

### DIFF
--- a/storage/backends/database/database.go
+++ b/storage/backends/database/database.go
@@ -172,23 +172,6 @@ func (repo *Repository) Close() error {
 	return nil
 }
 
-func (repo *Repository) Commit(snapshotID objects.Checksum, data []byte) error {
-	statement, err := repo.conn.Prepare(`INSERT INTO snapshots (snapshotID, data) VALUES(?, ?)`)
-	if err != nil {
-		return err
-	}
-	defer statement.Close()
-
-	repo.wrMutex.Lock()
-	_, err = statement.Exec(snapshotID, data)
-	repo.wrMutex.Unlock()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (repo *Repository) Configuration() storage.Configuration {
 	return repo.config
 }

--- a/storage/backends/null/null.go
+++ b/storage/backends/null/null.go
@@ -117,7 +117,3 @@ func (repository *Repository) GetPackfileBlob(checksum objects.Checksum, offset 
 func (repository *Repository) DeletePackfile(checksum objects.Checksum) error {
 	return nil
 }
-
-func (repository *Repository) Commit(snapshotID objects.Checksum, data []byte) error {
-	return nil
-}

--- a/storage/backends/s3/s3.go
+++ b/storage/backends/s3/s3.go
@@ -372,13 +372,3 @@ func (repository *Repository) DeletePackfile(checksum objects.Checksum) error {
 	}
 	return nil
 }
-
-//////
-
-func (repository *Repository) Commit(snapshotID objects.Checksum, data []byte) error {
-	_, err := repository.minioClient.PutObject(context.Background(), repository.bucketName, fmt.Sprintf("snapshots/%x/%s", snapshotID[0], hex.EncodeToString(snapshotID[:])), bytes.NewReader(data), int64(len(data)), minio.PutObjectOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}


### PR DESCRIPTION
doesn't seem to be used anywhere and not defined on the main storage.Store interface