### PR TITLE
fix checksum json unmarshalling

### DIFF
--- a/objects/objects.go
+++ b/objects/objects.go
@@ -1,6 +1,7 @@
 package objects
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -11,6 +12,20 @@ type Checksum [32]byte
 
 func (m Checksum) MarshalJSON() ([]byte, error) {
 	return json.Marshal(fmt.Sprintf("%0x", m[:]))
+}
+
+func (m *Checksum) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	decoded, err := hex.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	copy(m[:], decoded)
+	return nil
 }
 
 type Classification struct {

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -24,6 +24,11 @@ func (m *Checksum) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
+
+	if len(decoded) != 32 {
+		return fmt.Errorf("invalid checksum length: %d", len(decoded))
+	}
+
 	copy(m[:], decoded)
 	return nil
 }

--- a/objects/objects_test.go
+++ b/objects/objects_test.go
@@ -18,6 +18,17 @@ func TestChecksumMarshalJSON(t *testing.T) {
 	require.Equal(t, expected, string(jsonBytes))
 }
 
+func TestChecksumUnMarshalJSON(t *testing.T) {
+	expected := Checksum{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
+	marshalled := `"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"`
+
+	var checksum Checksum
+	err := json.Unmarshal([]byte(marshalled), &checksum)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, checksum)
+}
+
 func TestClassificationMarshalJSON(t *testing.T) {
 	classification := Classification{
 		Analyzer: "test-analyzer",

--- a/objects/objects_test.go
+++ b/objects/objects_test.go
@@ -19,11 +19,18 @@ func TestChecksumMarshalJSON(t *testing.T) {
 }
 
 func TestChecksumUnMarshalJSON(t *testing.T) {
+	brokenValue := `"010203"`
+
+	var c Checksum
+	err := json.Unmarshal([]byte(brokenValue), &c)
+	require.Error(t, err)
+
+	// working
 	expected := Checksum{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
 	marshalled := `"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"`
 
 	var checksum Checksum
-	err := json.Unmarshal([]byte(marshalled), &checksum)
+	err = json.Unmarshal([]byte(marshalled), &checksum)
 	require.NoError(t, err)
 
 	require.Equal(t, expected, checksum)


### PR DESCRIPTION
to avoid errors like 
```
json: cannot unmarshal string into Go value of type objects.Checksum
```