### PR TITLE
fix race condition in subscription to events bus for the client:

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -267,8 +267,9 @@ func (d *Agent) ListenAndServe(handler func(*appcontext.AppContext, *repository.
 			defer repo.Close()
 
 			eventsDone := make(chan struct{})
+			eventsChan := clientContext.Events().Listen()
 			go func() {
-				for evt := range clientContext.Events().Listen() {
+				for evt := range eventsChan {
 					serialized, err := events.Serialize(evt)
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Failed to serialize event: %s\n", err)

--- a/events/receiver.go
+++ b/events/receiver.go
@@ -1,7 +1,12 @@
 package events
 
+import (
+	"sync"
+)
+
 type Receiver struct {
 	listeners []chan interface{}
+	mu        sync.Mutex
 }
 
 func New() *Receiver {
@@ -11,18 +16,24 @@ func New() *Receiver {
 }
 
 func (er *Receiver) Listen() <-chan interface{} {
+	er.mu.Lock()
+	defer er.mu.Unlock()
 	ch := make(chan interface{})
 	er.listeners = append(er.listeners, ch)
 	return ch
 }
 
 func (er *Receiver) Send(event interface{}) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
 	for _, ch := range er.listeners {
 		ch <- event
 	}
 }
 
 func (er *Receiver) Close() {
+	er.mu.Lock()
+	defer er.mu.Unlock()
 	for _, ch := range er.listeners {
 		close(ch)
 	}


### PR DESCRIPTION
if Execute() returns too fast, either due to invalid command or to a command returning too fast, the goroutine may have subscribed to the bus _after_ it's been closed leading to a deadlock on the synchronization channel. make sure to subscribe before entering the goroutine to ensure the subscription is valid after Execute.