### PR TITLE
state: Implement a serial number for states.

### DIFF
--- a/caching/repository.go
+++ b/caching/repository.go
@@ -76,8 +76,8 @@ func (c *_RepositoryCache) DelState(stateID objects.Checksum) error {
 	return c.delete("__state__", fmt.Sprintf("%x", stateID))
 }
 
-func (c *_RepositoryCache) GetStates() ([]objects.Checksum, error) {
-	ret := make([]objects.Checksum, 0)
+func (c *_RepositoryCache) GetStates() (map[objects.Checksum][]byte, error) {
+	ret := make(map[objects.Checksum][]byte, 0)
 	iter := c.db.NewIterator(nil, nil)
 	defer iter.Release()
 
@@ -93,7 +93,7 @@ func (c *_RepositoryCache) GetStates() ([]objects.Checksum, error) {
 			fmt.Printf("Error decoding state ID: %v\n", err)
 			return nil, err
 		}
-		ret = append(ret, stateID)
+		ret[stateID] = iter.Value()
 	}
 
 	return ret, nil

--- a/caching/scan.go
+++ b/caching/scan.go
@@ -136,7 +136,7 @@ func (c *ScanCache) GetState(stateID objects.Checksum) ([]byte, error) {
 	panic("GetState should never be used on the ScanCache backend")
 }
 
-func (c *ScanCache) GetStates() ([]objects.Checksum, error) {
+func (c *ScanCache) GetStates() (map[objects.Checksum][]byte, error) {
 	panic("GetStates should never be used on the ScanCache backend")
 }
 

--- a/caching/state.go
+++ b/caching/state.go
@@ -12,7 +12,7 @@ type StateCache interface {
 	HasState(stateID objects.Checksum) (bool, error)
 	GetState(stateID objects.Checksum) ([]byte, error)
 	DelState(stateID objects.Checksum) error
-	GetStates() ([]objects.Checksum, error)
+	GetStates() (map[objects.Checksum][]byte, error)
 
 	PutDelta(blobType packfile.Type, blobCsum objects.Checksum, data []byte) error
 	GetDelta(blobType packfile.Type, blobCsum objects.Checksum) ([]byte, error)

--- a/cmd/plakar/subcommands/info/info.go
+++ b/cmd/plakar/subcommands/info/info.go
@@ -309,12 +309,7 @@ func info_state(repo *repository.Repository, args []string) error {
 
 			fmt.Printf("Version: %d.%d.%d\n", st.Metadata.Version/100, (st.Metadata.Version/10)%10, st.Metadata.Version%10)
 			fmt.Printf("Creation: %s\n", st.Metadata.Timestamp)
-			if len(st.Metadata.Extends) > 0 {
-				fmt.Printf("Extends:\n")
-				for _, stateID := range st.Metadata.Extends {
-					fmt.Printf("  %x\n", stateID)
-				}
-			}
+			fmt.Printf("State serial: %s\n", st.Metadata.Serial)
 
 			printBlobs := func(name string, Type packfile.Type) {
 				for snapshot, err := range st.ListObjectsOfType(Type) {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -68,7 +68,7 @@ func New(repo *repository.Repository) (*Snapshot, error) {
 		packerChanDone: make(chan bool),
 	}
 
-	snap.deltaState = state.NewLocalState(scanCache)
+	snap.deltaState = repo.NewStateDelta(scanCache)
 
 	if snap.AppContext().Identity != uuid.Nil {
 		snap.Header.Identity.Identifier = snap.AppContext().Identity


### PR DESCRIPTION
* Basic idea is to have a "generation number" like serial, that will let us deal with maintenance by detecting compacted / aggregated state.

* Initial serial is the repository id to avoid any race issues with concurrent first time backups.