### PR TITLE
Gchehade/remove-type-data

### DIFF
--- a/cmd/plakar/subcommands/info/info.go
+++ b/cmd/plakar/subcommands/info/info.go
@@ -329,7 +329,6 @@ func info_state(repo *repository.Repository, args []string) error {
 			printBlobs("chunk", packfile.TYPE_CHUNK)
 			printBlobs("object", packfile.TYPE_OBJECT)
 			printBlobs("file", packfile.TYPE_VFS)
-			printBlobs("data", packfile.TYPE_DATA)
 		}
 	}
 	return nil

--- a/packfile/packfile.go
+++ b/packfile/packfile.go
@@ -14,13 +14,12 @@ const VERSION = 100
 type Type uint8
 
 const (
-	TYPE_SNAPSHOT  Type = 0
-	TYPE_CHUNK     Type = 1
-	TYPE_OBJECT    Type = 2
-	TYPE_VFS       Type = 3
-	TYPE_VFS_ENTRY Type = 4
-	TYPE_CHILD     Type = 5
-	TYPE_DATA      Type = 6
+	TYPE_SNAPSHOT  Type = 1
+	TYPE_CHUNK     Type = 2
+	TYPE_OBJECT    Type = 3
+	TYPE_VFS       Type = 4
+	TYPE_VFS_ENTRY Type = 5
+	TYPE_CHILD     Type = 6
 	TYPE_SIGNATURE Type = 7
 	TYPE_ERROR     Type = 8
 )
@@ -33,7 +32,7 @@ type Blob struct {
 }
 
 func Types() []Type {
-	return []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_VFS_ENTRY, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}
+	return []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_VFS_ENTRY, TYPE_CHILD, TYPE_SIGNATURE, TYPE_ERROR}
 }
 
 func (b Blob) TypeName() string {
@@ -50,8 +49,6 @@ func (b Blob) TypeName() string {
 		return "vfs_entry"
 	case TYPE_CHILD:
 		return "directory"
-	case TYPE_DATA:
-		return "data"
 	case TYPE_SIGNATURE:
 		return "signature"
 	case TYPE_ERROR:

--- a/packfile/packfile_test.go
+++ b/packfile/packfile_test.go
@@ -188,8 +188,8 @@ func TestDefaultConfiguration(t *testing.T) {
 func TestTypes(t *testing.T) {
 	list := Types()
 
-	require.Equal(t, 9, len(list))
-	require.Equal(t, []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_VFS_ENTRY, TYPE_CHILD, TYPE_DATA, TYPE_SIGNATURE, TYPE_ERROR}, list)
+	require.Equal(t, 8, len(list))
+	require.Equal(t, []Type{TYPE_SNAPSHOT, TYPE_CHUNK, TYPE_OBJECT, TYPE_VFS, TYPE_VFS_ENTRY, TYPE_CHILD, TYPE_SIGNATURE, TYPE_ERROR}, list)
 }
 
 func TestBlobTypeName(t *testing.T) {
@@ -203,7 +203,6 @@ func TestBlobTypeName(t *testing.T) {
 		{TYPE_VFS, "vfs"},
 		{TYPE_VFS_ENTRY, "vfs_entry"},
 		{TYPE_CHILD, "directory"},
-		{TYPE_DATA, "data"},
 		{TYPE_SIGNATURE, "signature"},
 		{TYPE_ERROR, "error"},
 		{255, "unknown"}, // test default case

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -257,12 +257,6 @@ func (snap *Snapshot) ListObjects() (iter.Seq2[objects.Checksum, error], error) 
 	}, nil
 }
 
-func (snap *Snapshot) ListDatas() iter.Seq2[objects.Checksum, error] {
-	return func(yield func(objects.Checksum, error) bool) {
-		yield(snap.Header.Metadata, nil)
-	}
-}
-
 func (snap *Snapshot) Logger() *logging.Logger {
 	return snap.AppContext().GetLogger()
 }


### PR DESCRIPTION
this was intended to store blob indexes but with a btree now in, we might want to handle this differently.

get rid of it since the only use was content types which are being handled in a different way.

we'll introduce a more appropriate type if needed