### PR TITLE
rework encryption

### DIFF
--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -277,8 +277,11 @@ func entryPoint() int {
 						passphrase = []byte(envPassphrase)
 					}
 
-					secret, err = encryption.DeriveSecret(passphrase, store.Configuration().Encryption.Key)
+					key, err := encryption.DeriveKey(store.Configuration().Encryption.KDFParams, passphrase)
 					if err != nil {
+						continue
+					}
+					if !encryption.VerifyCanary(key, store.Configuration().Encryption.Canary) {
 						if envPassphrase != "" {
 							break
 						}
@@ -288,13 +291,15 @@ func entryPoint() int {
 					break
 				}
 			} else {
-				secret, err = encryption.DeriveSecret([]byte(ctx.KeyFromFile), store.Configuration().Encryption.Key)
+				key, err := encryption.DeriveKey(store.Configuration().Encryption.KDFParams, []byte(ctx.KeyFromFile))
 				if err == nil {
-					derived = true
+					if encryption.VerifyCanary(key, store.Configuration().Encryption.Canary) {
+						derived = true
+					}
 				}
 			}
 			if !derived {
-				fmt.Fprintf(os.Stderr, "%s: could not derive secret: %s\n", flag.CommandLine.Name(), err)
+				fmt.Fprintf(os.Stderr, "%s: could not derive secret\n", flag.CommandLine.Name())
 				os.Exit(1)
 			}
 			ctx.SetSecret(secret)

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -57,6 +57,8 @@ func cmd_create(ctx *appcontext.AppContext, _ *repository.Repository, args []str
 	storageConfiguration.Hashing = *hashingConfiguration
 
 	if !opt_noencryption {
+		storageConfiguration.Encryption.Algorithm = encryption.DefaultConfiguration().Algorithm
+
 		var passphrase []byte
 
 		envPassphrase := os.Getenv("PLAKAR_PASSPHRASE")
@@ -82,13 +84,22 @@ func cmd_create(ctx *appcontext.AppContext, _ *repository.Repository, args []str
 			return 1, fmt.Errorf("can't encrypt the repository with an empty passphrase")
 		}
 
-		encryptionKey, err := encryption.BuildSecretFromPassphrase(passphrase)
+		salt, err := encryption.Salt()
+		if err != nil {
+			return 1, err
+		}
+		storageConfiguration.Encryption.KDFParams.Salt = salt
+
+		key, err := encryption.DeriveKey(storageConfiguration.Encryption.KDFParams, passphrase)
 		if err != nil {
 			return 1, err
 		}
 
-		storageConfiguration.Encryption.Algorithm = encryption.DefaultConfiguration().Algorithm
-		storageConfiguration.Encryption.Key = encryptionKey
+		canary, err := encryption.DeriveCanary(key)
+		if err != nil {
+			return 1, err
+		}
+		storageConfiguration.Encryption.Canary = canary
 	} else {
 		storageConfiguration.Encryption = nil
 	}

--- a/cmd/plakar/subcommands/info/info.go
+++ b/cmd/plakar/subcommands/info/info.go
@@ -154,7 +154,14 @@ func info_repository(repo *repository.Repository) (int, error) {
 	if repo.Configuration().Encryption != nil {
 		fmt.Println("Encryption:")
 		fmt.Println(" - Algorithm:", repo.Configuration().Encryption.Algorithm)
-		fmt.Println(" - Key:", repo.Configuration().Encryption.Key)
+		fmt.Printf(" - Canary: %x\n", repo.Configuration().Encryption.Canary)
+		fmt.Println(" - KDF:", repo.Configuration().Encryption.KDF)
+		fmt.Println(" - KDFParams:")
+		fmt.Printf("   - N: %d\n", repo.Configuration().Encryption.KDFParams.N)
+		fmt.Printf("   - R: %d\n", repo.Configuration().Encryption.KDFParams.R)
+		fmt.Printf("   - P: %d\n", repo.Configuration().Encryption.KDFParams.P)
+		fmt.Printf("   - Salt: %x\n", repo.Configuration().Encryption.KDFParams.Salt)
+		fmt.Printf("   - KeyLen: %d\n", repo.Configuration().Encryption.KDFParams.KeyLen)
 	}
 
 	fmt.Println("Snapshots:", len(metadatas))

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -77,12 +77,16 @@ func cmd_sync(ctx *appcontext.AppContext, repo *repository.Repository, args []st
 				continue
 			}
 
-			secret, err := encryption.DeriveSecret(passphrase, peerStore.Configuration().Encryption.Key)
+			key, err := encryption.DeriveKey(peerStore.Configuration().Encryption.KDFParams, passphrase)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err)
 				continue
 			}
-			peerSecret = secret
+			if !encryption.VerifyCanary(key, peerStore.Configuration().Encryption.Canary) {
+				fmt.Fprintf(os.Stderr, "invalid passphrase\n")
+				continue
+			}
+			peerSecret = key
 			break
 		}
 	}


### PR DESCRIPTION
long story short:

We don't need to store the encrypted master key in the repository config as if we store the KDF parameters and salt, we can derive the same master key from the passphrase and config parameters.

Adding a canary field with encrypted random data, we can rely on the GCM integrity check to validate that the passphrase supplied was the same as during repository configuration without leaking any useful informations.