### PR TITLE
fix (some) summary accounting

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -424,10 +424,6 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 	var rootSummary *vfs.Summary
 
 	diriter := backupCtx.scanCache.EnumerateKeysWithPrefix("__directory__:", true)
-	if err != nil {
-		return err
-	}
-
 	for dirPath, bytes := range diriter {
 		select {
 		case <-snap.AppContext().GetContext().Done():
@@ -463,33 +459,38 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 				return err
 			}
 
-			if childEntry.Stat().Mode().IsDir() {
-				data, err := snap.scanCache.GetSummary(childPath)
-				if err != nil {
-					continue
-				}
+			data, err := vfsCache.GetFileSummary(childPath)
+			if err != nil {
+				continue
+			}
 
-				childSummary, err := vfs.SummaryFromBytes(data)
-				if err != nil {
-					continue
-				}
-
-				dirEntry.Summary.UpdateBelow(childSummary)
-			} else {
-				data, err := vfsCache.GetFileSummary(childPath)
-				if err != nil {
-					continue
-				}
-
-				fileSummary, err := vfs.FileSummaryFromBytes(data)
-				if err != nil {
-					continue
-				}
-
-				dirEntry.Summary.UpdateWithFileSummary(fileSummary)
+			fileSummary, err := vfs.FileSummaryFromBytes(data)
+			if err != nil {
+				continue
 			}
 
 			dirEntry.Summary.Directory.Children++
+			dirEntry.Summary.UpdateWithFileSummary(fileSummary)
+		}
+
+		subDirIter := backupCtx.scanCache.EnumerateKeysWithPrefix("__directory__:"+prefix, false)
+		for relpath, _ := range subDirIter {
+			if relpath == "" || strings.Contains(relpath, "/") {
+				continue
+			}
+
+			childPath := prefix + relpath
+			data, err := snap.scanCache.GetSummary(childPath)
+			if err != nil {
+				continue
+			}
+
+			childSummary, err := vfs.SummaryFromBytes(data)
+			if err != nil {
+				continue
+			}
+			dirEntry.Summary.Directory.Children++
+			dirEntry.Summary.UpdateBelow(childSummary)
 		}
 
 		erriter, err := backupCtx.erridx.ScanFrom(prefix)


### PR DESCRIPTION
Not sure if this is everything.  For examples, if i backup `/home/op/w/plakar/btree` i get this `info vfs` back:

```
[DirEntry]
Version: 2
ParentPath: /
Name: /
Type: 1
Size: 4.1 kB (4096 bytes)
Permissions: drwxr-xr-x
ModTime: 2024-07-24 09:59:59.463964813 +0200 CEST
DeviceID: 65025
InodeID: 2
UserID: 0
GroupID: 0
Username: root
Groupname: root
NumLinks: 20
ExtendedAttributes: []
FileAttributes: 0
Classification:
CustomMetadata: []
Tags: []
Below.Directories: 0
Below.Files: 7
Below.Symlinks: 0
Below.Devices: 0
Below.Pipes: 0
Below.Sockets: 0
Below.Setuid: 0
Below.Setgid: 0
Below.Sticky: 0
Below.Objects: 7
Below.Chunks: 7
Below.MinSize: 0 B (0 bytes)
Below.MaxSize: 6.9 kB (6907 bytes)
Below.Size: 26 kB (26442 bytes)
Below.MinModTime: 1970-01-01 01:00:00 +0100 CET
Below.MaxModTime: 2025-02-03 15:20:39 +0100 CET
Below.MinEntropy: 0.000000
Below.MaxEntropy: 5.158797
Below.HiEntropy: 0
Below.LoEntropy: 0
Below.MIMEAudio: 0
Below.MIMEVideo: 0
Below.MIMEImage: 0
Below.MIMEText: 7
Below.MIMEApplication: 0
Below.MIMEOther: 0
Below.Errors: 0
Directory.Directories: 0
Directory.Files: 0
Directory.Symlinks: 0
Directory.Devices: 0
Directory.Pipes: 0
Directory.Sockets: 0
Directory.Setuid: 0
Directory.Setgid: 0
Directory.Sticky: 0
Directory.Objects: 0
Directory.Chunks: 0
Directory.MinSize: 0 B (0 bytes)
Directory.MaxSize: 0 B (0 bytes)
Directory.Size: 0 B (0 bytes)
Directory.MinModTime: 1970-01-01 01:00:00 +0100 CET
Directory.MaxModTime: 1970-01-01 01:00:00 +0100 CET
Directory.MinEntropy: 0.000000
Directory.MaxEntropy: 0.000000
Directory.AvgEntropy: 0.000000
Directory.HiEntropy: 0
Directory.LoEntropy: 0
Directory.MIMEAudio: 0
Directory.MIMEVideo: 0
Directory.MIMEImage: 0
Directory.MIMEText: 0
Directory.MIMEApplication: 0
Directory.MIMEOther: 0
Directory.Errors: 0
Directory.Children: 1
Child[0].FileInfo.Name(): home
Child[0].FileInfo.Size(): 4096
Child[0].FileInfo.Mode(): drwxr-xr-x
Child[0].FileInfo.Dev(): 65025
Child[0].FileInfo.Ino(): 14548993
Child[0].FileInfo.Uid(): 0
Child[0].FileInfo.Gid(): 0
Child[0].FileInfo.Username(): root
Child[0].FileInfo.Groupname(): root
Child[0].FileInfo.Nlink(): 3
```

Which seems overall good to me, except for the `Directory.{Min,Max}ModTime` and the size:

```
$ du -h btree
48K	btree/
$ ./plakar info vfs d0cb6696:/ | grep ^Below.Size
Below.Size: 26 kB (26442 bytes)
```

But at least the size are matching: 
```
$ ls -lah btree
-rw-r--r--   1 op             users     698 2025-01-10 17:44 README.md
-rw-r--r--   1 op             users    6.2k 2025-02-03 09:50 btree.go
-rw-r--r--   1 op             users    6.7k 2025-02-03 15:20 btree_test.go
-rw-r--r--   1 op             users    4.2k 2025-01-09 09:38 iter.go
-rw-r--r--   1 op             users     897 2025-02-03 15:20 memorystore.go
-rw-r--r--   1 op             users    1.6k 2025-02-03 15:20 persist.go
-rw-r--r--   1 op             users    5.5k 2025-01-24 19:36 verify.go
$ ./plakar ls d0cb6696:/home/op/w/plakar/btree
2025-01-10T16:44:18Z -rw-r--r--                      698 B README.md
2025-02-03T08:50:40Z -rw-r--r--                     6.4 kB btree.go
2025-02-03T14:20:39Z -rw-r--r--                     6.9 kB btree_test.go
2025-01-09T08:38:47Z -rw-r--r--                     4.3 kB iter.go
2025-02-03T14:20:39Z -rw-r--r--                      897 B memorystore.go
2025-02-03T14:20:39Z -rw-r--r--                     1.6 kB persist.go
2025-01-24T18:36:36Z -rw-r--r--                     5.7 kB verify.go
```
