### PR TITLE
create: avoid infinite loop if stdin is a pipe

### DIFF
--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -84,7 +84,7 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 			if envPassphrase != "" {
 				passphrase = []byte(envPassphrase)
 			} else {
-				for {
+				for attempt := 0; attempt < 3; attempt++ {
 					tmp, err := utils.GetPassphraseConfirm("repository")
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "%s\n", err)


### PR DESCRIPTION
it fixes `echo | plakar create` that was previously an infinite loop, but it's still not possible to provide the passphrase through a pipe.