### PR TITLE
let repository provide a HMAC hasher preset with repository master key and a ChecksumHMAC helper

### DIFF
--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -1,6 +1,7 @@
 package hashing
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
 	"hash"
@@ -32,6 +33,15 @@ func GetHasher(name string) hash.Hash {
 	switch name {
 	case "SHA256":
 		return sha256.New()
+	default:
+		return nil
+	}
+}
+
+func GetHMAC(name string, key []byte) hash.Hash {
+	switch name {
+	case "SHA256":
+		return hmac.New(sha256.New, key)
 	default:
 		return nil
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"bytes"
-	"crypto/hmac"
 	"errors"
 	"hash"
 	"io"
@@ -266,7 +265,7 @@ func (r *Repository) Checksum(data []byte) objects.Checksum {
 }
 
 func (r *Repository) HMAC() hash.Hash {
-	return hmac.New(r.Hasher, r.AppContext().GetSecret())
+	return hashing.GetHMAC(r.Configuration().Hashing.Algorithm, r.AppContext().GetSecret())
 }
 
 func (r *Repository) ChecksumHMAC(data []byte) objects.Checksum {


### PR DESCRIPTION
this will be used to generate HMAC for the storage file format and for privacy-friendly lookup keys