### PR TITLE
swap lookup key with a hmac before calling state lookups or repository lookups

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -391,9 +391,12 @@ func (r *Repository) DeletePackfile(checksum objects.Checksum) error {
 func (r *Repository) GetBlob(Type resources.Type, checksum objects.Checksum) (io.ReadSeeker, error) {
 	t0 := time.Now()
 	defer func() {
-		r.Logger().Trace("repository", "GetBlob(%x): %s", checksum, time.Since(t0))
+		r.Logger().Trace("repository", "GetBlob(%s, %x): %s", Type, checksum, time.Since(t0))
 	}()
 
+	if Type != resources.RT_SNAPSHOT {
+		checksum = r.ChecksumHMAC(checksum[:])
+	}
 	packfileChecksum, offset, length, exists := r.state.GetSubpartForBlob(Type, checksum)
 	if !exists {
 		return nil, ErrPackfileNotFound
@@ -413,6 +416,9 @@ func (r *Repository) BlobExists(Type resources.Type, checksum objects.Checksum) 
 		r.Logger().Trace("repository", "BlobExists(%x): %s", checksum, time.Since(t0))
 	}()
 
+	if Type != resources.RT_SNAPSHOT {
+		checksum = r.ChecksumHMAC(checksum[:])
+	}
 	return r.state.BlobExists(Type, checksum)
 }
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -145,12 +145,12 @@ func Fork(repo *repository.Repository, Identifier objects.Checksum) (*Snapshot, 
 
 	snap.Header.Identifier = identifier
 
-	snap.Logger().Trace("snapshot", "%x: Fork(): %s", snap.Header.Identifier, snap.Header.GetIndexShortID())
+	snap.Logger().Trace("snapshot", "%x: Fork(): %x", snap.Header.Identifier, snap.Header.GetIndexShortID())
 	return snap, nil
 }
 
 func (snap *Snapshot) Close() error {
-	snap.Logger().Trace("snapshot", "%x: Close(): %s", snap.Header.Identifier, snap.Header.GetIndexShortID())
+	snap.Logger().Trace("snapshot", "%x: Close(): %x", snap.Header.Identifier, snap.Header.GetIndexShortID())
 
 	if snap.scanCache != nil {
 		return snap.scanCache.Close()


### PR DESCRIPTION
if the resourceType is not snapshot, this allows building packfiles with field
checksum in the index set as the hmac and lets state and repo use correct keys