### PR TITLE
teach plakar how to hint at providing a proper passphrase, allow

### DIFF
--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -114,7 +114,6 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 			if err != nil {
 				return 1, fmt.Errorf("passphrase is too weak: %s", err)
 			}
-
 		}
 
 		salt, err := encryption.Salt()

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -107,15 +107,14 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 			return 1, fmt.Errorf("can't encrypt the repository with an empty passphrase")
 		}
 
-		// keepass considers < 80 bits as weak
-		minEntropBits := 80.
-		if cmd.AllowWeak {
-			minEntropBits = 0.
-		}
+		if !cmd.AllowWeak {
+			// keepass considers < 80 bits as weak
+			minEntropBits := 80.
+			err := passwordvalidator.Validate(string(passphrase), minEntropBits)
+			if err != nil {
+				return 1, fmt.Errorf("passphrase is too weak: %s", err)
+			}
 
-		err := passwordvalidator.Validate(string(passphrase), minEntropBits)
-		if err != nil {
-			return 1, fmt.Errorf("passphrase is too weak: %s", err)
 		}
 
 		salt, err := encryption.Salt()

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -30,6 +30,7 @@ import (
 	"github.com/PlakarKorp/plakar/hashing"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/storage"
+	passwordvalidator "github.com/wagslane/go-password-validator"
 )
 
 func init() {
@@ -39,8 +40,10 @@ func init() {
 func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, args []string) (subcommands.Subcommand, error) {
 	var opt_noencryption bool
 	var opt_nocompression bool
+	var opt_allowweak bool
 
 	flags := flag.NewFlagSet("create", flag.ExitOnError)
+	flags.BoolVar(&opt_allowweak, "weak-passphrase", false, "allow weak passphrase to protect the repository")
 	flags.BoolVar(&opt_noencryption, "no-encryption", false, "disable transparent encryption")
 	flags.BoolVar(&opt_nocompression, "no-compression", false, "disable transparent compression")
 	flags.Parse(args)
@@ -50,6 +53,7 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 	}
 
 	return &Create{
+		AllowWeak:     opt_allowweak,
 		NoEncryption:  opt_noencryption,
 		NoCompression: opt_nocompression,
 		Location:      flags.Arg(0),
@@ -57,6 +61,7 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 }
 
 type Create struct {
+	AllowWeak     bool
 	NoEncryption  bool
 	NoCompression bool
 	Location      string
@@ -100,6 +105,16 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 
 		if len(passphrase) == 0 {
 			return 1, fmt.Errorf("can't encrypt the repository with an empty passphrase")
+		}
+
+		minEntropBits := 60.
+		if cmd.AllowWeak {
+			minEntropBits = 0.
+		}
+
+		err := passwordvalidator.Validate(string(passphrase), minEntropBits)
+		if err != nil {
+			return 1, fmt.Errorf("passphrase is too weak: %s", err)
 		}
 
 		salt, err := encryption.Salt()

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -107,7 +107,8 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 			return 1, fmt.Errorf("can't encrypt the repository with an empty passphrase")
 		}
 
-		minEntropBits := 60.
+		// keypass considers < 80 bits as weak
+		minEntropBits := 80.
 		if cmd.AllowWeak {
 			minEntropBits = 0.
 		}

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -107,7 +107,7 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 			return 1, fmt.Errorf("can't encrypt the repository with an empty passphrase")
 		}
 
-		// keypass considers < 80 bits as weak
+		// keepass considers < 80 bits as weak
 		minEntropBits := 80.
 		if cmd.AllowWeak {
 			minEntropBits = 0.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
+	github.com/wagslane/go-password-validator v0.3.0
 	github.com/whilp/git-urls v1.0.0
 	go.omarpolo.com/ttlmap v0.0.0-20231012080932-0154c95c7516
 	golang.org/x/crypto v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/wagslane/go-password-validator v0.3.0 h1:vfxOPzGHkz5S146HDpavl0cw1DSVP061Ry2PX0/ON6I=
+github.com/wagslane/go-password-validator v0.3.0/go.mod h1:TI1XJ6T5fRdRnHqHt14pvy1tNVnrwe7m3/f1f2fDphQ=
 github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
 github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
bypassing with -weak-passphrase as this can still be useful if a
passphrase is deemed secure by the user despite our warnings and
they still want to encrypt the passphrase with it rather than to
go `-no-encryption`