### PR TITLE
state: Save blob version when pushing them.

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -509,15 +509,6 @@ func (r *Repository) ListSnapshots() iter.Seq[objects.Checksum] {
 	return r.state.ListSnapshots()
 }
 
-func (r *Repository) SetPackfileForBlob(Type resources.Type, packfileChecksum objects.Checksum, chunkChecksum objects.Checksum, offset uint64, length uint32) {
-	t0 := time.Now()
-	defer func() {
-		r.Logger().Trace("repository", "SetPackfileForBlob(%x, %x, %d, %d): %s", packfileChecksum, chunkChecksum, offset, length, time.Since(t0))
-	}()
-
-	r.state.SetPackfileForBlob(Type, packfileChecksum, chunkChecksum, offset, length)
-}
-
 func (r *Repository) Logger() *logging.Logger {
 	return r.AppContext().GetLogger()
 }

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -795,8 +795,9 @@ func (snap *Snapshot) PutPackfile(packer *Packer) error {
 			for idx, blob := range packer.Packfile.Index {
 				if blob.HMAC == blobHMAC && blob.Type == Type {
 					delta := state.DeltaEntry{
-						Type: blob.Type,
-						Blob: blobHMAC,
+						Type:    blob.Type,
+						Version: packer.Packfile.Index[idx].Version,
+						Blob:    blobHMAC,
 						Location: state.Location{
 							Packfile: checksum,
 							Offset:   packer.Packfile.Index[idx].Offset,


### PR DESCRIPTION
* This way we don't have to go through the index to check a blob version.

* While here remove an old function that is unused anymore, reducing the number of way we push DeltaEntries to the state.