### PR TITLE
improve ls snapshotID

### DIFF
--- a/cmd/plakar/subcommands/ls/ls.go
+++ b/cmd/plakar/subcommands/ls/ls.go
@@ -138,7 +138,11 @@ func list_snapshots(ctx *appcontext.AppContext, repo *repository.Repository, use
 
 func list_snapshot(ctx *appcontext.AppContext, repo *repository.Repository, snapshotPath string, recursive bool) error {
 	prefix, pathname := utils.ParseSnapshotID(snapshotPath)
-	pathname = path.Clean(pathname)
+	if pathname == "" {
+		pathname = "/"
+	} else {
+		pathname = path.Clean(pathname)
+	}
 
 	snap, err := utils.OpenSnapshotByPrefix(repo, prefix)
 	if err != nil {

--- a/objects/fileinfo.go
+++ b/objects/fileinfo.go
@@ -71,7 +71,7 @@ func (f FileInfo) Nlink() uint16 {
 }
 
 func (f FileInfo) Sys() any {
-	return nil
+	return f
 }
 
 func (f FileInfo) Username() string {

--- a/objects/fileinfo_test.go
+++ b/objects/fileinfo_test.go
@@ -229,8 +229,4 @@ func TestFileInfoFromStat(t *testing.T) {
 	if fileInfo.Groupname() != groupname {
 		t.Errorf("expected Groupname %v, got %v", groupname, fileInfo.Lgroupname)
 	}
-
-	if fileInfo.Sys() != nil {
-		t.Errorf("expected nil, got %v", fileInfo.Sys())
-	}
 }


### PR DESCRIPTION
before:

```sh
$ plakar ls 80
2024-07-24T07:59:59Z drwxr-xr-x                     4.1 kB /
$ plakar ls 80:/
2024-07-16T17:11:30Z drwxr-xr-x                     4.1 kB home
```

now:

```sh
$ plakar ls 80
2024-07-16T17:11:30Z drwxr-xr-x                     4.1 kB home
```

I was tempted to change `utils.ParseSnapshotId` to return `"/"` instead of the empty string, but that's useful in some commands to disambiguate with the wrong usage, so changing only ls for now.