### PR TITLE
api: treat ErrPackfileNotFound as 500

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -33,8 +33,6 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, repository.ErrBlobNotFound):
 		fallthrough
-	case errors.Is(err, repository.ErrPackfileNotFound):
-		fallthrough
 	case errors.Is(err, fs.ErrNotExist):
 		fallthrough
 	case errors.Is(err, snapshot.ErrNotFound):


### PR DESCRIPTION
Unlike the snapshot not found case, which may be caused by a typo or a purposefully deleted snapshot, the packfile not found case is a sympthom of a worst problem: some kind of corruption in the repository.