### PR TITLE
ls: default to the importer directory

### DIFF
--- a/cmd/plakar/subcommands/ls/ls.go
+++ b/cmd/plakar/subcommands/ls/ls.go
@@ -138,17 +138,18 @@ func list_snapshots(ctx *appcontext.AppContext, repo *repository.Repository, use
 
 func list_snapshot(ctx *appcontext.AppContext, repo *repository.Repository, snapshotPath string, recursive bool) error {
 	prefix, pathname := utils.ParseSnapshotID(snapshotPath)
-	if pathname == "" {
-		pathname = "/"
-	} else {
-		pathname = path.Clean(pathname)
-	}
 
 	snap, err := utils.OpenSnapshotByPrefix(repo, prefix)
 	if err != nil {
 		return fmt.Errorf("ls: could not fetch snapshot: %w", err)
 	}
 	defer snap.Close()
+
+	if pathname == "" {
+		pathname = snap.Header.GetSource(0).Importer.Directory
+	} else {
+		pathname = path.Clean(pathname)
+	}
 
 	pvfs, err := snap.Filesystem()
 	if err != nil {


### PR DESCRIPTION
before:

```
$ plakar ls 2199
2024-07-16T17:11:30Z drwxr-xr-x     root     root   4.1 kB home
```

now:

```
$ plakar ls 2199
2024-11-28T10:22:58Z drwxr-xr-x       op    users   4.1 kB .direnv
2024-12-28T09:25:44Z -rw-r--r--       op    users      8 B .envrc
2024-11-12T15:11:27Z drwxr-xr-x       op    users   4.1 kB .github
2024-11-12T16:32:03Z -rw-r--r--       op    users     29 B .gitignore
2025-02-10T08:30:55Z drwxr-xr-x       op    users   4.1 kB .got
[...]
```