### PR TITLE
vfs: Export ResolveEntry()

### DIFF
--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -193,7 +193,7 @@ func (e *Entry) Getdents(fsc *Filesystem) (iter.Seq2[*Entry, error], error) {
 			if !isEntryBelow(prefix, path) {
 				break
 			}
-			if !yield(fsc.resolveEntry(csum)) {
+			if !yield(fsc.ResolveEntry(csum)) {
 				return
 			}
 		}
@@ -460,7 +460,7 @@ func (vf *vdir) ReadDir(n int) (entries []fs.DirEntry, err error) {
 		}
 		path, csum := vf.iter.Current()
 
-		dirent, err := vf.fs.resolveEntry(csum)
+		dirent, err := vf.fs.ResolveEntry(csum)
 		if err != nil {
 			return nil, err
 		}

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -105,10 +105,10 @@ func (fsc *Filesystem) lookup(entrypath string) (*Entry, error) {
 		return nil, fs.ErrNotExist
 	}
 
-	return fsc.resolveEntry(csum)
+	return fsc.ResolveEntry(csum)
 }
 
-func (fsc *Filesystem) resolveEntry(csum objects.Checksum) (*Entry, error) {
+func (fsc *Filesystem) ResolveEntry(csum objects.Checksum) (*Entry, error) {
 	rd, err := fsc.repo.GetBlob(resources.RT_VFS_ENTRY, csum)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func (fsc *Filesystem) Files() iter.Seq2[string, error] {
 
 		for iter.Next() {
 			path, csum := iter.Current()
-			entry, err := fsc.resolveEntry(csum)
+			entry, err := fsc.ResolveEntry(csum)
 			if err != nil {
 				if !yield(path, err) {
 					return


### PR DESCRIPTION
* This used to be private but now that we have a way of iterating over nodes (and as a result the checksum entries) it makes sense to have this public rather than coding it ad-hoc everywhere, especially since this does quite a bit of things.