### PR TITLE
vfs: add another btree for extended attributes

### DIFF
--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -379,18 +379,23 @@ func snapshotVFSErrors(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
+	fs, err := snap.Filesystem()
+	if err != nil {
+		return err
+	}
+
 	if path == "" {
 		path = "/"
 	}
 
-	errorList, err := snap.Errors(path)
+	errorList, err := fs.Errors(path)
 	if err != nil {
 		return err
 	}
 
 	var i int64
-	items := Items[*snapshot.ErrorItem]{
-		Items: []*snapshot.ErrorItem{},
+	items := Items[*vfs.ErrorItem]{
+		Items: []*vfs.ErrorItem{},
 	}
 	for errorEntry := range errorList {
 		if i < offset {

--- a/caching/scan.go
+++ b/caching/scan.go
@@ -95,6 +95,14 @@ func (c *ScanCache) GetFile(file string) ([]byte, error) {
 	return c.get("__file__", file)
 }
 
+func (c *ScanCache) PutXattr(xattr string, data []byte) error {
+	return c.put("__xattr__", xattr, data)
+}
+
+func (c *ScanCache) GetXattr(xattr string) ([]byte, error) {
+	return c.get("__xattr__", xattr)
+}
+
 func (c *ScanCache) PutDirectory(directory string, data []byte) error {
 	return c.put("__directory__", directory, data)
 }

--- a/cmd/plakar/subcommands/backup/backup.go
+++ b/cmd/plakar/subcommands/backup/backup.go
@@ -177,7 +177,7 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 	ctx.GetLogger().Info("created %s snapshot %x with root %s of size %s in %s",
 		"unsigned",
 		snap.Header.GetIndexShortID(),
-		base64.RawStdEncoding.EncodeToString(snap.Header.GetSource(0).VFS[:]),
+		base64.RawStdEncoding.EncodeToString(snap.Header.GetSource(0).VFS.Root[:]),
 		humanize.Bytes(snap.Header.GetSource(0).Summary.Directory.Size+snap.Header.GetSource(0).Summary.Below.Size),
 		snap.Header.Duration)
 	return 0, nil

--- a/cmd/plakar/subcommands/diag/errors.go
+++ b/cmd/plakar/subcommands/diag/errors.go
@@ -32,7 +32,12 @@ func (cmd *InfoErrors) Execute(ctx *appcontext.AppContext, repo *repository.Repo
 	}
 	defer snap.Close()
 
-	errstream, err := snap.Errors(pathname)
+	fs, err := snap.Filesystem()
+	if err != nil {
+		return 1, err
+	}
+
+	errstream, err := fs.Errors(pathname)
 	if err != nil {
 		return 1, err
 	}

--- a/cmd/plakar/subcommands/diag/vfs.go
+++ b/cmd/plakar/subcommands/diag/vfs.go
@@ -74,6 +74,7 @@ func (cmd *InfoVFS) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 	}
 	fmt.Fprintf(ctx.Stdout, "CustomMetadata: %s\n", entry.CustomMetadata)
 	fmt.Fprintf(ctx.Stdout, "Tags: %s\n", entry.Tags)
+	fmt.Fprintf(ctx.Stdout, "ExtendedAttributes: %v\n", entry.ExtendedAttributes)
 
 	if entry.Summary != nil {
 		fmt.Fprintf(ctx.Stdout, "Below.Directories: %d\n", entry.Summary.Below.Directories)
@@ -150,6 +151,7 @@ func (cmd *InfoVFS) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 		fmt.Fprintf(ctx.Stdout, "Child[%d].FileInfo.Username(): %s\n", offset, child.Stat().Username())
 		fmt.Fprintf(ctx.Stdout, "Child[%d].FileInfo.Groupname(): %s\n", offset, child.Stat().Groupname())
 		fmt.Fprintf(ctx.Stdout, "Child[%d].FileInfo.Nlink(): %d\n", offset, child.Stat().Nlink())
+		fmt.Fprintf(ctx.Stdout, "Child[%d].ExtendedAttributes(): %v\n", offset, child.ExtendedAttributes)
 		offset++
 	}
 

--- a/cmd/plakar/subcommands/diag/vfs.go
+++ b/cmd/plakar/subcommands/diag/vfs.go
@@ -155,7 +155,7 @@ func (cmd *InfoVFS) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 		offset++
 	}
 
-	errors, err := snap1.Errors(pathname)
+	errors, err := fs.Errors(pathname)
 	if err != nil {
 		return 1, err
 	}

--- a/cmd/plakar/subcommands/info/vfs.go
+++ b/cmd/plakar/subcommands/info/vfs.go
@@ -154,7 +154,7 @@ func (cmd *InfoVFS) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 		offset++
 	}
 
-	errors, err := snap1.Errors(pathname)
+	errors, err := fs.Errors(pathname)
 	if err != nil {
 		return 1, err
 	}

--- a/objects/fileinfo.go
+++ b/objects/fileinfo.go
@@ -29,8 +29,7 @@ type FileInfo struct {
 	Lusername  string      `json:"username" msgpack:"username"`   // local addition
 	Lgroupname string      `json:"groupname" msgpack:"groupname"` // local addition
 
-	// Windows specific fields
-	AlternateDataStream bool `json:"alternate_data_stream" msgpack:"alternate_data_stream"`
+	ExtendedAttribute bool `json:"extended_attribute" msgpack:"extended_attribute"`
 }
 
 func (f FileInfo) Name() string {

--- a/objects/fileinfo_windows.go
+++ b/objects/fileinfo_windows.go
@@ -25,8 +25,7 @@ type FileInfo struct {
 	Lusername  string      `json:"username" msgpack:"username"`
 	Lgroupname string      `json:"groupname" msgpack:"groupname"`
 
-	// Windows specific fields
-	AlternateDataStream bool `json:"alternate_data_stream" msgpack:"alternate_data_stream"`
+	ExtendedAttribute bool `json:"extended_attribute" msgpack:"extended_attribute"`
 }
 
 func (f FileInfo) Name() string {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -15,7 +15,9 @@ const (
 	RT_VFS_ENTRY   Type = 11
 	RT_ERROR_BTREE Type = 12
 	RT_ERROR_ENTRY Type = 13
-	RT_BTREE       Type = 14
+	RT_XATTR_BTREE Type = 14
+	RT_XATTR_ENTRY Type = 15
+	RT_BTREE       Type = 16
 )
 
 func Types() []Type {
@@ -32,6 +34,8 @@ func Types() []Type {
 		RT_VFS_ENTRY,
 		RT_ERROR_BTREE,
 		RT_ERROR_ENTRY,
+		RT_XATTR_BTREE,
+		RT_XATTR_ENTRY,
 		RT_BTREE,
 	}
 }
@@ -62,6 +66,10 @@ func (r Type) String() string {
 		return "error btree"
 	case RT_ERROR_ENTRY:
 		return "error entry"
+	case RT_XATTR_BTREE:
+		return "xattr btree"
+	case RT_XATTR_ENTRY:
+		return "xattr entry"
 	case RT_BTREE:
 		return "btree"
 	default:

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -74,7 +74,7 @@ func (bc *BackupContext) recordError(path string, err error) error {
 	return e
 }
 
-func (bc *BackupContext) recordXattr(record importer.ScanRecord, object objects.Checksum) error {
+func (bc *BackupContext) recordXattr(record importer.ScanRecord, object *objects.Object) error {
 	bc.muxattridx.Lock()
 	err := bc.xattridx.Insert(record.Pathname, vfs.NewXattr(record, object))
 	bc.muxattridx.Unlock()
@@ -353,7 +353,7 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 
 			// xattrs are a special case
 			if record.FileInfo.ExtendedAttribute {
-				backupCtx.recordXattr(record, object.MAC)
+				backupCtx.recordXattr(record, object)
 				return
 			}
 

--- a/snapshot/filesystem.go
+++ b/snapshot/filesystem.go
@@ -9,7 +9,7 @@ func (s *Snapshot) Filesystem() (*vfs.Filesystem, error) {
 
 	if s.filesystem != nil {
 		return s.filesystem, nil
-	} else if fs, err := vfs.NewFilesystem(s.repository, v.Root, v.Xattrs); err != nil {
+	} else if fs, err := vfs.NewFilesystem(s.repository, v.Root, v.Xattrs, v.Errors); err != nil {
 		return nil, err
 	} else {
 		s.filesystem = fs

--- a/snapshot/filesystem.go
+++ b/snapshot/filesystem.go
@@ -5,9 +5,11 @@ import (
 )
 
 func (s *Snapshot) Filesystem() (*vfs.Filesystem, error) {
+	v := s.Header.GetSource(0).VFS
+
 	if s.filesystem != nil {
 		return s.filesystem, nil
-	} else if fs, err := vfs.NewFilesystem(s.repository, s.Header.GetSource(0).VFS); err != nil {
+	} else if fs, err := vfs.NewFilesystem(s.repository, v.Root, v.Xattrs); err != nil {
 		return nil, err
 	} else {
 		s.filesystem = fs

--- a/snapshot/header/header.go
+++ b/snapshot/header/header.go
@@ -53,9 +53,14 @@ type Index struct {
 	Value objects.Checksum `msgpack:"value" json:"value"`
 }
 
+type VFS struct {
+	Root   objects.Checksum `msgpack:"root" json:"root"`
+	Xattrs objects.Checksum `msgpack:"xattrs" json:"xattrs"`
+}
+
 type Source struct {
 	Importer Importer         `msgpack:"importer" json:"importer"`
-	VFS      objects.Checksum `msgpack:"root" json:"root"`
+	VFS      VFS `msgpack:"root" json:"root"`
 	Errors   objects.Checksum `msgpack:"errors" json:"errors"`
 	Indexes  []Index          `msgpack:"indexes" json:"indexes"`
 	Summary  vfs.Summary      `msgpack:"summary" json:"summary"`
@@ -64,7 +69,7 @@ type Source struct {
 func NewSource() Source {
 	return Source{
 		Importer: Importer{},
-		VFS:      objects.Checksum{},
+		VFS:      VFS{},
 		Errors:   objects.Checksum{},
 		Indexes:  []Index{},
 		Summary:  vfs.Summary{},

--- a/snapshot/header/header.go
+++ b/snapshot/header/header.go
@@ -56,21 +56,20 @@ type Index struct {
 type VFS struct {
 	Root   objects.Checksum `msgpack:"root" json:"root"`
 	Xattrs objects.Checksum `msgpack:"xattrs" json:"xattrs"`
+	Errors objects.Checksum `msgpack:"errors" json:"errors"`
 }
 
 type Source struct {
-	Importer Importer         `msgpack:"importer" json:"importer"`
-	VFS      VFS `msgpack:"root" json:"root"`
-	Errors   objects.Checksum `msgpack:"errors" json:"errors"`
-	Indexes  []Index          `msgpack:"indexes" json:"indexes"`
-	Summary  vfs.Summary      `msgpack:"summary" json:"summary"`
+	Importer Importer    `msgpack:"importer" json:"importer"`
+	VFS      VFS         `msgpack:"root" json:"root"`
+	Indexes  []Index     `msgpack:"indexes" json:"indexes"`
+	Summary  vfs.Summary `msgpack:"summary" json:"summary"`
 }
 
 func NewSource() Source {
 	return Source{
 		Importer: Importer{},
 		VFS:      VFS{},
-		Errors:   objects.Checksum{},
 		Indexes:  []Index{},
 		Summary:  vfs.Summary{},
 	}

--- a/snapshot/importer/fs/walkdir_windows.go
+++ b/snapshot/importer/fs/walkdir_windows.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/snapshot/importer"
+	"github.com/pkg/xattr"
 )
 
 func toUnixPath(pathname string) string {
@@ -66,7 +67,7 @@ func walkDir_worker(jobs <-chan string, results chan<- importer.ScanResult, wg *
 			}
 		}
 
-		extendedAttributes, err := getExtendedAttributes(pathname)
+		extendedAttributes, err := xattr.List(pathname)
 		if err != nil {
 			results <- importer.ScanError{Pathname: unixPath, Err: err}
 			continue

--- a/snapshot/importer/fs/xattr.go
+++ b/snapshot/importer/fs/xattr.go
@@ -19,11 +19,13 @@ package fs
 import (
 	"os"
 
+	"github.com/PlakarKorp/plakar/snapshot/importer"
 	"github.com/pkg/xattr"
 )
 
-func getExtendedAttributes(path string) (map[string][]byte, error) {
-	attrs := make(map[string][]byte)
+func getExtendedAttributes(path string) ([]importer.ExtendedAttributes, error) {
+
+	attrs := make([]importer.ExtendedAttributes, 0)
 
 	// Get the list of attribute names
 	attributes, err := xattr.List(path)
@@ -41,7 +43,7 @@ func getExtendedAttributes(path string) (map[string][]byte, error) {
 			}
 			return nil, err
 		}
-		attrs[attr] = value
+		attrs = append(attrs, importer.ExtendedAttributes{Name: attr, Value: value})
 	}
 
 	return attrs, nil

--- a/snapshot/importer/ftp/ftp.go
+++ b/snapshot/importer/ftp/ftp.go
@@ -189,6 +189,14 @@ func (p *FTPImporter) NewReader(pathname string) (io.ReadCloser, error) {
 	return tmpfile, nil
 }
 
+func (p *FTPImporter) NewExtendedAttributeReader(pathname string, attribute string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("extended attributes are not supported on FTP")
+}
+
+func (p *FTPImporter) GetExtendedAttributes(pathname string) ([]importer.ExtendedAttributes, error) {
+	return nil, fmt.Errorf("extended attributes are not supported on FTP")
+}
+
 func (p *FTPImporter) Close() error {
 	if p.client != nil {
 		return p.client.Close()

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -32,11 +32,16 @@ type ScanResult interface {
 	scanResult()
 }
 
+type ExtendedAttributes struct {
+	Name  string
+	Value []byte
+}
+
 type ScanRecord struct {
 	Pathname           string
 	Target             string
 	FileInfo           objects.FileInfo
-	ExtendedAttributes map[string][]byte
+	ExtendedAttributes []string
 	FileAttributes     uint32
 }
 
@@ -58,6 +63,8 @@ type Importer interface {
 	Root() string
 	Scan() (<-chan ScanResult, error)
 	NewReader(string) (io.ReadCloser, error)
+	NewExtendedAttributeReader(string, string) (io.ReadCloser, error)
+	GetExtendedAttributes(string) ([]ExtendedAttributes, error)
 	Close() error
 }
 

--- a/snapshot/importer/s3/s3.go
+++ b/snapshot/importer/s3/s3.go
@@ -154,6 +154,14 @@ func (p *S3Importer) NewReader(pathname string) (io.ReadCloser, error) {
 	return obj, nil
 }
 
+func (p *S3Importer) NewExtendedAttributeReader(pathname string, attribute string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("extended attributes are not supported on S3")
+}
+
+func (p *S3Importer) GetExtendedAttributes(pathname string) ([]importer.ExtendedAttributes, error) {
+	return nil, fmt.Errorf("extended attributes are not supported on S3")
+}
+
 func (p *S3Importer) Close() error {
 	return nil
 }

--- a/snapshot/reader.go
+++ b/snapshot/reader.go
@@ -5,8 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path"
-
-	"github.com/PlakarKorp/plakar/snapshot/vfs"
 )
 
 func (snapshot *Snapshot) NewReader(pathname string) (io.ReadCloser, error) {
@@ -16,7 +14,7 @@ func (snapshot *Snapshot) NewReader(pathname string) (io.ReadCloser, error) {
 func NewReader(snap *Snapshot, pathname string) (io.ReadCloser, error) {
 	pathname = path.Clean(pathname)
 
-	fsc, err := vfs.NewFilesystem(snap.Repository(), snap.Header.GetSource(0).VFS)
+	fsc, err := snap.Filesystem()
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -49,7 +49,7 @@ type Entry struct {
 	FileAttributes       uint32   `msgpack:"file_attributes,omitempty" json:"file_attributes"`
 
 	/* Unix fields */
-	ExtendedAttributes []ExtendedAttribute `msgpack:"extended_attributes,omitempty" json:"extended_attributes"`
+	ExtendedAttributes []string `msgpack:"extended_attributes,omitempty" json:"extended_attributes"`
 
 	/* Custom metadata and tags */
 	Classifications []Classification `msgpack:"classifications,omitempty" json:"classifications"`
@@ -75,7 +75,7 @@ func (e *Entry) MarshalJSON() ([]byte, error) {
 		ret.SecurityDescriptor = []byte{}
 	}
 	if ret.ExtendedAttributes == nil {
-		ret.ExtendedAttributes = []ExtendedAttribute{}
+		ret.ExtendedAttributes = []string{}
 	}
 	if ret.Classifications == nil {
 		ret.Classifications = []Classification{}
@@ -96,16 +96,9 @@ func NewEntry(parentPath string, record *importer.ScanRecord) *Entry {
 		target = record.Target
 	}
 
-	ExtendedAttributes := make([]ExtendedAttribute, 0, len(record.ExtendedAttributes))
-	for name, value := range record.ExtendedAttributes {
-		ExtendedAttributes = append(ExtendedAttributes, ExtendedAttribute{
-			Name:  name,
-			Value: value,
-		})
-	}
-
+	ExtendedAttributes := record.ExtendedAttributes
 	sort.Slice(ExtendedAttributes, func(i, j int) bool {
-		return ExtendedAttributes[i].Name < ExtendedAttributes[j].Name
+		return ExtendedAttributes[i] < ExtendedAttributes[j]
 	})
 
 	entry := &Entry{

--- a/snapshot/vfs/reader.go
+++ b/snapshot/vfs/reader.go
@@ -1,0 +1,140 @@
+package vfs
+
+import (
+	"errors"
+	"io"
+
+	"github.com/PlakarKorp/plakar/objects"
+	"github.com/PlakarKorp/plakar/repository"
+	"github.com/PlakarKorp/plakar/resources"
+)
+
+type ObjectReader struct {
+	object *objects.Object
+	repo   *repository.Repository
+	size   int64
+
+	objoff int
+	off    int64
+	rd     io.ReadSeeker
+}
+
+func NewObjectReader(repo *repository.Repository, object *objects.Object, size int64) *ObjectReader {
+	return &ObjectReader{
+		object: object,
+		repo:   repo,
+		size:   0,
+	}
+}
+
+func (or *ObjectReader) Read(p []byte) (int, error) {
+	for or.objoff < len(or.object.Chunks) {
+		if or.rd == nil {
+			rd, err := or.repo.GetBlob(resources.RT_CHUNK,
+				or.object.Chunks[or.objoff].MAC)
+			if err != nil {
+				return -1, err
+			}
+			or.rd = rd
+		}
+
+		n, err := or.rd.Read(p)
+		if errors.Is(err, io.EOF) {
+			or.objoff++
+			or.rd = nil
+			continue
+		}
+		or.off += int64(n)
+		return n, err
+	}
+
+	return 0, io.EOF
+}
+
+func (or *ObjectReader) Seek(offset int64, whence int) (int64, error) {
+	chunks := or.object.Chunks
+
+	switch whence {
+	case io.SeekStart:
+		or.rd = nil
+		or.off = 0
+		for or.objoff = 0; or.objoff < len(chunks); or.objoff++ {
+			clen := int64(chunks[or.objoff].Length)
+			if offset > clen {
+				or.off += clen
+				offset -= clen
+				continue
+			}
+			or.off += offset
+			rd, err := or.repo.GetBlob(resources.RT_CHUNK,
+				chunks[or.objoff].MAC)
+			if err != nil {
+				return 0, err
+			}
+			if _, err := rd.Seek(offset, whence); err != nil {
+				return 0, err
+			}
+			or.rd = rd
+			break
+		}
+
+	case io.SeekEnd:
+		or.rd = nil
+		or.off = or.size
+		for or.objoff = len(chunks) - 1; or.objoff >= 0; or.objoff-- {
+			clen := int64(chunks[or.objoff].Length)
+			if offset > clen {
+				or.off -= clen
+				offset -= clen
+				continue
+			}
+			or.off -= offset
+			rd, err := or.repo.GetBlob(resources.RT_CHUNK,
+				chunks[or.objoff].MAC)
+			if err != nil {
+				return 0, err
+			}
+			if _, err := rd.Seek(offset, whence); err != nil {
+				return 0, err
+			}
+			or.rd = rd
+			break
+		}
+
+	case io.SeekCurrent:
+		if or.rd != nil {
+			n, err := or.rd.Seek(offset, whence)
+			if err != nil {
+				return 0, err
+			}
+			diff := n - or.off
+			or.off += diff
+			offset -= diff
+		}
+
+		if offset == 0 {
+			break
+		}
+
+		or.objoff++
+		for or.objoff < len(chunks) {
+			clen := int64(chunks[or.objoff].Length)
+			if offset > clen {
+				or.off += clen
+				offset -= clen
+			}
+			or.off += offset
+			rd, err := or.repo.GetBlob(resources.RT_CHUNK,
+				chunks[or.objoff].MAC)
+			if err != nil {
+				return 0, err
+			}
+			if _, err := rd.Seek(offset, whence); err != nil {
+				return 0, err
+			}
+			or.rd = rd
+		}
+	}
+
+	return or.off, nil
+}

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -239,7 +239,7 @@ func (fsc *Filesystem) GetEntry(path string) (*Entry, error) {
 	return fsc.lookup(path)
 }
 
-func (fsc *Filesystem) Xattr(entry *Entry, xattrName string) (*Xattr, error) {
+func (fsc *Filesystem) Xattr(entry *Entry, xattrName string) (io.ReadSeeker, error) {
 	p := fmt.Sprintf("%s:%s", entry.Path(), xattrName)
 	csum, found, err := fsc.xattrs.Find(p)
 	if err != nil {
@@ -275,7 +275,11 @@ func (fsc *Filesystem) Xattr(entry *Entry, xattrName string) (*Xattr, error) {
 	}
 
 	xattr.ResolvedObject, err = objects.NewObjectFromBytes(bytes)
-	return xattr, err
+	if err != nil {
+		return nil, err
+	}
+
+	return NewObjectReader(fsc.repo, xattr.ResolvedObject, xattr.Size), nil
 }
 
 func (fsc *Filesystem) Children(path string) (iter.Seq2[string, error], error) {

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -1,7 +1,6 @@
 package vfs
 
 import (
-	"fmt"
 	"io"
 	"io/fs"
 	"iter"
@@ -237,49 +236,6 @@ func (fsc *Filesystem) Pathnames() iter.Seq2[string, error] {
 
 func (fsc *Filesystem) GetEntry(path string) (*Entry, error) {
 	return fsc.lookup(path)
-}
-
-func (fsc *Filesystem) Xattr(entry *Entry, xattrName string) (io.ReadSeeker, error) {
-	p := fmt.Sprintf("%s:%s", entry.Path(), xattrName)
-	csum, found, err := fsc.xattrs.Find(p)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, fs.ErrNotExist
-	}
-
-	rd, err := fsc.repo.GetBlob(resources.RT_XATTR_ENTRY, csum)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := io.ReadAll(rd)
-	if err != nil {
-		return nil, err
-	}
-
-	xattr, err := XattrFromBytes(bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	rd, err = fsc.repo.GetBlob(resources.RT_OBJECT, xattr.Object)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes, err = io.ReadAll(rd)
-	if err != nil {
-		return nil, err
-	}
-
-	xattr.ResolvedObject, err = objects.NewObjectFromBytes(bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewObjectReader(fsc.repo, xattr.ResolvedObject, xattr.Size), nil
 }
 
 func (fsc *Filesystem) Children(path string) (iter.Seq2[string, error], error) {

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -87,7 +87,7 @@ func NewFilesystem(repo *repository.Repository, root, xattrs objects.Checksum) (
 	}
 
 	xstore := repository.NewRepositoryStore[string, objects.Checksum](repo, resources.RT_XATTR_BTREE)
-	xtree, err := btree.Deserialize(rd, xstore, PathCmp)
+	xtree, err := btree.Deserialize(rd, xstore, strings.Compare)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/vfs/xattr.go
+++ b/snapshot/vfs/xattr.go
@@ -19,6 +19,7 @@ func init() {
 type Xattr struct {
 	Version versioning.Version `msgpack:"version" json:"version"`
 	Name    string             `msgpack:"name" json:"name"`
+	Size    int64              `msgpack:"size" json:"size"`
 	Object  objects.Checksum   `msgpack:"object,omitempty" json:"-"`
 
 	// This the true object, resolved when opening the
@@ -27,11 +28,18 @@ type Xattr struct {
 	ResolvedObject *objects.Object `msgpack:"-" json:"object,omitempty"`
 }
 
-func NewXattr(record importer.ScanRecord, object objects.Checksum) *Xattr {
+func NewXattr(record importer.ScanRecord, object *objects.Object) *Xattr {
+	var size int64
+
+	for _, chunk := range object.Chunks {
+		size += int64(chunk.Length)
+	}
+
 	return &Xattr{
 		Version: versioning.FromString(VFS_XATTR_VERSION),
-		Name: record.FileInfo.Lname,
-		Object: object,
+		Name:    record.FileInfo.Lname,
+		Object:  object.MAC,
+		Size:    size,
 	}
 }
 

--- a/snapshot/vfs/xattr.go
+++ b/snapshot/vfs/xattr.go
@@ -1,0 +1,46 @@
+package vfs
+
+import (
+	"github.com/PlakarKorp/plakar/btree"
+	"github.com/PlakarKorp/plakar/objects"
+	"github.com/PlakarKorp/plakar/resources"
+	"github.com/PlakarKorp/plakar/snapshot/importer"
+	"github.com/PlakarKorp/plakar/versioning"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+const VFS_XATTR_VERSION = "1.0.0"
+
+func init() {
+	versioning.Register(resources.RT_XATTR_BTREE, versioning.FromString(btree.BTREE_VERSION))
+	versioning.Register(resources.RT_XATTR_ENTRY, versioning.FromString(VFS_XATTR_VERSION))
+}
+
+type Xattr struct {
+	Version versioning.Version `msgpack:"version" json:"version"`
+	Name    string             `msgpack:"name" json:"name"`
+	Object  objects.Checksum   `msgpack:"object,omitempty" json:"-"`
+
+	// This the true object, resolved when opening the
+	// xattr. Beware we serialize it as "Object" only for json to
+	// not break API compat.
+	ResolvedObject *objects.Object `msgpack:"-" json:"object,omitempty"`
+}
+
+func NewXattr(record importer.ScanRecord, object objects.Checksum) *Xattr {
+	return &Xattr{
+		Version: versioning.FromString(VFS_XATTR_VERSION),
+		Name: record.FileInfo.Lname,
+		Object: object,
+	}
+}
+
+func XattrFromBytes(bytes []byte) (*Xattr, error) {
+	xattr := &Xattr{}
+	err := msgpack.Unmarshal(bytes, &xattr)
+	return xattr, err
+}
+
+func (x *Xattr) ToBytes() ([]byte, error) {
+	return msgpack.Marshal(x)
+}

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -35,7 +35,7 @@ var behaviors = map[string]mockedBackendBehavior{
 	},
 	"oneState": {
 		statesChecksums:    []objects.Checksum{{0x01}, {0x02}, {0x03}, {0x04}},
-		header:             header.Header{Timestamp: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Identifier: [32]byte{0x1}, Sources: []header.Source{{VFS: objects.Checksum{0x01}}}},
+		header:             header.Header{Timestamp: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Identifier: [32]byte{0x1}, Sources: []header.Source{{VFS: header.VFS{Root: objects.Checksum{0x01}}}}},
 		packfilesChecksums: []objects.Checksum{{0x04}, {0x05}, {0x06}},
 	},
 	"oneSnapshot": {


### PR DESCRIPTION
Since these can be varying in size (on darwin for example), we're tracking their content in an object like it were a file itself but to avoid cluttering the "real" VFS, we're keeping these entries in their own tree which the VFS package take care of.

The interface to handle xattrs will be improved in subsequent commits.
