### PR TITLE
switch to AES256-GCM-SIV

### DIFF
--- a/cmd/plakar/subcommands/info/repository.go
+++ b/cmd/plakar/subcommands/info/repository.go
@@ -54,8 +54,9 @@ func (cmd *InfoRepository) Execute(ctx *appcontext.AppContext, repo *repository.
 
 	if repo.Configuration().Encryption != nil {
 		fmt.Fprintln(ctx.Stdout, "Encryption:")
-		fmt.Fprintln(ctx.Stdout, " - Data Algorithm:", repo.Configuration().Encryption.DataAlgorithm)
-		fmt.Fprintln(ctx.Stdout, " - Subkey Algorithm:", repo.Configuration().Encryption.SubKeyAlgorithm)
+		fmt.Fprintln(ctx.Stdout, " - SubkeyAlgorithm:", repo.Configuration().Encryption.SubKeyAlgorithm)
+		fmt.Fprintln(ctx.Stdout, " - DataAlgorithm:", repo.Configuration().Encryption.DataAlgorithm)
+		fmt.Fprintln(ctx.Stdout, " - ChunkSize:", repo.Configuration().Encryption.ChunkSize)
 		fmt.Fprintf(ctx.Stdout, " - Canary: %x\n", repo.Configuration().Encryption.Canary)
 		fmt.Fprintln(ctx.Stdout, " - KDF:", repo.Configuration().Encryption.KDFParams.KDF)
 		fmt.Fprintf(ctx.Stdout, "   - Salt: %x\n", repo.Configuration().Encryption.KDFParams.Salt)

--- a/encryption/symmetric.go
+++ b/encryption/symmetric.go
@@ -10,8 +10,9 @@ import (
 	"io"
 	"runtime"
 
+	subtle "github.com/tink-crypto/tink-go/v2/aead/subtle"
+
 	"github.com/PlakarKorp/plakar/hashing"
-	"github.com/google/tink/go/aead/subtle"
 	aeskw "github.com/nickball/go-aes-key-wrap"
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/pbkdf2"

--- a/encryption/symmetric.go
+++ b/encryption/symmetric.go
@@ -25,8 +25,9 @@ const (
 )
 
 type Configuration struct {
-	DataAlgorithm   string
 	SubKeyAlgorithm string
+	DataAlgorithm   string
+	ChunkSize       int
 	KDFParams       KDFParams
 	Canary          []byte
 }
@@ -116,8 +117,9 @@ func NewDefaultConfiguration() *Configuration {
 	}
 
 	return &Configuration{
-		DataAlgorithm:   "AES256-GCM-SIV",
 		SubKeyAlgorithm: "AES256-KW",
+		DataAlgorithm:   "AES256-GCM-SIV",
+		ChunkSize:       chunkSize,
 		KDFParams:       *kdfParams,
 	}
 }
@@ -292,7 +294,7 @@ func EncryptStream(config *Configuration, key []byte, r io.Reader) (io.Reader, e
 		}
 
 		// Encrypt and write data chunks
-		chunk := make([]byte, chunkSize)
+		chunk := make([]byte, config.ChunkSize)
 		for {
 			// Use ReadFull to read exactly chunkSize or less at EOF
 			n, err := io.ReadFull(r, chunk)
@@ -346,7 +348,7 @@ func DecryptStream(config *Configuration, key []byte, r io.Reader) (io.Reader, e
 	go func() {
 		defer pw.Close()
 
-		buffer := make([]byte, chunkSize+AESGMSIV_OVERHEAD)
+		buffer := make([]byte, config.ChunkSize+AESGMSIV_OVERHEAD)
 		for {
 			n, err := r.Read(buffer)
 			if err != nil {

--- a/encryption/symmetric.go
+++ b/encryption/symmetric.go
@@ -10,10 +10,9 @@ import (
 	"io"
 	"runtime"
 
-	"github.com/tink-crypto/tink-go/v2/aead/subtle"
-
 	"github.com/PlakarKorp/plakar/hashing"
 	aeskw "github.com/nickball/go-aes-key-wrap"
+	"github.com/tink-crypto/tink-go/v2/aead/subtle"
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/crypto/scrypt"

--- a/encryption/symmetric.go
+++ b/encryption/symmetric.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"runtime"
 
-	subtle "github.com/tink-crypto/tink-go/v2/aead/subtle"
+	"github.com/tink-crypto/tink-go/v2/aead/subtle"
 
 	"github.com/PlakarKorp/plakar/hashing"
 	aeskw "github.com/nickball/go-aes-key-wrap"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.1
-	github.com/google/tink/go v1.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20250106100439-5c39aecd6999
@@ -29,6 +28,7 @@ require (
 	github.com/secsy/goftp v0.0.0-20200609142545-aa2de14babf4
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.0
+	github.com/tink-crypto/tink-go/v2 v2.3.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	github.com/wagslane/go-password-validator v0.3.0
 	github.com/whilp/git-urls v1.0.0
@@ -93,7 +93,7 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
+	google.golang.org/protobuf v1.36.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/tink/go v1.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20250106100439-5c39aecd6999

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlGkMFWCjLFlqqEZjEmObmhUy6Vo=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
+github.com/google/tink/go v1.7.0 h1:6Eox8zONGebBFcCBqkVmt60LaWZa6xg1cl/DwAh/J1w=
+github.com/google/tink/go v1.7.0/go.mod h1:GAUOd+QE3pgj9q8VKIGTCP33c/B7eb4NhxLcgTJZStM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlGkMFWCjLFlqqEZjEmObmhUy6Vo=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
-github.com/google/tink/go v1.7.0 h1:6Eox8zONGebBFcCBqkVmt60LaWZa6xg1cl/DwAh/J1w=
-github.com/google/tink/go v1.7.0/go.mod h1:GAUOd+QE3pgj9q8VKIGTCP33c/B7eb4NhxLcgTJZStM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
@@ -212,6 +210,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/tink-crypto/tink-go/v2 v2.3.0 h1:4/TA0lw0lA/iVKBL9f8R5eP7397bfc4antAMXF5JRhs=
+github.com/tink-crypto/tink-go/v2 v2.3.0/go.mod h1:kfPOtXIadHlekBTeBtJrHWqoGL+Fm3JQg0wtltPuxLU=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
@@ -321,8 +321,8 @@ golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
-google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+google.golang.org/protobuf v1.36.0 h1:mjIs9gYtt56AzC4ZaffQuh88TZurBGhIJMBZGSxNerQ=
+google.golang.org/protobuf v1.36.0/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Following crypto audit, it was suggested as an improvement to switch to AES256-GCM-SIV:


**We recommend switching to AES-GCM-SIV for chunk encryption.**

AES-GCM-SIV is a mode defined in [RFC 8452](https://www.rfc-editor.org/rfc/rfc8452.html) that does not rely on
randomness. It produces the nonce by computing a PRF over the message to
encrypt. It implies that encrypting the same message twice will produce
the same ciphertext. However, if each subkey encrypts a single chunk,
this is not an issue.

AES-GCM-SIV also prevents streaming of the data hashed, therefore the
whole chunk has to be stored in memory. Since data is already chunked to
be streamed, and chunks are of fixed, small size (64 KB), this is not an
issue.

That said, AES-GCM-SIV has less adoption than AES-GCM, and is not as
standardized as AES-GCM. AES-GCM is fine security-wise, switching to the
SIV mode would just eliminate one risk related to randomness. Depending
on the business requirements and client needs, AES-GCM may be preferable
(for example, if a FIPS standard is needed).

The most reliable implementation of AES-GCM-SIV is in [Google's Tink
package](https://pkg.go.dev/github.com/google/tink/go@v1.7.0/aead/subtle#AESGCMSIV).

Note that the Go language maintainers are planning to [add AES-GCM-SIV to x/crypto](https://github.com/golang/go/issues/54364#issuecomment-2460514455).
