### PR TITLE
simplify repository constructor so we don't store the key twice,

### DIFF
--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -333,7 +333,7 @@ func _TestSnapshotPathParam(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			req, err := http.NewRequest("GET", "/path/{id}", nil)

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -46,7 +46,7 @@ func _Test_RepositoryConfiguration(t *testing.T) {
 	defer cache.Close()
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+	repo, err := repository.New(ctx, lstore, wrappedConfig)
 	require.NoError(t, err, "creating repository")
 
 	var noToken string
@@ -325,7 +325,7 @@ func _Test_RepositorySnapshots(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -424,7 +424,7 @@ func _Test_RepositorySnapshotsErrors(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -498,7 +498,7 @@ func _Test_RepositoryStates(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -566,7 +566,7 @@ func _Test_RepositoryState(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -639,7 +639,7 @@ func Test_RepositoryStateErrors(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -699,7 +699,7 @@ func _Test_RepositoryPackfiles(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -764,7 +764,7 @@ func _Test_RepositoryPackfilesErrors(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -820,7 +820,7 @@ func _Test_RepositoryPackfile(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -921,7 +921,7 @@ func Test_RepositoryPackfileErrors(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -152,7 +152,7 @@ func _TestSnapshotHeader(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -225,7 +225,7 @@ func TestSnapshotHeaderErrors(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -283,7 +283,7 @@ func _TestSnapshotSign(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			token := "test-token"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -51,7 +51,7 @@ func TestAuthMiddleware(t *testing.T) {
 	defer cache.Close()
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+	repo, err := repository.New(ctx, lstore, wrappedConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func Test_UnknownEndpoint(t *testing.T) {
 	defer cache.Close()
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	repo, err := repository.New(ctx, lstore, wrappedConfig, nil)
+	repo, err := repository.New(ctx, lstore, wrappedConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -336,13 +336,13 @@ func entryPoint() int {
 
 	var repo *repository.Repository
 	if opt_agentless && command != "server" {
-		repo, err = repository.New(ctx, store, serializedConfig, secret)
+		repo, err = repository.New(ctx, store, serializedConfig)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 			return 1
 		}
 	} else {
-		repo, err = repository.NewNoRebuild(ctx, store, serializedConfig, secret)
+		repo, err = repository.NewNoRebuild(ctx, store, serializedConfig)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 			return 1

--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -540,7 +540,7 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 				}
 				defer store.Close()
 
-				repo, err = repository.New(clientContext, store, serializedConfig, clientContext.GetSecret())
+				repo, err = repository.New(clientContext, store, serializedConfig)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to open repository: %s\n", err)
 					return

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -117,7 +117,10 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 			break
 		}
 	}
-	peerRepository, err := repository.New(ctx, peerStore, peerStoreSerializedConfig, peerSecret)
+
+	peerCtx := appcontext.NewAppContextFrom(ctx)
+	peerCtx.SetSecret(peerSecret)
+	peerRepository, err := repository.New(peerCtx, peerStore, peerStoreSerializedConfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: could not open repository: %s\n", peerStore.Location(), err)
 		return 1, err

--- a/server/plakard/server.go
+++ b/server/plakard/server.go
@@ -90,7 +90,7 @@ func handleConnection(ctx *appcontext.AppContext, repo *repository.Repository, r
 				if err != nil {
 					retErr = err.Error()
 				} else {
-					lrepository, err = repository.New(ctx, st, request.Payload.(network.ReqCreate).Configuration, nil)
+					lrepository, err = repository.New(ctx, st, request.Payload.(network.ReqCreate).Configuration)
 					if err != nil {
 						retErr = err.Error()
 					}
@@ -120,7 +120,7 @@ func handleConnection(ctx *appcontext.AppContext, repo *repository.Repository, r
 				if err != nil {
 					retErr = err.Error()
 				} else {
-					lrepository, err = repository.New(ctx, st, serializedConfig, nil)
+					lrepository, err = repository.New(ctx, st, serializedConfig)
 					if err != nil {
 						retErr = err.Error()
 					}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -74,7 +74,7 @@ func generateSnapshot(t *testing.T, keyPair *keypair.KeyPair) *Snapshot {
 	logger := logging.NewLogger(os.Stdout, os.Stderr)
 	logger.EnableTrace("all")
 	ctx.SetLogger(logger)
-	repo, err := repository.New(ctx, r, serializedConfig, nil)
+	repo, err := repository.New(ctx, r, serializedConfig)
 	require.NoError(t, err, "creating repository")
 
 	// create a snapshot


### PR DESCRIPTION
once in the appcontext and once in the repository