### PR TITLE
add flags to packfiles and packfiles blob indexes, we spotted a case

### DIFF
--- a/cmd/plakar/subcommands/diag/packfile.go
+++ b/cmd/plakar/subcommands/diag/packfile.go
@@ -107,7 +107,7 @@ func (cmd *InfoPackfile) Execute(ctx *appcontext.AppContext, repo *repository.Re
 			fmt.Fprintln(ctx.Stdout)
 
 			for i, entry := range p.Index {
-				fmt.Fprintf(ctx.Stdout, "blob[%d]: %x %d %d %s\n", i, entry.MAC, entry.Offset, entry.Length, entry.Type)
+				fmt.Fprintf(ctx.Stdout, "blob[%d]: %x %d %d %x %s\n", i, entry.MAC, entry.Offset, entry.Length, entry.Flags, entry.Type)
 			}
 		}
 	}

--- a/packfile/packfile_test.go
+++ b/packfile/packfile_test.go
@@ -24,8 +24,8 @@ func TestPackFile(t *testing.T) {
 	mac2 := [32]byte{2} // Mock mac for chunk2
 
 	// Test AddBlob
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1)
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1, 0)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2, 0)
 
 	// Test GetBlob
 	retrievedChunk1, exists := p.GetBlob(mac1)
@@ -63,8 +63,8 @@ func TestPackFileSerialization(t *testing.T) {
 	mac2 := [32]byte{2} // Mock mac for chunk2
 
 	// Test AddBlob
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1)
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1, 0)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2, 0)
 
 	// Test Serialize and NewFromBytes
 	serialized, err := p.Serialize()
@@ -115,8 +115,8 @@ func TestPackFileSerializeIndex(t *testing.T) {
 	mac2 := objects.MAC{2} // Mock mac for chunk2
 
 	// Test AddBlob
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1)
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1, 0)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2, 0)
 
 	// Test packfile Size
 	require.Equal(t, p.Size(), uint32(44), "Expected 2 blobs but got %q", p.Size())
@@ -157,8 +157,8 @@ func TestPackFileSerializeFooter(t *testing.T) {
 	mac2 := [32]byte{2} // Mock mac for chunk2
 
 	// Test AddBlob
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1)
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1, 0)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2, 0)
 
 	// Test Serialize and NewFromBytes
 	serialized, err := p.SerializeFooter()
@@ -183,8 +183,8 @@ func TestPackFileSerializeData(t *testing.T) {
 	mac2 := [32]byte{2} // Mock mac for chunk2
 
 	// Test AddBlob
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1)
-	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac1, chunk1, 0)
+	p.AddBlob(resources.RT_CHUNK, versioning.GetCurrentVersion(resources.RT_CHUNK), mac2, chunk2, 0)
 
 	// Test SerializeData
 	serialized, err := p.SerializeData()


### PR DESCRIPTION
where it would help us in the future: being able to know pre-deserialization
that a blob has to be handled in a specific way.