### PR TITLE
add context to importers for future uses of remote importers

### DIFF
--- a/snapshot/header/header.go
+++ b/snapshot/header/header.go
@@ -61,6 +61,7 @@ type VFS struct {
 
 type Source struct {
 	Importer Importer    `msgpack:"importer" json:"importer"`
+	Context  []KeyValue  `msgpack:"context" json:"context"`
 	VFS      VFS         `msgpack:"root" json:"root"`
 	Indexes  []Index     `msgpack:"indexes" json:"indexes"`
 	Summary  vfs.Summary `msgpack:"summary" json:"summary"`
@@ -69,6 +70,7 @@ type Source struct {
 func NewSource() Source {
 	return Source{
 		Importer: Importer{},
+		Context:  []KeyValue{},
 		VFS:      VFS{},
 		Indexes:  []Index{},
 		Summary:  vfs.Summary{},


### PR DESCRIPTION
in the future we will support remote importers, so we need their context