### PR TITLE
move the btree.Iterator interface to its own package

### DIFF
--- a/btree/iter.go
+++ b/btree/iter.go
@@ -1,10 +1,6 @@
 package btree
 
-type Iterator[K, V any] interface {
-	Next() bool
-	Current() (K, V)
-	Err() error
-}
+import "github.com/PlakarKorp/plakar/iterator"
 
 type forwardIter[K, P any, V any] struct {
 	b       *BTree[K, P, V]
@@ -51,7 +47,7 @@ func (fit *forwardIter[K, P, V]) Err() error {
 
 // ScanAll returns an iterator that visits all the values from the
 // smaller one onwards.
-func (b *BTree[K, P, V]) ScanAll() (Iterator[K, V], error) {
+func (b *BTree[K, P, V]) ScanAll() (iterator.Iterator[K, V], error) {
 	ptr := b.Root
 
 	var n *Node[K, P, V]
@@ -79,7 +75,7 @@ func (b *BTree[K, P, V]) ScanAll() (Iterator[K, V], error) {
 // ScanFrom returns an iterator that visits all the values starting
 // from the given key, or the first key larger than the given one,
 // onwards.
-func (b *BTree[K, P, V]) ScanFrom(key K) (Iterator[K, V], error) {
+func (b *BTree[K, P, V]) ScanFrom(key K) (iterator.Iterator[K, V], error) {
 	node, path, err := b.findleaf(key)
 	if err != nil {
 		return nil, err
@@ -200,7 +196,7 @@ func (bit *backwardIter[K, P, V]) Err() error {
 	return bit.err
 }
 
-func (b *BTree[K, P, V]) ScanAllReverse() (Iterator[K, V], error) {
+func (b *BTree[K, P, V]) ScanAllReverse() (iterator.Iterator[K, V], error) {
 	bit := &backwardIter[K, P, V]{
 		b: b,
 	}
@@ -252,7 +248,7 @@ func (dit *dfsIter[K, P, V]) Err() error {
 	return dit.err
 }
 
-func (b *BTree[K, P, V]) IterDFS() Iterator[P, *Node[K, P, V]] {
+func (b *BTree[K, P, V]) IterDFS() iterator.Iterator[P, *Node[K, P, V]] {
 	return &dfsIter[K, P, V]{
 		b:     b,
 		stack: []step[K, P, V]{{b.Root, -1}},

--- a/iterator/iter.go
+++ b/iterator/iter.go
@@ -1,0 +1,7 @@
+package iterator
+
+type Iterator[K, V any] interface {
+	Next() bool
+	Current() (K, V)
+	Err() error
+}

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/PlakarKorp/plakar/btree"
+	"github.com/PlakarKorp/plakar/iterator"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/resources"
@@ -332,7 +332,7 @@ type vdir struct {
 	path   string
 	entry  *Entry
 	fs     *Filesystem
-	iter   btree.Iterator[string, objects.MAC]
+	iter   iterator.Iterator[string, objects.MAC]
 	closed bool
 }
 

--- a/snapshot/vfs/errors.go
+++ b/snapshot/vfs/errors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/PlakarKorp/plakar/btree"
+	"github.com/PlakarKorp/plakar/iterator"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/resources"
 	"github.com/PlakarKorp/plakar/versioning"
@@ -90,6 +91,6 @@ func (fsc *Filesystem) Errors(beneath string) (iter.Seq2[*ErrorItem, error], err
 	}, nil
 }
 
-func (fsc *Filesystem) IterErrorNodes() (btree.Iterator[objects.MAC, *btree.Node[string, objects.MAC, objects.MAC]], error) {
+func (fsc *Filesystem) IterErrorNodes() (iterator.Iterator[objects.MAC, *btree.Node[string, objects.MAC, objects.MAC]], error) {
 	return fsc.errors.IterDFS(), nil
 }

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/PlakarKorp/plakar/btree"
+	"github.com/PlakarKorp/plakar/iterator"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/resources"
@@ -279,11 +280,11 @@ func (fsc *Filesystem) Children(path string) (iter.Seq2[string, error], error) {
 	}, nil
 }
 
-func (fsc *Filesystem) IterNodes() btree.Iterator[objects.MAC, *btree.Node[string, objects.MAC, objects.MAC]] {
+func (fsc *Filesystem) IterNodes() iterator.Iterator[objects.MAC, *btree.Node[string, objects.MAC, objects.MAC]] {
 	return fsc.tree.IterDFS()
 }
 
-func (fsc *Filesystem) XattrNodes() btree.Iterator[objects.MAC, *btree.Node[string, objects.MAC, objects.MAC]] {
+func (fsc *Filesystem) XattrNodes() iterator.Iterator[objects.MAC, *btree.Node[string, objects.MAC, objects.MAC]] {
 	return fsc.xattrs.IterDFS()
 }
 


### PR DESCRIPTION
it's helpful to have this kind of "iter.Seq3" iterators around, could be used in other places as well.