### PR TITLE
WIP: state: Add a new entry for configuration storage.

### DIFF
--- a/caching/repository.go
+++ b/caching/repository.go
@@ -201,3 +201,30 @@ func (c *_RepositoryCache) GetPackfiles() iter.Seq2[objects.MAC, []byte] {
 func (c *_RepositoryCache) GetPackfilesForState(stateID objects.MAC) iter.Seq2[objects.MAC, []byte] {
 	return c.getObjects(fmt.Sprintf("__packfile__:%x", stateID))
 }
+
+func (c *_RepositoryCache) PutConfiguration(key string, data []byte) error {
+	return c.put("__configuration__", key, data)
+}
+
+func (c *_RepositoryCache) GetConfiguration(key string) ([]byte, error) {
+	return c.get("__configuration__", key)
+}
+
+func (c *_RepositoryCache) GetConfigurations() iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		iter := c.db.NewIterator(nil, nil)
+		defer iter.Release()
+
+		keyPrefix := "__configuration__:"
+
+		for iter.Seek([]byte(keyPrefix)); iter.Valid(); iter.Next() {
+			if !strings.HasPrefix(string(iter.Key()), keyPrefix) {
+				break
+			}
+
+			if !yield(iter.Value()) {
+				return
+			}
+		}
+	}
+}

--- a/caching/scan.go
+++ b/caching/scan.go
@@ -255,6 +255,33 @@ func (c *ScanCache) GetPackfilesForState(stateID objects.MAC) iter.Seq2[objects.
 	return c.getObjects(fmt.Sprintf("__packfile__:%x", stateID))
 }
 
+func (c *ScanCache) PutConfiguration(key string, data []byte) error {
+	return c.put("__configuration__", key, data)
+}
+
+func (c *ScanCache) GetConfiguration(key string) ([]byte, error) {
+	return c.get("__configuration__", key)
+}
+
+func (c *ScanCache) GetConfigurations() iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		iter := c.db.NewIterator(nil, nil)
+		defer iter.Release()
+
+		keyPrefix := "__configuration__:"
+
+		for iter.Seek([]byte(keyPrefix)); iter.Valid(); iter.Next() {
+			if !strings.HasPrefix(string(iter.Key()), keyPrefix) {
+				break
+			}
+
+			if !yield(iter.Value()) {
+				return
+			}
+		}
+	}
+}
+
 func (c *ScanCache) EnumerateKeysWithPrefix(prefix string, reverse bool) iter.Seq2[string, []byte] {
 	l := len(prefix)
 

--- a/caching/state.go
+++ b/caching/state.go
@@ -28,4 +28,8 @@ type StateCache interface {
 	PutPackfile(stateID objects.MAC, packfile objects.MAC, data []byte) error
 	GetPackfiles() iter.Seq2[objects.MAC, []byte]
 	GetPackfilesForState(stateID objects.MAC) iter.Seq2[objects.MAC, []byte]
+
+	PutConfiguration(key string, data []byte) error
+	GetConfiguration(key string) ([]byte, error)
+	GetConfigurations() iter.Seq[[]byte]
 }


### PR DESCRIPTION
* Since the state is the only mutable structure in our repository use it at our advantage to store configuration options for the repository.

* Unused for now but cleanup will use it soon.


It's in WIP because there is a caveat, since our state is an append only structure it makes deletion unpractical. I didn't want to have DeletedConfigurationEntries because it increases the complexity of it, but if we really want it we can. My best guess was to use the default value (empty slice) as a marker of deletion.