### PR TITLE
plakar: Fix implicit agentless error reporting.

### DIFF
--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -368,7 +368,7 @@ func entryPoint() int {
 			// Reopen using the agentless cache, and rebuild a repository
 			ctx.GetCache().Close()
 			cacheSubDir = "plakar-agentless"
-			cacheDir, err := utils.GetCacheDir(cacheSubDir)
+			cacheDir, err = utils.GetCacheDir(cacheSubDir)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s: could not get cache directory: %s\n", flag.CommandLine.Name(), err)
 				return 1


### PR DESCRIPTION
* Because a short variable form declaration was used the err variable was local and shadowed the global one, therefore when out of the inner scope the global err was nil and nothing was logged.