### PR TITLE
fix handling of xattrs

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -72,7 +72,7 @@ func (bc *BackupContext) recordError(path string, err error) error {
 
 func (bc *BackupContext) recordXattr(record *importer.ScanRecord, object *objects.Object) error {
 	bc.muxattridx.Lock()
-	err := bc.xattridx.Insert(record.Pathname, vfs.NewXattr(record, object))
+	err := bc.xattridx.Insert(record.Pathname + ":" + record.XattrName, vfs.NewXattr(record, object))
 	bc.muxattridx.Unlock()
 	return err
 }
@@ -725,10 +725,7 @@ func (snap *Snapshot) chunkify(imp importer.Importer, cf *classifier.Classifier,
 	var err error
 
 	if record.IsXattr {
-		atoms := strings.Split(record.Pathname, ":")
-		attribute := atoms[len(atoms)-1]
-		pathname := strings.Join(atoms[:len(atoms)-1], ":")
-		rd, err = imp.NewExtendedAttributeReader(pathname, attribute)
+		rd, err = imp.NewExtendedAttributeReader(record.Pathname, record.XattrName)
 	} else {
 		rd, err = imp.NewReader(record.Pathname)
 	}

--- a/snapshot/importer/fs/walkdir.go
+++ b/snapshot/importer/fs/walkdir.go
@@ -111,7 +111,7 @@ func walkDir_worker(jobs <-chan string, results chan<- *importer.ScanResult, wg 
 				Lmode:             0,
 			}
 
-			results <- importer.NewScanXattr(filepath.ToSlash(path) + ":" + attr, fileinfo)
+			results <- importer.NewScanXattr(filepath.ToSlash(path), attr, fileinfo)
 		}
 	}
 }

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -44,6 +44,7 @@ type ScanRecord struct {
 	ExtendedAttributes []string
 	FileAttributes     uint32
 	IsXattr            bool
+	XattrName          string
 }
 
 type ScanError struct {
@@ -134,12 +135,13 @@ func NewScanRecord(pathname, target string, fileinfo objects.FileInfo, xattr []s
 	}
 }
 
-func NewScanXattr(pathname string, fileinfo objects.FileInfo) *ScanResult {
+func NewScanXattr(pathname, xattr string, fileinfo objects.FileInfo) *ScanResult {
 	return &ScanResult{
 		Record: &ScanRecord{
-			Pathname: pathname,
-			FileInfo: fileinfo,
-			IsXattr:  true,
+			Pathname:  pathname,
+			FileInfo:  fileinfo,
+			IsXattr:   true,
+			XattrName: xattr,
 		},
 	}
 }

--- a/snapshot/importer/importer_test.go
+++ b/snapshot/importer/importer_test.go
@@ -118,12 +118,14 @@ func TestNewScanRecord(t *testing.T) {
 
 func TestNewScanXattr(t *testing.T) {
 	pathname := "/path/to/file"
+	xattrname := "foo/bar"
 	fileinfo := objects.NewFileInfo("file", 300000, 0644, time.Now().Local(), 1, 2, 3, 4, 5)
 
-	record := NewScanXattr(pathname, fileinfo)
+	record := NewScanXattr(pathname, xattrname, fileinfo)
 
 	require.Equal(t, pathname, record.Record.Pathname)
 	require.Equal(t, fileinfo, record.Record.FileInfo)
+	require.Equal(t, xattrname, record.Record.XattrName)
 	require.True(t, record.Record.IsXattr)
 }
 

--- a/utils/btreescan/main.go
+++ b/utils/btreescan/main.go
@@ -59,6 +59,7 @@ func (l *leveldbstore) Put(node *Node) (int, error) {
 func main() {
 	var (
 		verify  bool
+		xattr   bool
 		dbpath  string
 		order   int
 		dot     string
@@ -66,6 +67,7 @@ func main() {
 		cpuprof string
 	)
 	flag.BoolVar(&verify, "verify", false, `Whether to verify the tree at the end`)
+	flag.BoolVar(&xattr, "xattr", false, `get xattr for all the files as well`)
 	flag.StringVar(&dbpath, "dbpath", "/tmp/leveldb", `Path to the leveldb; use "memory" for an in-memory btree`)
 	flag.IntVar(&order, "order", 50, `Order of the btree`)
 	flag.StringVar(&dot, "dot", "", `where to put the generated dot; empty for none`)
@@ -142,6 +144,15 @@ func main() {
 				log.Fatalf("failed to insert %s: %v", path, err)
 			}
 			items++
+
+			if xattr && record.Record.IsXattr {
+				rd, err := imp.NewExtendedAttributeReader(path, record.Record.XattrName)
+				if err != nil {
+					log.Fatalln("failed to get xattr for", path, "due to", err)
+				}
+				rd.Close()
+				log.Println(path, "found xattr named", record.Record.XattrName)
+			}
 		default:
 			log.Fatalln("got unknown scanrecord", record)
 		}


### PR DESCRIPTION
We concatenate the path with the name of the xattr, and then feed this constructed bogus path to NewExtendedAttributeReader which can't work.

Instead, keep separate the two information until we actually have to insert something in the btree.