### PR TITLE
differentiate between resource versions for btree root wrapper and nodes

### DIFF
--- a/btree/btree.go
+++ b/btree/btree.go
@@ -15,9 +15,11 @@ var (
 )
 
 const BTREE_VERSION = "1.0.0"
+const NODE_VERSION = "1.0.0"
 
 func init() {
-	versioning.Register(resources.RT_BTREE, versioning.FromString(BTREE_VERSION))
+	versioning.Register(resources.RT_BTREE_ROOT, versioning.FromString(BTREE_VERSION))
+	versioning.Register(resources.RT_BTREE_NODE, versioning.FromString(NODE_VERSION))
 }
 
 type Storer[K any, P any, V any] interface {

--- a/cmd/plakar/subcommands/diag/contenttype.go
+++ b/cmd/plakar/subcommands/diag/contenttype.go
@@ -38,12 +38,12 @@ func (cmd *InfoContentType) Execute(ctx *appcontext.AppContext, repo *repository
 		prefix += "/"
 	}
 
-	rd, err := repo.GetBlob(resources.RT_BTREE, snap.Header.GetSource(0).Indexes[0].Value)
+	rd, err := repo.GetBlob(resources.RT_BTREE_ROOT, snap.Header.GetSource(0).Indexes[0].Value)
 	if err != nil {
 		return 1, err
 	}
 
-	store := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_BTREE)
+	store := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_BTREE_NODE)
 	tree, err := btree.Deserialize(rd, store, strings.Compare)
 	if err != nil {
 		return 1, err

--- a/cmd/plakar/subcommands/diag/xattrs.go
+++ b/cmd/plakar/subcommands/diag/xattrs.go
@@ -44,7 +44,7 @@ func (cmd *InfoXattr) Execute(ctx *appcontext.AppContext, repo *repository.Repos
 		return 1, err
 	}
 
-	store := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_XATTR_BTREE)
+	store := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_XATTR_NODE)
 	tree, err := btree.Deserialize(rd, store, vfs.PathCmp)
 	if err != nil {
 		return 1, err

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -12,12 +12,16 @@ const (
 	RT_OBJECT      Type = 7
 	RT_CHUNK       Type = 9
 	RT_VFS_BTREE   Type = 10
-	RT_VFS_ENTRY   Type = 11
-	RT_ERROR_BTREE Type = 12
-	RT_ERROR_ENTRY Type = 13
-	RT_XATTR_BTREE Type = 14
-	RT_XATTR_ENTRY Type = 15
-	RT_BTREE       Type = 16
+	RT_VFS_NODE    Type = 11
+	RT_VFS_ENTRY   Type = 12
+	RT_ERROR_BTREE Type = 13
+	RT_ERROR_NODE  Type = 14
+	RT_ERROR_ENTRY Type = 15
+	RT_XATTR_BTREE Type = 16
+	RT_XATTR_NODE  Type = 17
+	RT_XATTR_ENTRY Type = 18
+	RT_BTREE_ROOT  Type = 19
+	RT_BTREE_NODE  Type = 20
 )
 
 func Types() []Type {
@@ -31,12 +35,16 @@ func Types() []Type {
 		RT_OBJECT,
 		RT_CHUNK,
 		RT_VFS_BTREE,
+		RT_VFS_NODE,
 		RT_VFS_ENTRY,
 		RT_ERROR_BTREE,
+		RT_ERROR_NODE,
 		RT_ERROR_ENTRY,
 		RT_XATTR_BTREE,
+		RT_XATTR_NODE,
 		RT_XATTR_ENTRY,
-		RT_BTREE,
+		RT_BTREE_ROOT,
+		RT_BTREE_NODE,
 	}
 }
 
@@ -60,18 +68,26 @@ func (r Type) String() string {
 		return "chunk"
 	case RT_VFS_BTREE:
 		return "vfs btree"
+	case RT_VFS_NODE:
+		return "vfs node"
 	case RT_VFS_ENTRY:
 		return "vfs entry"
 	case RT_ERROR_BTREE:
 		return "error btree"
+	case RT_ERROR_NODE:
+		return "error node"
 	case RT_ERROR_ENTRY:
 		return "error entry"
 	case RT_XATTR_BTREE:
 		return "xattr btree"
+	case RT_XATTR_NODE:
+		return "xattr node"
 	case RT_XATTR_ENTRY:
 		return "xattr entry"
-	case RT_BTREE:
-		return "btree"
+	case RT_BTREE_ROOT:
+		return "btree root"
+	case RT_BTREE_NODE:
+		return "btree node"
 	default:
 		return "unknown"
 	}

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -459,7 +459,7 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 	}
 	scannerWg.Wait()
 
-	errcsum, err := persistIndex(snap, backupCtx.erridx, resources.RT_ERROR_BTREE, func(e *vfs.ErrorItem) (csum objects.MAC, err error) {
+	errcsum, err := persistIndex(snap, backupCtx.erridx, resources.RT_ERROR_BTREE, resources.RT_ERROR_NODE, func(e *vfs.ErrorItem) (csum objects.MAC, err error) {
 		serialized, err := e.ToBytes()
 		if err != nil {
 			return
@@ -609,7 +609,7 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 		}
 	}
 
-	rootcsum, err := persistIndex(snap, fileidx, resources.RT_VFS_BTREE, func(entry *vfs.Entry) (csum objects.MAC, err error) {
+	rootcsum, err := persistIndex(snap, fileidx, resources.RT_VFS_BTREE, resources.RT_VFS_NODE, func(entry *vfs.Entry) (csum objects.MAC, err error) {
 		serialized, err := entry.ToBytes()
 		if err != nil {
 			return
@@ -624,7 +624,7 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 		return err
 	}
 
-	xattrcsum, err := persistIndex(snap, backupCtx.xattridx, resources.RT_XATTR_BTREE, func(xattr *vfs.Xattr) (csum objects.MAC, err error) {
+	xattrcsum, err := persistIndex(snap, backupCtx.xattridx, resources.RT_XATTR_BTREE, resources.RT_XATTR_NODE, func(xattr *vfs.Xattr) (csum objects.MAC, err error) {
 		serialized, err := xattr.ToBytes()
 		if err != nil {
 			return
@@ -639,7 +639,7 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 		return err
 	}
 
-	ctmac, err := persistIndex(snap, ctidx, resources.RT_BTREE, func(mac objects.MAC) (objects.MAC, error) {
+	ctmac, err := persistIndex(snap, ctidx, resources.RT_BTREE_ROOT, resources.RT_BTREE_NODE, func(mac objects.MAC) (objects.MAC, error) {
 		return mac, nil
 	})
 	if err != nil {

--- a/snapshot/store.go
+++ b/snapshot/store.go
@@ -55,10 +55,10 @@ func (s *SnapshotStore[K, V]) Put(node *btree.Node[K, objects.MAC, V]) (objects.
 
 // persistIndex saves a btree[K, P, V] index to the snapshot.  The
 // pointer type P is converted to a MAC.
-func persistIndex[K, P, VA, VB any](snap *Snapshot, tree *btree.BTree[K, P, VA], t resources.Type, conv func(VA) (VB, error)) (csum objects.MAC, err error) {
+func persistIndex[K, P, VA, VB any](snap *Snapshot, tree *btree.BTree[K, P, VA], rootres, noderes resources.Type, conv func(VA) (VB, error)) (csum objects.MAC, err error) {
 	root, err := btree.Persist(tree, &SnapshotStore[K, VB]{
 		readonly: false,
-		blobtype: t,
+		blobtype: noderes,
 		snap:     snap,
 	}, conv)
 	if err != nil {
@@ -74,8 +74,8 @@ func persistIndex[K, P, VA, VB any](snap *Snapshot, tree *btree.BTree[K, P, VA],
 	}
 
 	csum = snap.repository.ComputeMAC(bytes)
-	if !snap.BlobExists(t, csum) {
-		err = snap.PutBlob(t, csum, bytes)
+	if !snap.BlobExists(rootres, csum) {
+		err = snap.PutBlob(rootres, csum, bytes)
 	}
 	return
 }

--- a/snapshot/vfs/errors.go
+++ b/snapshot/vfs/errors.go
@@ -17,6 +17,7 @@ const VFS_ERROR_VERSION = "1.0.0"
 
 func init() {
 	versioning.Register(resources.RT_ERROR_BTREE, versioning.FromString(btree.BTREE_VERSION))
+	versioning.Register(resources.RT_ERROR_NODE, versioning.FromString(btree.NODE_VERSION))
 	versioning.Register(resources.RT_ERROR_ENTRY, versioning.FromString(VFS_ERROR_VERSION))
 }
 

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -17,6 +17,7 @@ import (
 
 func init() {
 	versioning.Register(resources.RT_VFS_BTREE, versioning.FromString(btree.BTREE_VERSION))
+	versioning.Register(resources.RT_VFS_NODE, versioning.FromString(btree.NODE_VERSION))
 }
 
 type Score struct {
@@ -76,7 +77,7 @@ func NewFilesystem(repo *repository.Repository, root, xattrs, errors objects.MAC
 		return nil, err
 	}
 
-	fsstore := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_VFS_BTREE)
+	fsstore := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_VFS_NODE)
 	tree, err := btree.Deserialize(rd, fsstore, PathCmp)
 	if err != nil {
 		return nil, err
@@ -87,7 +88,7 @@ func NewFilesystem(repo *repository.Repository, root, xattrs, errors objects.MAC
 		return nil, err
 	}
 
-	xstore := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_XATTR_BTREE)
+	xstore := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_XATTR_NODE)
 	xtree, err := btree.Deserialize(rd, xstore, strings.Compare)
 	if err != nil {
 		return nil, err
@@ -98,7 +99,7 @@ func NewFilesystem(repo *repository.Repository, root, xattrs, errors objects.MAC
 		return nil, err
 	}
 
-	errstore := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_ERROR_BTREE)
+	errstore := repository.NewRepositoryStore[string, objects.MAC](repo, resources.RT_ERROR_NODE)
 	errtree, err := btree.Deserialize(rd, errstore, strings.Compare)
 	if err != nil {
 		return nil, err

--- a/snapshot/vfs/xattr.go
+++ b/snapshot/vfs/xattr.go
@@ -13,6 +13,7 @@ const VFS_XATTR_VERSION = "1.0.0"
 
 func init() {
 	versioning.Register(resources.RT_XATTR_BTREE, versioning.FromString(btree.BTREE_VERSION))
+	versioning.Register(resources.RT_XATTR_NODE, versioning.FromString(btree.NODE_VERSION))
 	versioning.Register(resources.RT_XATTR_ENTRY, versioning.FromString(VFS_XATTR_VERSION))
 }
 


### PR DESCRIPTION
Unfortunately another break, but I think we need to differentiate between the root wrapper structure and the node structures, since they're completely different structures.  This makes both recovering easier to do, but also simplifies some future work I'd like to do with sync/colouring.