### PR TITLE
make sure create uses the same feel as other commands

### DIFF
--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -248,8 +248,30 @@ func entryPoint() int {
 		}
 	}
 
+	// create is a special case, it operates without a repository...
+	// but needs a repository location to store the new repository
+	if command == "create" {
+		repo, err := repository.Inexistant(ctx, repositoryPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
+			return 1
+		}
+		defer repo.Close()
+
+		cmd, err := subcommands.Parse(ctx, repo, command, args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
+			return 1
+		}
+		retval, err := cmd.Execute(ctx, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
+		}
+		return retval
+	}
+
 	// these commands need to be ran before the repository is opened
-	if command == "agent" || command == "create" || command == "version" || command == "stdio" || command == "help" {
+	if command == "agent" || command == "version" || command == "stdio" || command == "help" {
 		cmd, err := subcommands.Parse(ctx, nil, command, args)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -63,7 +63,7 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 	flags.BoolVar(&opt_nocompression, "no-compression", false, "disable transparent compression")
 	flags.Parse(args)
 
-	if flags.NArg() > 1 {
+	if flags.NArg() != 0 {
 		return nil, fmt.Errorf("%s: too many parameters", flag.CommandLine.Name())
 	}
 
@@ -76,7 +76,7 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 		Hashing:       opt_hashing,
 		NoEncryption:  opt_noencryption,
 		NoCompression: opt_nocompression,
-		Location:      flags.Arg(0),
+		Location:      repo.Location(),
 	}, nil
 }
 

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -51,8 +51,8 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 
 	flags := flag.NewFlagSet("create", flag.ExitOnError)
 	flags.Usage = func() {
-		fmt.Fprintf(flags.Output(), "Usage: %s [OPTIONS] /path/to/repository\n", flags.Name())
-		fmt.Fprintf(flags.Output(), "       %s [OPTIONS] s3://bucket/path\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "Usage: plakar [on /path/to/repository] %s [OPTIONS]\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "       plakar [on s3://path/to/bucket] %s [OPTIONS]\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")
 		flags.PrintDefaults()
 	}

--- a/cmd/plakar/subcommands/create/plakar-create.1
+++ b/cmd/plakar/subcommands/create/plakar-create.1
@@ -8,13 +8,10 @@
 .Nm
 .Op Fl no-encryption
 .Op Fl no-compression
-.Op Ar path
 .Sh DESCRIPTION
 The
 .Nm
-command creates a new Plakar repository at the specified
-.Ar path ,
-which defaults to
+command creates a new Plakar repository at the specified path which defaults to
 .Pa ~/.plakar .
 .Pp
 The options are as follows:

--- a/cmd/plakar/subcommands/help/docs/plakar-create.md
+++ b/cmd/plakar/subcommands/help/docs/plakar-create.md
@@ -9,15 +9,12 @@ PLAKAR-CREATE(1) - General Commands Manual
 **plakar create**
 \[**-no-encryption**]
 \[**-no-compression**]
-\[*path*]
 
 # DESCRIPTION
 
 The
 **plakar create**
-command creates a new Plakar repository at the specified
-*path*,
-which defaults to
+command creates a new Plakar repository at the specified path which defaults to
 *~/.plakar*.
 
 The options are as follows:

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -42,6 +42,20 @@ type Repository struct {
 	appContext *appcontext.AppContext
 }
 
+func Inexistant(ctx *appcontext.AppContext, repositoryPath string) (*Repository, error) {
+	st, err := storage.New(repositoryPath)
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+
+	return &Repository{
+		store:         st,
+		configuration: *storage.NewConfiguration(),
+		appContext:    ctx,
+	}, nil
+}
+
 func New(ctx *appcontext.AppContext, store storage.Store, config []byte) (*Repository, error) {
 	t0 := time.Now()
 	defer func() {


### PR DESCRIPTION
plakar create is the only command that takes a repository path as parameter rather than using the `on` construct, which makes it confusing as:

plakar on /tmp/foobar create

does not do what you expect, fix this.