### PR TITLE
backup: Remove scan.PutMAC() call in backup.

### DIFF
--- a/caching/scan.go
+++ b/caching/scan.go
@@ -111,32 +111,6 @@ func (c *ScanCache) GetDirectory(directory string) ([]byte, error) {
 	return c.get("__directory__", directory)
 }
 
-func (c *ScanCache) PutMAC(pathname string, mac objects.MAC) error {
-	pathname = strings.TrimSuffix(pathname, "/")
-	if pathname == "" {
-		pathname = "/"
-	}
-	return c.put("__mac__", pathname, mac[:])
-}
-
-func (c *ScanCache) GetMAC(pathname string) (objects.MAC, error) {
-	pathname = strings.TrimSuffix(pathname, "/")
-	if pathname == "" {
-		pathname = "/"
-	}
-
-	data, err := c.get("__mac__", pathname)
-	if err != nil {
-		return objects.MAC{}, err
-	}
-
-	if len(data) != 32 {
-		return objects.MAC{}, fmt.Errorf("invalid MAC length: %d", len(data))
-	}
-
-	return objects.MAC(data), nil
-}
-
 func (c *ScanCache) PutSummary(pathname string, data []byte) error {
 	pathname = strings.TrimSuffix(pathname, "/")
 	if pathname == "" {

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -452,12 +452,6 @@ func (snap *Snapshot) Backup(scanDir string, imp importer.Importer, options *Bac
 				return
 			}
 
-			// Record the MAC of the FileEntry in the cache
-			err = snap.scanCache.PutMAC(record.Pathname, fileEntryMAC)
-			if err != nil {
-				backupCtx.recordError(record.Pathname, err)
-				return
-			}
 			snap.Event(events.FileOKEvent(snap.Header.Identifier, record.Pathname, record.FileInfo.Size()))
 		}(_record)
 	}


### PR DESCRIPTION
* While here remove this whole caching API, it's unused nowadays.