### PR TITLE
cleanup: Fix for deleted Packfiles.

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -686,16 +686,6 @@ func (r *Repository) GetBlob(Type resources.Type, mac objects.MAC) (io.ReadSeeke
 		return nil, ErrPackfileNotFound
 	}
 
-	has, err := r.HasDeletedPackfile(loc.Packfile)
-	if err != nil {
-		return nil, err
-	}
-
-	if has {
-		error := fmt.Errorf("Cleanup was too eager, we have a referenced blob (%x) in a deleted packfile (%x)\n", mac, loc.Packfile)
-		r.Logger().Error("GetBlob(%s, %x): %s", Type, mac, error)
-	}
-
 	rd, err := r.GetPackfileBlob(loc)
 	if err != nil {
 		return nil, err

--- a/repository/state/state.go
+++ b/repository/state/state.go
@@ -642,7 +642,8 @@ func (ls *LocalState) BlobExists(Type resources.Type, blobMAC objects.MAC) bool 
 			continue
 		}
 
-		if ok {
+		deleted, _ := ls.HasDeletedResource(resources.RT_PACKFILE, de.Location.Packfile)
+		if ok && !deleted {
 			return true
 		}
 	}


### PR DESCRIPTION
* GetSubpartForBlob() is not the best place to test if a blob belongs to a deleted packfile. Indeed, there are some rare cases (concurrent backup and colouring cleanup phase) where we might have falsely flagged a packfile for deletion, only to roll it back later at sweep time. As such, it's valid to call GetSubpartForBlob(), since we still want people to be able to acces them.

* Rather, let's do this check in the BlobExists function, so that anyone trying to push new stuff will not see it as available.

* Note that this might endup doing a bit of duplication, if we imagine a scenario where we have a concurrent backup using blob X, but we marked X for deletion, later on if we have another backup that ends up with X BlobExists() will return false so we will commit the same blob to another packfile. This is no problem (a part from disk usage), and will be adressed anyway later on by maintainance merging same blobs from different packfiles.