### PR TITLE
fix usage in `create` subcommand

### DIFF
--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -49,8 +49,8 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 
 	flags := flag.NewFlagSet("create", flag.ExitOnError)
 	flags.Usage = func() {
-		fmt.Fprintf(flags.Output(), "Usage: plakar [on /path/to/repository] %s [OPTIONS]\n", flags.Name())
-		fmt.Fprintf(flags.Output(), "       plakar [on s3://path/to/bucket] %s [OPTIONS]\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "Usage: plakar [at /path/to/repository] %s [OPTIONS]\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "       plakar [at s3://path/to/bucket] %s [OPTIONS]\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")
 		flags.PrintDefaults()
 	}


### PR DESCRIPTION
the `on repository` syntax is invalid and it should be `at repository`.

the `on REPOSITORY` syntax isn't accurate. it should be `at REPOSITORY`.