### PR TITLE
create usage: fix ref to "plakar at s3://"

### DIFF
--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -50,7 +50,7 @@ func parse_cmd_create(ctx *appcontext.AppContext, repo *repository.Repository, a
 	flags := flag.NewFlagSet("create", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: plakar [at /path/to/repository] %s [OPTIONS]\n", flags.Name())
-		fmt.Fprintf(flags.Output(), "       plakar [at s3://path/to/bucket] %s [OPTIONS]\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "       plakar [at @REPOSITORY] %s [OPTIONS]\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")
 		flags.PrintDefaults()
 	}


### PR DESCRIPTION
To reference a repository stored on s3, the syntax @REPOSITORY should be used. The syntax "s3://user:pass@domain" is not supported anymore.