### PR TITLE
more manpages fixes

### DIFF
--- a/cmd/plakar/subcommands/agent/plakar-agent.1
+++ b/cmd/plakar/subcommands/agent/plakar-agent.1
@@ -13,7 +13,7 @@
 The
 .Nm
 command starts the Plakar agent which will execute subsequent
-.Xr plakar
+.Xr plakar 1
 commands on their behalfs for faster processing.
 .Nm
 continues running indefinitely.

--- a/cmd/plakar/subcommands/cat/plakar-cat.1
+++ b/cmd/plakar/subcommands/cat/plakar-cat.1
@@ -8,12 +8,12 @@
 .Nm
 .Op Fl no-decompress
 .Op Fl highlight
-.Ar snapshotID : Ns Ar filepath ...
+.Ar snapshotID : Ns Ar path ...
 .Sh DESCRIPTION
 The
 .Nm
 command outputs the contents of
-.Ar filepath
+.Ar path
 within Plakar snapshots to the
 standard output.
 It can decompress compressed files and optionally apply syntax

--- a/cmd/plakar/subcommands/check/plakar-check.1
+++ b/cmd/plakar/subcommands/check/plakar-check.1
@@ -53,13 +53,15 @@ Only apply command to snapshots that match
 .It Fl latest
 Only apply command to latest snapshot matching filters.
 .It Fl before Ar date
-Only apply command to snapshots matching filters and older than the specified date.
+Only apply command to snapshots matching filters and older than the specified
+date.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats
 .Pq e.g. "2006-01-02 15:04:05" .
 .It Fl since Ar date
-Only apply command to snapshots matching filters and created since the specified date, included.
+Only apply command to snapshots matching filters and created since the specified
+date, included.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats

--- a/cmd/plakar/subcommands/check/plakar-check.1
+++ b/cmd/plakar/subcommands/check/plakar-check.1
@@ -1,5 +1,5 @@
 .Dd March 3, 2025
-.Dt PLAKAR CHECK 1
+.Dt PLAKAR-CHECK 1
 .Os
 .Sh NAME
 .Nm plakar check

--- a/cmd/plakar/subcommands/digest/plakar-digest.1
+++ b/cmd/plakar/subcommands/digest/plakar-digest.1
@@ -7,19 +7,19 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl hashing Ar algorithm
-.Ar snapshotID Ns Op : Ns Ar filepath
+.Ar snapshotID Ns Op : Ns Ar path
 .Op ...
 .Sh DESCRIPTION
 The
 .Nm
 command computes and displays digests for specified
-.Ar filepath
+.Ar path
 in a the given
 .Ar snapshotID .
 Multiple
 .Ar snapshotID
 and
-.Ar filepath
+.Ar path
 may be given.
 By default, the command computes the digest by reading the file
 contents.

--- a/cmd/plakar/subcommands/digest/plakar-digest.1
+++ b/cmd/plakar/subcommands/digest/plakar-digest.1
@@ -7,7 +7,8 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl hashing Ar algorithm
-.Ar snapshotID Ns No : Ns Ar filepath Op ...
+.Ar snapshotID Ns Op : Ns Ar filepath
+.Op ...
 .Sh DESCRIPTION
 The
 .Nm

--- a/cmd/plakar/subcommands/exec/plakar-exec.1
+++ b/cmd/plakar/subcommands/exec/plakar-exec.1
@@ -6,13 +6,13 @@
 .Nd Execute a file from a Plakar snapshot
 .Sh SYNOPSIS
 .Nm
-.Ar snapshotID : Ns Ar filepath
+.Ar snapshotID : Ns Ar path
 .Op Ar command_args ...
 .Sh DESCRIPTION
 The
 .Nm
 command extracts and executes a file at
-.Ar filepath
+.Ar path
 from a Plakar snapshot passing the given arguments
 .Ar command_args
 to it.

--- a/cmd/plakar/subcommands/locate/plakar-locate.1
+++ b/cmd/plakar/subcommands/locate/plakar-locate.1
@@ -50,13 +50,15 @@ Only apply command to snapshots that match
 .It Fl latest
 Only apply command to latest snapshot matching filters.
 .It Fl before Ar date
-Only apply command to snapshots matching filters and older than the specified date.
+Only apply command to snapshots matching filters and older than the specified
+date.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats
 .Pq e.g. "2006-01-02 15:04:05" .
 .It Fl since Ar date
-Only apply command to snapshots matching filters and created since the specified date, included.
+Only apply command to snapshots matching filters and created since the specified
+date, included.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats

--- a/cmd/plakar/subcommands/ls/plakar-ls.1
+++ b/cmd/plakar/subcommands/ls/plakar-ls.1
@@ -49,13 +49,15 @@ the given tag.
 .It Fl latest
 Only apply command to latest snapshot matching filters.
 .It Fl before Ar date
-Only apply command to snapshots matching filters and older than the specified date.
+Only apply command to snapshots matching filters and older than the specified
+date.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats
 .Pq e.g. "2006-01-02 15:04:05" .
 .It Fl since Ar date
-Only apply command to snapshots matching filters and created since the specified date, included.
+Only apply command to snapshots matching filters and created since the specified
+date, included.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats

--- a/cmd/plakar/subcommands/rm/plakar-rm.1
+++ b/cmd/plakar/subcommands/rm/plakar-rm.1
@@ -59,7 +59,8 @@ Accepted formats include relative durations
 or specific dates in various formats
 .Pq e.g. "2006-01-02 15:04:05" .
 .It Fl since Ar date
-Filter snapshots matching filters and created since the specified date, included.
+Filter snapshots matching filters and created since the specified date,
+included.
 Accepted formats include relative durations
 .Pq e.g. "2d" for two days, "1w" for one week
 or specific dates in various formats


### PR DESCRIPTION
I used `mandoc -Tlint` to found and fixes some problems in man pages.

I did separated commits as some might not be not desirable (like "input text line longer than 80 bytes" or "snapshotID:path unification")