### PR TITLE
storage/fs: Use the right path when creation repo.

### DIFF
--- a/storage/backends/fs/fs.go
+++ b/storage/backends/fs/fs.go
@@ -66,13 +66,12 @@ func (repo *Repository) Path(args ...string) string {
 }
 
 func (repo *Repository) Create(config []byte) error {
-
-	dirfp, err := os.Open(repo.Location())
+	dirfp, err := os.Open(repo.Path())
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
-		err = os.MkdirAll(repo.Location(), 0700)
+		err = os.MkdirAll(repo.Path(), 0700)
 		if err != nil {
 			return err
 		}
@@ -83,7 +82,7 @@ func (repo *Repository) Create(config []byte) error {
 			return err
 		}
 		if len(entries) > 0 {
-			return fmt.Errorf("directory %s is not empty", repo.Location())
+			return fmt.Errorf("directory %s is not empty", repo.Path())
 		}
 	}
 


### PR DESCRIPTION
* Location() actually is the full "remote" line, so it might include the "fs://" URI scheme in it.

* Instead use Path() which resolves to the absolute path on the local filesystem.

* fixes 88c3126b7e

* Bug found and fix provided by sayoun@ ! Thx!