### PR TITLE
importer/fs: Fix path cleaning.

### DIFF
--- a/snapshot/importer/fs/fs.go
+++ b/snapshot/importer/fs/fs.go
@@ -49,6 +49,8 @@ func NewFSImporter(config map[string]string) (importer.Importer, error) {
 		return nil, fmt.Errorf("not an absolute path %s", location)
 	}
 
+	location = path.Clean(location)
+
 	return &FSImporter{
 		rootDir: location,
 	}, nil

--- a/snapshot/importer/fs/walkdir.go
+++ b/snapshot/importer/fs/walkdir.go
@@ -105,9 +105,7 @@ func walkDir_worker(jobs <-chan string, results chan<- *importer.ScanResult, wg 
 }
 
 func walkDir_addPrefixDirectories(rootDir string, jobs chan<- string, results chan<- *importer.ScanResult) {
-	// Clean the directory and split the path into components
-	directory := filepath.Clean(rootDir)
-	atoms := strings.Split(directory, string(os.PathSeparator))
+	atoms := strings.Split(rootDir, string(os.PathSeparator))
 
 	for i := 0; i < len(atoms)-1; i++ {
 		path := filepath.Join(atoms[0 : i+1]...)

--- a/snapshot/importer/fs/walkdir_windows.go
+++ b/snapshot/importer/fs/walkdir_windows.go
@@ -96,9 +96,7 @@ func walkDir_worker(jobs <-chan string, results chan<- *importer.ScanResult, wg 
 }
 
 func walkDir_addPrefixDirectories(rootDir string, jobs chan<- string, results chan<- *importer.ScanResult) {
-	// Clean the directory and split the path into components
-	directory := filepath.Clean(rootDir)
-	atoms := strings.Split(directory, string(os.PathSeparator))
+	atoms := strings.Split(rootDir, string(os.PathSeparator))
 
 	jobs <- "/"
 	for i := 0; i < len(atoms)-1; i++ {


### PR DESCRIPTION
* Before this, this is the record we produced when doing a backup like this:

./plakar backup -quiet /tmp/powerlog/
-> record /
-> record /tmp
-> record /tmp/powerlog/

That last record, with an appended slash doesn't fare well with our VFS layer and it breaks in all kind of ways.

* Let's sanitize the path once and for all when instantiating the fs importer so that the rootDir is always a path that we can process and we can respect the VFS layer contract.

* While here remove clean from the walkdir function, it's not the right place to do this.