### PR TITLE
reset version

### DIFF
--- a/cmd/plakar/utils/utils.go
+++ b/cmd/plakar/utils/utils.go
@@ -255,7 +255,7 @@ func GetConfigDir(appName string) (string, error) {
 	return configDir, nil
 }
 
-const VERSION = "v1.0.0-beta.2"
+var VERSION = "v1.0.0"
 
 func GetVersion() string {
 	return VERSION


### PR DESCRIPTION
we can't have main keep updating versions, reset it to a global version, then release branches can have their own specific version (-beta, etc...) and nightlies can patch the version at build time.