### PR TITLE
trace: use hexadecimal output for lockID in trace

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -783,7 +783,7 @@ func (r *Repository) GetLocks() ([]objects.MAC, error) {
 func (r *Repository) GetLock(lockID objects.MAC) (versioning.Version, io.Reader, error) {
 	t0 := time.Now()
 	defer func() {
-		r.Logger().Trace("repository", "GetLock(%s): %s", lockID, time.Since(t0))
+		r.Logger().Trace("repository", "GetLock(%x): %s", lockID, time.Since(t0))
 	}()
 
 	rd, err := r.store.GetLock(lockID)
@@ -806,7 +806,7 @@ func (r *Repository) GetLock(lockID objects.MAC) (versioning.Version, io.Reader,
 func (r *Repository) PutLock(lockID objects.MAC, rd io.Reader) error {
 	t0 := time.Now()
 	defer func() {
-		r.Logger().Trace("repository", "PutLock(%s, ...): %s", lockID, time.Since(t0))
+		r.Logger().Trace("repository", "PutLock(%x, ...): %s", lockID, time.Since(t0))
 	}()
 
 	rd, err := r.Encode(rd)


### PR DESCRIPTION
when using `plakar -trace all` prefer hexadecimal output instead of raw string.