### PR TITLE
fix tests with tmp output listing issue

### DIFF
--- a/cmd/plakar/subcommands/backup/backup_test.go
+++ b/cmd/plakar/subcommands/backup/backup_test.go
@@ -93,7 +93,7 @@ func generateFixtures(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) 
 	return repo, tmpBackupDir
 }
 
-func _TestExecuteCmdCreateDefault(t *testing.T) {
+func TestExecuteCmdCreateDefault(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 
@@ -127,13 +127,12 @@ func _TestExecuteCmdCreateDefault(t *testing.T) {
 
 	output := bufOut.String()
 	lines := strings.Split(strings.Trim(output, "\n"), "\n")
-	require.Equal(t, 10, len(lines))
 	// last line should have the summary
 	lastline := lines[len(lines)-1]
 	require.Contains(t, lastline, "created unsigned snapshot")
 }
 
-func _TestExecuteCmdCreateDefaultWithExcludes(t *testing.T) {
+func TestExecuteCmdCreateDefaultWithExcludes(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 
@@ -166,7 +165,6 @@ func _TestExecuteCmdCreateDefaultWithExcludes(t *testing.T) {
 
 	output := bufOut.String()
 	lines := strings.Split(strings.Trim(output, "\n"), "\n")
-	require.Equal(t, 9, len(lines))
 	// last line should have the summary
 	lastline := lines[len(lines)-1]
 	require.Contains(t, lastline, "created unsigned snapshot")

--- a/cmd/plakar/subcommands/locate/locate_test.go
+++ b/cmd/plakar/subcommands/locate/locate_test.go
@@ -108,7 +108,7 @@ func generateSnapshot(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) 
 	return snap
 }
 
-func _TestExecuteCmdLocateDefault(t *testing.T) {
+func TestExecuteCmdLocateDefault(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 
@@ -120,7 +120,7 @@ func _TestExecuteCmdLocateDefault(t *testing.T) {
 
 	// override the homedir to avoid having test overwriting existing home configuration
 	ctx.HomeDir = snap.Repository().Location()
-	args := []string{"*"}
+	args := []string{"dummy.txt"}
 
 	subcommand, err := parse_cmd_locate(ctx, snap.Repository(), args)
 	require.NoError(t, err)
@@ -132,21 +132,14 @@ func _TestExecuteCmdLocateDefault(t *testing.T) {
 	require.NotNil(t, status)
 
 	// output should look like this
-	// d92a4c73:/tmp
-	// d92a4c73:/tmp/tmp_to_backup1424943315
-	// d92a4c73:/tmp/tmp_to_backup1424943315/another_subdir
-	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir
-	// d92a4c73:/tmp/tmp_to_backup1424943315/another_subdir/bar
 	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir/dummy.txt
-	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir/foo.txt
-	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir/to_exclude
 
 	output := bufOut.String()
 	lines := strings.Split(strings.Trim(output, "\n"), "\n")
-	require.Equal(t, 8, len(lines))
+	require.Equal(t, 1, len(lines))
 }
 
-func _TestExecuteCmdLocateWithSnapshotId(t *testing.T) {
+func TestExecuteCmdLocateWithSnapshotId(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 
@@ -158,7 +151,7 @@ func _TestExecuteCmdLocateWithSnapshotId(t *testing.T) {
 
 	// override the homedir to avoid having test overwriting existing home configuration
 	ctx.HomeDir = snap.Repository().Location()
-	args := []string{"-snapshot", hex.EncodeToString(snap.Header.GetIndexShortID()), "*"}
+	args := []string{"-snapshot", hex.EncodeToString(snap.Header.GetIndexShortID()), "dummy.txt"}
 
 	subcommand, err := parse_cmd_locate(ctx, snap.Repository(), args)
 	require.NoError(t, err)
@@ -170,16 +163,9 @@ func _TestExecuteCmdLocateWithSnapshotId(t *testing.T) {
 	require.NotNil(t, status)
 
 	// output should look like this
-	// d92a4c73:/tmp
-	// d92a4c73:/tmp/tmp_to_backup1424943315
-	// d92a4c73:/tmp/tmp_to_backup1424943315/another_subdir
-	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir
-	// d92a4c73:/tmp/tmp_to_backup1424943315/another_subdir/bar
 	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir/dummy.txt
-	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir/foo.txt
-	// d92a4c73:/tmp/tmp_to_backup1424943315/subdir/to_exclude
 
 	output := bufOut.String()
 	lines := strings.Split(strings.Trim(output, "\n"), "\n")
-	require.Equal(t, 8, len(lines))
+	require.Equal(t, 1, len(lines))
 }


### PR DESCRIPTION
issue was symlinks on macOS on other systems where /tmp is a symlink.

* backup will only verify the summary line, not testing the content lines that have been printed
* locate will search for a specific file so we will always have one line, should not be affected by symlinks