### PR TITLE
packfile: Make deserialization faster.

### DIFF
--- a/packfile/packfile.go
+++ b/packfile/packfile.go
@@ -168,7 +168,7 @@ func NewFromBytes(hasher hash.Hash, version versioning.Version, serialized []byt
 		return nil, err
 	}
 	data := make([]byte, footer.IndexOffset)
-	if err := binary.Read(reader, binary.LittleEndian, &data); err != nil {
+	if err := binary.Read(reader, binary.LittleEndian, data); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
* Passing a pointer to a slice makes binary.Read default to reflection rather than its fast path (which is static type matching), so remove the pointer indirection we don't need it.

* This is a 60% perf gain on GetPackfile.