### PR TITLE
Fix /api/repository/locate-pathname for root folder

### DIFF
--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -216,7 +216,11 @@ func repositoryLocatePathname(w http.ResponseWriter, r *http.Request) error {
 			continue
 		}
 
-		if !strings.HasPrefix(resource, snap.Header.GetSource(0).Importer.Directory+"/") {
+		path := snap.Header.GetSource(0).Importer.Directory
+		if path != "/" {
+			path = path + "/"
+		}
+		if !strings.HasPrefix(resource, path) {
 			snap.Close()
 			continue
 		}


### PR DESCRIPTION
The endpoint /api/repository/locate-pathname was not working for the / folder.