### PR TITLE
do not reuse the maxConcurrency semaphore in importerJob, not only

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -138,11 +138,9 @@ func (snap *Snapshot) importerJob(backupCtx *BackupContext, options *BackupOptio
 				continue
 			}
 
-			backupCtx.maxConcurrency <- true
 			wg.Add(1)
 			go func(record *importer.ScanResult) {
 				defer func() {
-					<-backupCtx.maxConcurrency
 					wg.Done()
 				}()
 


### PR DESCRIPTION
it is useless but it falsifies accounting and causes a deadlock