### PR TITLE
create per-repo client version cookies for the local machine to know

### DIFF
--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -410,7 +410,6 @@ func entryPoint() int {
 	}
 
 	var repo *repository.Repository
-	fmt.Println("Opening repository...", opt_agentless)
 	if opt_agentless && command != "server" {
 		repo, err = repository.New(ctx, store, serializedConfig)
 		if err != nil {

--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -410,6 +410,7 @@ func entryPoint() int {
 	}
 
 	var repo *repository.Repository
+	fmt.Println("Opening repository...", opt_agentless)
 	if opt_agentless && command != "server" {
 		repo, err = repository.New(ctx, store, serializedConfig)
 		if err != nil {
@@ -452,11 +453,12 @@ func entryPoint() int {
 			ctx.SetCache(caching.NewManager(cacheDir))
 			defer ctx.GetCache().Close()
 
-			if err := repo.RebuildState(); err != nil {
+			repo, err = repository.New(ctx, store, serializedConfig)
+			if err != nil {
 				if errors.Is(err, caching.ErrInUse) {
 					fmt.Fprintf(os.Stderr, "%s: the agentless cache is locked by another process. To run multiple processes concurrently, start `plakar agent` and run your command again.\n", flag.CommandLine.Name())
 				} else {
-					fmt.Fprintf(os.Stderr, "%s: failed to rebuild state: %s\n", flag.CommandLine.Name(), err)
+					fmt.Fprintf(os.Stderr, "%s: failed to open repository: %s\n", flag.CommandLine.Name(), err)
 				}
 				return 1
 			}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -95,6 +95,18 @@ func New(ctx *appcontext.AppContext, store storage.Store, config []byte) (*Repos
 		return nil, err
 	}
 
+	cacheInstance, err := r.AppContext().GetCache().Repository(r.Configuration().RepositoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	clientVersion := r.appContext.Client
+	if !cacheInstance.HasCookie(clientVersion) {
+		if err := cacheInstance.PutCookie(clientVersion); err != nil {
+			return nil, err
+		}
+	}
+
 	return r, nil
 }
 
@@ -130,6 +142,18 @@ func NewNoRebuild(ctx *appcontext.AppContext, store storage.Store, config []byte
 		store:         store,
 		configuration: *configInstance,
 		appContext:    ctx,
+	}
+
+	cacheInstance, err := r.AppContext().GetCache().Repository(r.Configuration().RepositoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	clientVersion := r.appContext.Client
+	if !cacheInstance.HasCookie(clientVersion) {
+		if err := cacheInstance.PutCookie(clientVersion); err != nil {
+			return nil, err
+		}
 	}
 
 	return r, nil


### PR DESCRIPTION
which versions have touched a repo, while at it fix the plakar.go
swapping of cache when an agent client falls back to agentless