### PR TITLE
do a PutCurrentState() if this is the first run of a new version,

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -102,6 +102,13 @@ func New(ctx *appcontext.AppContext, store storage.Store, config []byte) (*Repos
 
 	clientVersion := r.appContext.Client
 	if !cacheInstance.HasCookie(clientVersion) {
+
+		// XXX - this is until beta.6 is no longer in the wild
+		err = r.PutCurrentState()
+		if err != nil {
+			return nil, err
+		}
+
 		if err := cacheInstance.PutCookie(clientVersion); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
applying fix to the beta.6 empty state bug. to be removed when we
no longer see beta.6 hitting the version check