### PR TITLE
Jcastets/fix agent config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -34,7 +34,7 @@ var (
 	ErrWrongVersion   = errors.New("agent has a different version")
 )
 
-func ExecuteRPC(ctx *appcontext.AppContext, cmd subcommands.Subcommand) (int, error) {
+func ExecuteRPC(ctx *appcontext.AppContext, cmd subcommands.Subcommand, storeConfig map[string]string) (int, error) {
 	rpcCmd, ok := cmd.(subcommands.RPC)
 	if !ok {
 		return 1, fmt.Errorf("subcommand is not an RPC")
@@ -50,7 +50,7 @@ func ExecuteRPC(ctx *appcontext.AppContext, cmd subcommands.Subcommand) (int, er
 	}
 	defer client.Close()
 
-	if status, err := client.SendCommand(ctx, rpcCmd); err != nil {
+	if status, err := client.SendCommand(ctx, rpcCmd, storeConfig); err != nil {
 		return status, err
 	}
 	return 0, nil
@@ -96,8 +96,8 @@ func (c *Client) handshake() error {
 	return nil
 }
 
-func (c *Client) SendCommand(ctx *appcontext.AppContext, cmd subcommands.RPC) (int, error) {
-	if err := subcommands.EncodeRPC(c.enc, cmd); err != nil {
+func (c *Client) SendCommand(ctx *appcontext.AppContext, cmd subcommands.RPC, storeConfig map[string]string) (int, error) {
+	if err := subcommands.EncodeRPC(c.enc, cmd, storeConfig); err != nil {
 		return 1, err
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -13,7 +13,6 @@ import (
 	"github.com/PlakarKorp/plakar/cmd/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/cmd/plakar/utils"
 	"github.com/PlakarKorp/plakar/events"
-	"github.com/PlakarKorp/plakar/repository"
 	"github.com/vmihailenco/msgpack/v5"
 )
 
@@ -35,7 +34,7 @@ var (
 	ErrWrongVersion   = errors.New("agent has a different version")
 )
 
-func ExecuteRPC(ctx *appcontext.AppContext, repo *repository.Repository, cmd subcommands.Subcommand) (int, error) {
+func ExecuteRPC(ctx *appcontext.AppContext, cmd subcommands.Subcommand) (int, error) {
 	rpcCmd, ok := cmd.(subcommands.RPC)
 	if !ok {
 		return 1, fmt.Errorf("subcommand is not an RPC")
@@ -51,7 +50,7 @@ func ExecuteRPC(ctx *appcontext.AppContext, repo *repository.Repository, cmd sub
 	}
 	defer client.Close()
 
-	if status, err := client.SendCommand(ctx, rpcCmd, repo); err != nil {
+	if status, err := client.SendCommand(ctx, rpcCmd); err != nil {
 		return status, err
 	}
 	return 0, nil
@@ -97,7 +96,7 @@ func (c *Client) handshake() error {
 	return nil
 }
 
-func (c *Client) SendCommand(ctx *appcontext.AppContext, cmd subcommands.RPC, repo *repository.Repository) (int, error) {
+func (c *Client) SendCommand(ctx *appcontext.AppContext, cmd subcommands.RPC) (int, error) {
 	if err := subcommands.EncodeRPC(c.enc, cmd); err != nil {
 		return 1, err
 	}

--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -436,7 +436,7 @@ func entryPoint() int {
 	if opt_agentless {
 		status, err = cmd.Execute(ctx, repo)
 	} else {
-		status, err = agent.ExecuteRPC(ctx, cmd)
+		status, err = agent.ExecuteRPC(ctx, cmd, storeConfig)
 		if err == agent.ErrRetryAgentless {
 			err = nil
 			// Reopen using the agentless cache, and rebuild a repository

--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -274,19 +274,10 @@ func entryPoint() int {
 		}
 	}
 
-	storeConfig := map[string]string{"location": repositoryPath}
-	if strings.HasPrefix(repositoryPath, "@") {
-		remote, ok := ctx.Config.GetRepository(repositoryPath[1:])
-		if !ok {
-			fmt.Fprintf(os.Stderr, "%s: could not resolve repository: %s\n", flag.CommandLine.Name(), repositoryPath)
-			return 1
-		}
-		if _, ok := remote["location"]; !ok {
-			fmt.Fprintf(os.Stderr, "%s: could not resolve repository location: %s\n", flag.CommandLine.Name(), repositoryPath)
-			return 1
-		} else {
-			storeConfig = remote
-		}
+	storeConfig, err := ctx.Config.GetRepository(repositoryPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
+		return 1
 	}
 
 	// create is a special case, it operates without a repository...

--- a/cmd/plakar/plakar.go
+++ b/cmd/plakar/plakar.go
@@ -436,7 +436,7 @@ func entryPoint() int {
 	if opt_agentless {
 		status, err = cmd.Execute(ctx, repo)
 	} else {
-		status, err = agent.ExecuteRPC(ctx, repo, cmd)
+		status, err = agent.ExecuteRPC(ctx, cmd)
 		if err == agent.ErrRetryAgentless {
 			err = nil
 			// Reopen using the agentless cache, and rebuild a repository

--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -120,7 +120,7 @@ func parse_cmd_agent(ctx *appcontext.AppContext, repo *repository.Repository, ar
 		}
 		defer client.Close()
 
-		retval, err := client.SendCommand(ctx, &AgentStop{})
+		retval, err := client.SendCommand(ctx, &AgentStop{}, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 			logger.EnableInfo()
 			clientContext.SetLogger(logger)
 
-			name, request, err := subcommands.DecodeRPC(decoder)
+			name, storeConfig, request, err := subcommands.DecodeRPC(decoder)
 			if err != nil {
 				if isDisconnectError(err) {
 					fmt.Fprintf(os.Stderr, "Client disconnected during initial request\n")
@@ -759,7 +759,7 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					clientContext.SetSecret(repositorySecret)
 				}
 
-				store, serializedConfig, err := storage.Open(map[string]string{"location": repositoryLocation})
+				store, serializedConfig, err := storage.Open(storeConfig)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to open storage: %s\n", err)
 					return

--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -365,7 +365,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 			}()
 
 			var subcommand subcommands.RPC
-			var repositoryLocation string
 			var repositorySecret []byte
 
 			switch name {
@@ -388,7 +387,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&ls.Ls{}).Name():
 				var cmd struct {
@@ -400,7 +398,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&backup.Backup{}).Name():
 				var cmd struct {
@@ -412,7 +409,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&info.InfoRepository{}).Name():
 				var cmd struct {
@@ -424,7 +420,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&info.InfoSnapshot{}).Name():
 				var cmd struct {
@@ -436,7 +431,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&info.InfoVFS{}).Name():
 				var cmd struct {
@@ -448,7 +442,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagContentType{}).Name():
 				var cmd struct {
@@ -460,7 +453,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagErrors{}).Name():
 				var cmd struct {
@@ -472,7 +464,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagObject{}).Name():
 				var cmd struct {
@@ -484,7 +475,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagPackfile{}).Name():
 				var cmd struct {
@@ -496,7 +486,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagRepository{}).Name():
 				var cmd struct {
@@ -508,7 +497,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagSearch{}).Name():
 				var cmd struct {
@@ -520,7 +508,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagSnapshot{}).Name():
 				var cmd struct {
@@ -532,7 +519,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagState{}).Name():
 				var cmd struct {
@@ -544,7 +530,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagVFS{}).Name():
 				var cmd struct {
@@ -556,7 +541,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagXattr{}).Name():
 				var cmd struct {
@@ -568,7 +552,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diag.DiagLocks{}).Name():
 				var cmd struct {
@@ -580,7 +563,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&rm.Rm{}).Name():
 				var cmd struct {
@@ -592,7 +574,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&digest.Digest{}).Name():
 				var cmd struct {
@@ -604,7 +585,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&locate.Locate{}).Name():
 				var cmd struct {
@@ -616,7 +596,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&check.Check{}).Name():
 				var cmd struct {
@@ -628,7 +607,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&maintenance.Maintenance{}).Name():
 				var cmd struct {
@@ -640,7 +618,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&clone.Clone{}).Name():
 				var cmd struct {
@@ -652,7 +629,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&archive.Archive{}).Name():
 				var cmd struct {
@@ -664,7 +640,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&diff.Diff{}).Name():
 				var cmd struct {
@@ -676,7 +651,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&cmd_exec.Exec{}).Name():
 				var cmd struct {
@@ -688,7 +662,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&mount.Mount{}).Name():
 				var cmd struct {
@@ -700,7 +673,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&restore.Restore{}).Name():
 				var cmd struct {
@@ -712,7 +684,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&server.Server{}).Name():
 				var cmd struct {
@@ -724,7 +695,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			case (&cmd_sync.Sync{}).Name():
 				var cmd struct {
@@ -736,7 +706,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.SourceRepositoryLocation
 				repositorySecret = cmd.Subcommand.SourceRepositorySecret
 			case (&ui.Ui{}).Name():
 				var cmd struct {
@@ -748,31 +717,28 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 					return
 				}
 				subcommand = &cmd.Subcommand
-				repositoryLocation = cmd.Subcommand.RepositoryLocation
 				repositorySecret = cmd.Subcommand.RepositorySecret
 			}
 
 			var repo *repository.Repository
 
-			if repositoryLocation != "" {
-				if repositorySecret != nil {
-					clientContext.SetSecret(repositorySecret)
-				}
-
-				store, serializedConfig, err := storage.Open(storeConfig)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to open storage: %s\n", err)
-					return
-				}
-				defer store.Close()
-
-				repo, err = repository.New(clientContext, store, serializedConfig)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to open repository: %s\n", err)
-					return
-				}
-				defer repo.Close()
+			if repositorySecret != nil {
+				clientContext.SetSecret(repositorySecret)
 			}
+
+			store, serializedConfig, err := storage.Open(storeConfig)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to open storage: %s\n", err)
+				return
+			}
+			defer store.Close()
+
+			repo, err = repository.New(clientContext, store, serializedConfig)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to open repository: %s\n", err)
+				return
+			}
+			defer repo.Close()
 
 			eventsDone := make(chan struct{})
 			eventsChan := clientContext.Events().Listen()

--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -120,7 +120,7 @@ func parse_cmd_agent(ctx *appcontext.AppContext, repo *repository.Repository, ar
 		}
 		defer client.Close()
 
-		retval, err := client.SendCommand(ctx, &AgentStop{}, nil)
+		retval, err := client.SendCommand(ctx, &AgentStop{})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/plakar/subcommands/archive/archive.go
+++ b/cmd/plakar/subcommands/archive/archive.go
@@ -68,18 +68,16 @@ func parse_cmd_archive(ctx *appcontext.AppContext, repo *repository.Repository, 
 	}
 
 	return &Archive{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		Rebase:             opt_rebase,
-		Output:             opt_output,
-		Format:             opt_format,
-		SnapshotPrefix:     flags.Arg(0),
+		RepositorySecret: ctx.GetSecret(),
+		Rebase:           opt_rebase,
+		Output:           opt_output,
+		Format:           opt_format,
+		SnapshotPrefix:   flags.Arg(0),
 	}, nil
 }
 
 type Archive struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Rebase         bool
 	Output         string

--- a/cmd/plakar/subcommands/backup/backup.go
+++ b/cmd/plakar/subcommands/backup/backup.go
@@ -107,21 +107,19 @@ func parse_cmd_backup(ctx *appcontext.AppContext, repo *repository.Repository, a
 		}
 	}
 	return &Backup{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		Concurrency:        opt_concurrency,
-		Tags:               opt_tags,
-		Excludes:           excludes,
-		Quiet:              opt_quiet,
-		Path:               flags.Arg(0),
-		OptCheck:           opt_check,
+		RepositorySecret: ctx.GetSecret(),
+		Concurrency:      opt_concurrency,
+		Tags:             opt_tags,
+		Excludes:         excludes,
+		Quiet:            opt_quiet,
+		Path:             flags.Arg(0),
+		OptCheck:         opt_check,
 	}, nil
 }
 
 type Backup struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
-	Job                string
+	RepositorySecret []byte
+	Job              string
 
 	Concurrency uint64
 	Tags        string

--- a/cmd/plakar/subcommands/cat/cat.go
+++ b/cmd/plakar/subcommands/cat/cat.go
@@ -56,17 +56,15 @@ func parse_cmd_cat(ctx *appcontext.AppContext, repo *repository.Repository, args
 	}
 
 	return &Cat{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		NoDecompress:       opt_nodecompress,
-		Highlight:          opt_highlight,
-		Paths:              flags.Args(),
+		RepositorySecret: ctx.GetSecret(),
+		NoDecompress:     opt_nodecompress,
+		Highlight:        opt_highlight,
+		Paths:            flags.Args(),
 	}, nil
 }
 
 type Cat struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	NoDecompress bool
 	Highlight    bool

--- a/cmd/plakar/subcommands/check/check.go
+++ b/cmd/plakar/subcommands/check/check.go
@@ -98,8 +98,7 @@ func parse_cmd_check(ctx *appcontext.AppContext, repo *repository.Repository, ar
 	}
 
 	return &Check{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 
 		OptBefore: beforeDate,
 		OptSince:  sinceDate,
@@ -122,8 +121,7 @@ func parse_cmd_check(ctx *appcontext.AppContext, repo *repository.Repository, ar
 }
 
 type Check struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	OptBefore time.Time
 	OptSince  time.Time

--- a/cmd/plakar/subcommands/clone/clone.go
+++ b/cmd/plakar/subcommands/clone/clone.go
@@ -23,7 +23,6 @@ import (
 	"hash"
 	"io"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -99,17 +98,9 @@ func (cmd *Clone) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 		return 1, err
 	}
 
-	storeConfig := map[string]string{"location": cmd.Dest}
-	if strings.HasPrefix(cmd.Dest, "@") {
-		remote, ok := ctx.Config.GetRepository(cmd.Dest[1:])
-		if !ok {
-			return 1, fmt.Errorf("could not resolve repository: %s", cmd.Dest)
-		}
-		if _, ok := remote["location"]; !ok {
-			return 1, fmt.Errorf("could not resolve repository location: %s", cmd.Dest)
-		} else {
-			storeConfig = remote
-		}
+	storeConfig, err := ctx.Config.GetRepository(cmd.Dest)
+	if err != nil {
+		return 1, err
 	}
 
 	cloneStore, err := storage.Create(storeConfig, wrappedSerializedConfig)

--- a/cmd/plakar/subcommands/clone/clone.go
+++ b/cmd/plakar/subcommands/clone/clone.go
@@ -53,15 +53,13 @@ func parse_cmd_clone(ctx *appcontext.AppContext, repo *repository.Repository, ar
 	}
 
 	return &Clone{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		Dest:               flags.Arg(1),
+		RepositorySecret: ctx.GetSecret(),
+		Dest:             flags.Arg(1),
 	}, nil
 }
 
 type Clone struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Dest string
 }

--- a/cmd/plakar/subcommands/diag/contenttype.go
+++ b/cmd/plakar/subcommands/diag/contenttype.go
@@ -10,8 +10,7 @@ import (
 )
 
 type DiagContentType struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotPath string
 }

--- a/cmd/plakar/subcommands/diag/diag.go
+++ b/cmd/plakar/subcommands/diag/diag.go
@@ -32,8 +32,7 @@ func init() {
 func parse_cmd_diag(ctx *appcontext.AppContext, repo *repository.Repository, args []string) (subcommands.Subcommand, error) {
 	if len(args) == 0 {
 		return &DiagRepository{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
+			RepositorySecret: ctx.GetSecret(),
 		}, nil
 	}
 
@@ -60,71 +59,62 @@ func parse_cmd_diag(ctx *appcontext.AppContext, repo *repository.Repository, arg
 			return nil, fmt.Errorf("usage: %s snapshot SNAPSHOT", flags.Name())
 		}
 		return &DiagSnapshot{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotID:         flags.Args()[1],
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotID:       flags.Args()[1],
 		}, nil
 	case "errors":
 		if len(flags.Args()) < 2 {
 			return nil, fmt.Errorf("usage: %s errors SNAPSHOT", flags.Name())
 		}
 		return &DiagErrors{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotID:         flags.Args()[1],
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotID:       flags.Args()[1],
 		}, nil
 	case "state":
 		return &DiagState{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			Args:               flags.Args()[1:],
+			RepositorySecret: ctx.GetSecret(),
+			Args:             flags.Args()[1:],
 		}, nil
 	case "packfile":
 		return &DiagPackfile{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			Args:               flags.Args()[1:],
+			RepositorySecret: ctx.GetSecret(),
+			Args:             flags.Args()[1:],
 		}, nil
 	case "object":
 		if len(flags.Args()) < 2 {
 			return nil, fmt.Errorf("usage: %s object OBJECT", flags.Name())
 		}
 		return &DiagObject{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			ObjectID:           flags.Args()[1],
+			RepositorySecret: ctx.GetSecret(),
+			ObjectID:         flags.Args()[1],
 		}, nil
 	case "vfs":
 		if len(flags.Args()) < 2 {
 			return nil, fmt.Errorf("usage: %s vfs SNAPSHOT[:PATH]", flags.Name())
 		}
 		return &DiagVFS{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotPath:       flags.Args()[1],
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotPath:     flags.Args()[1],
 		}, nil
 	case "xattr":
 		if len(flags.Args()) < 2 {
 			return nil, fmt.Errorf("usage: %s xattr SNAPSHOT[:PATH]", flags.Name())
 		}
 		return &DiagXattr{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotPath:       flags.Args()[1],
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotPath:     flags.Args()[1],
 		}, nil
 	case "contenttype":
 		if len(flags.Args()) < 2 {
 			return nil, fmt.Errorf("usage: %s contenttype SNAPSHOT[:PATH]", flags.Name())
 		}
 		return &DiagContentType{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotPath:       flags.Args()[1],
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotPath:     flags.Args()[1],
 		}, nil
 	case "locks":
 		return &DiagLocks{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
+			RepositorySecret: ctx.GetSecret(),
 		}, nil
 	case "search":
 		var path, mime string
@@ -138,10 +128,9 @@ func parse_cmd_diag(ctx *appcontext.AppContext, repo *repository.Repository, arg
 				flags.Name())
 		}
 		return &DiagSearch{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotPath:       path,
-			Mime:               mime,
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotPath:     path,
+			Mime:             mime,
 		}, nil
 	}
 	return nil, fmt.Errorf("Invalid parameter. usage: diag [contenttype|snapshot|object|state|packfile|vfs|xattr|errors|search]")

--- a/cmd/plakar/subcommands/diag/errors.go
+++ b/cmd/plakar/subcommands/diag/errors.go
@@ -9,8 +9,7 @@ import (
 )
 
 type DiagErrors struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotID string
 }

--- a/cmd/plakar/subcommands/diag/locks.go
+++ b/cmd/plakar/subcommands/diag/locks.go
@@ -9,8 +9,7 @@ import (
 )
 
 type DiagLocks struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 }
 
 func (cmd *DiagLocks) Name() string {

--- a/cmd/plakar/subcommands/diag/object.go
+++ b/cmd/plakar/subcommands/diag/object.go
@@ -12,8 +12,7 @@ import (
 )
 
 type DiagObject struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	ObjectID string
 }

--- a/cmd/plakar/subcommands/diag/packfile.go
+++ b/cmd/plakar/subcommands/diag/packfile.go
@@ -10,8 +10,7 @@ import (
 )
 
 type DiagPackfile struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Args []string
 }

--- a/cmd/plakar/subcommands/diag/search.go
+++ b/cmd/plakar/subcommands/diag/search.go
@@ -10,11 +10,10 @@ import (
 )
 
 type DiagSearch struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotPath string
-	Mime string
+	Mime         string
 }
 
 func (cmd *DiagSearch) Name() string {
@@ -30,8 +29,8 @@ func (cmd *DiagSearch) Execute(ctx *appcontext.AppContext, repo *repository.Repo
 
 	opts := snapshot.SearchOpts{
 		Recursive: true,
-		Prefix: pathname,
-		Mime: cmd.Mime,
+		Prefix:    pathname,
+		Mime:      cmd.Mime,
 	}
 	it, err := snap.Search(&opts)
 	if err != nil {

--- a/cmd/plakar/subcommands/diag/snapshot.go
+++ b/cmd/plakar/subcommands/diag/snapshot.go
@@ -15,8 +15,7 @@ import (
 )
 
 type DiagSnapshot struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotID string
 }

--- a/cmd/plakar/subcommands/diag/state.go
+++ b/cmd/plakar/subcommands/diag/state.go
@@ -14,8 +14,7 @@ import (
 )
 
 type DiagState struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Args []string
 }

--- a/cmd/plakar/subcommands/diag/vfs.go
+++ b/cmd/plakar/subcommands/diag/vfs.go
@@ -12,8 +12,7 @@ import (
 )
 
 type DiagVFS struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotPath string
 }

--- a/cmd/plakar/subcommands/diag/xattrs.go
+++ b/cmd/plakar/subcommands/diag/xattrs.go
@@ -14,8 +14,7 @@ import (
 )
 
 type DiagXattr struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotPath string
 }

--- a/cmd/plakar/subcommands/diff/diff.go
+++ b/cmd/plakar/subcommands/diff/diff.go
@@ -53,17 +53,15 @@ func parse_cmd_diff(ctx *appcontext.AppContext, repo *repository.Repository, arg
 	}
 
 	return &Diff{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		Highlight:          opt_highlight,
-		SnapshotPath1:      flags.Arg(0),
-		SnapshotPath2:      flags.Arg(1),
+		RepositorySecret: ctx.GetSecret(),
+		Highlight:        opt_highlight,
+		SnapshotPath1:    flags.Arg(0),
+		SnapshotPath2:    flags.Arg(1),
 	}, nil
 }
 
 type Diff struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Highlight     bool
 	SnapshotPath1 string

--- a/cmd/plakar/subcommands/digest/digest.go
+++ b/cmd/plakar/subcommands/digest/digest.go
@@ -60,16 +60,14 @@ func parse_cmd_digest(ctx *appcontext.AppContext, repo *repository.Repository, a
 	}
 
 	return &Digest{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		HashingFunction:    hashingFunction,
-		Targets:            flags.Args(),
+		RepositorySecret: ctx.GetSecret(),
+		HashingFunction:  hashingFunction,
+		Targets:          flags.Args(),
 	}, nil
 }
 
 type Digest struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	HashingFunction string
 	Targets         []string

--- a/cmd/plakar/subcommands/exec/exec.go
+++ b/cmd/plakar/subcommands/exec/exec.go
@@ -48,16 +48,14 @@ func parse_cmd_exec(ctx *appcontext.AppContext, repo *repository.Repository, arg
 		return nil, fmt.Errorf("at least one parameters is required")
 	}
 	return &Exec{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		SnapshotPrefix:     flags.Arg(0),
-		Args:               flags.Args()[1:],
+		RepositorySecret: ctx.GetSecret(),
+		SnapshotPrefix:   flags.Arg(0),
+		Args:             flags.Args()[1:],
 	}, nil
 }
 
 type Exec struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotPrefix string
 	Args           []string

--- a/cmd/plakar/subcommands/info/info.go
+++ b/cmd/plakar/subcommands/info/info.go
@@ -33,8 +33,7 @@ func init() {
 func parse_cmd_info(ctx *appcontext.AppContext, repo *repository.Repository, args []string) (subcommands.Subcommand, error) {
 	if len(args) == 0 {
 		return &InfoRepository{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
+			RepositorySecret: ctx.GetSecret(),
 		}, nil
 	}
 
@@ -54,15 +53,13 @@ func parse_cmd_info(ctx *appcontext.AppContext, repo *repository.Repository, arg
 	}
 	if path != "" {
 		return &InfoVFS{
-			RepositoryLocation: repo.Location(),
-			RepositorySecret:   ctx.GetSecret(),
-			SnapshotPath:       flags.Arg(0),
+			RepositorySecret: ctx.GetSecret(),
+			SnapshotPath:     flags.Arg(0),
 		}, nil
 	}
 
 	return &InfoSnapshot{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		SnapshotID:         flags.Args()[0],
+		RepositorySecret: ctx.GetSecret(),
+		SnapshotID:       flags.Args()[0],
 	}, nil
 }

--- a/cmd/plakar/subcommands/info/snapshot.go
+++ b/cmd/plakar/subcommands/info/snapshot.go
@@ -15,8 +15,7 @@ import (
 )
 
 type InfoSnapshot struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotID string
 }

--- a/cmd/plakar/subcommands/info/vfs.go
+++ b/cmd/plakar/subcommands/info/vfs.go
@@ -12,8 +12,7 @@ import (
 )
 
 type InfoVFS struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	SnapshotPath string
 }

--- a/cmd/plakar/subcommands/locate/locate.go
+++ b/cmd/plakar/subcommands/locate/locate.go
@@ -90,8 +90,7 @@ func parse_cmd_locate(ctx *appcontext.AppContext, repo *repository.Repository, a
 	}
 
 	return &Locate{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 
 		OptBefore: beforeDate,
 		OptSince:  sinceDate,
@@ -110,8 +109,7 @@ func parse_cmd_locate(ctx *appcontext.AppContext, repo *repository.Repository, a
 }
 
 type Locate struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	OptBefore time.Time
 	OptSince  time.Time

--- a/cmd/plakar/subcommands/ls/ls.go
+++ b/cmd/plakar/subcommands/ls/ls.go
@@ -94,8 +94,7 @@ func parse_cmd_ls(ctx *appcontext.AppContext, repo *repository.Repository, args 
 	}
 
 	return &Ls{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 
 		OptBefore: beforeDate,
 		OptSince:  sinceDate,
@@ -115,8 +114,7 @@ func parse_cmd_ls(ctx *appcontext.AppContext, repo *repository.Repository, args 
 }
 
 type Ls struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	OptBefore time.Time
 	OptSince  time.Time

--- a/cmd/plakar/subcommands/maintenance/maintenance.go
+++ b/cmd/plakar/subcommands/maintenance/maintenance.go
@@ -45,14 +45,12 @@ func parse_cmd_maintenance(ctx *appcontext.AppContext, repo *repository.Reposito
 	flags.Parse(args)
 
 	return &Maintenance{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 	}, nil
 }
 
 type Maintenance struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	repository    *repository.Repository
 	maintenanceID objects.MAC

--- a/cmd/plakar/subcommands/mount/mount.go
+++ b/cmd/plakar/subcommands/mount/mount.go
@@ -41,15 +41,13 @@ func parse_cmd_mount(ctx *appcontext.AppContext, repo *repository.Repository, ar
 		return nil, fmt.Errorf("need mountpoint")
 	}
 	return &Mount{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		Mountpoint:         flags.Arg(0),
+		RepositorySecret: ctx.GetSecret(),
+		Mountpoint:       flags.Arg(0),
 	}, nil
 }
 
 type Mount struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Mountpoint string
 }

--- a/cmd/plakar/subcommands/restore/restore.go
+++ b/cmd/plakar/subcommands/restore/restore.go
@@ -80,8 +80,7 @@ func parse_cmd_restore(ctx *appcontext.AppContext, repo *repository.Repository, 
 	}
 
 	return &Restore{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 
 		OptName:        opt_name,
 		OptCategory:    opt_category,
@@ -99,8 +98,7 @@ func parse_cmd_restore(ctx *appcontext.AppContext, repo *repository.Repository, 
 }
 
 type Restore struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	OptName        string
 	OptCategory    string

--- a/cmd/plakar/subcommands/rm/rm.go
+++ b/cmd/plakar/subcommands/rm/rm.go
@@ -91,8 +91,7 @@ func parse_cmd_rm(ctx *appcontext.AppContext, repo *repository.Repository, args 
 	}
 
 	return &Rm{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 
 		OptBefore: beforeDate,
 		OptSince:  sinceDate,
@@ -110,8 +109,7 @@ func parse_cmd_rm(ctx *appcontext.AppContext, repo *repository.Repository, args 
 }
 
 type Rm struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	OptBefore time.Time
 	OptSince  time.Time

--- a/cmd/plakar/subcommands/server/server.go
+++ b/cmd/plakar/subcommands/server/server.go
@@ -50,8 +50,7 @@ func parse_cmd_server(ctx *appcontext.AppContext, repo *repository.Repository, a
 		noDelete = false
 	}
 	return &Server{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
+		RepositorySecret: ctx.GetSecret(),
 
 		ListenAddr: opt_listen,
 		NoDelete:   noDelete,
@@ -59,8 +58,7 @@ func parse_cmd_server(ctx *appcontext.AppContext, repo *repository.Repository, a
 }
 
 type Server struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	ListenAddr string
 	NoDelete   bool

--- a/cmd/plakar/subcommands/subcommands_test.go
+++ b/cmd/plakar/subcommands/subcommands_test.go
@@ -100,13 +100,15 @@ func TestEncodeDecodeRPC(t *testing.T) {
 
 	bufIn := bytes.NewBuffer(nil)
 	encoder := msgpack.NewEncoder(bufIn)
-	err := EncodeRPC(encoder, rpc)
+	err := EncodeRPC(encoder, rpc, map[string]string{"location": "s3://bucket", "access_key": "deadbeef"})
 	require.NoError(t, err)
 
 	decoder := msgpack.NewDecoder(bufIn)
-	name, rawRequest, err := DecodeRPC(decoder)
+	name, storeConfig, rawRequest, err := DecodeRPC(decoder)
 	require.NoError(t, err)
 	require.Equal(t, "test", name)
+	require.Equal(t, storeConfig["location"], "s3://bucket")
+	require.Equal(t, storeConfig["access_key"], "deadbeef")
 	require.NotEmpty(t, rawRequest)
 
 	var subcmdOut MockedSubcommand

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/cmd/plakar/subcommands"
@@ -67,17 +66,9 @@ func parse_cmd_sync(ctx *appcontext.AppContext, repo *repository.Repository, arg
 		return nil, fmt.Errorf("invalid direction, must be to, from or with")
 	}
 
-	storeConfig := map[string]string{"location": peerRepositoryPath}
-	if strings.HasPrefix(peerRepositoryPath, "@") {
-		remote, ok := ctx.Config.GetRepository(peerRepositoryPath[1:])
-		if !ok {
-			return nil, fmt.Errorf("could not resolve peer repository: %s", peerRepositoryPath)
-		}
-		if _, ok := remote["location"]; !ok {
-			return nil, fmt.Errorf("could not resolve peer repository location: %s", peerRepositoryPath)
-		} else {
-			storeConfig = remote
-		}
+	storeConfig, err := ctx.Config.GetRepository(peerRepositoryPath)
+	if err != nil {
+		return nil, fmt.Errorf("peer repository: %w", err)
 	}
 
 	peerStore, peerStoreSerializedConfig, err := storage.Open(storeConfig)
@@ -156,18 +147,9 @@ func (cmd *Sync) Name() string {
 }
 
 func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
-
-	storeConfig := map[string]string{"location": cmd.PeerRepositoryLocation}
-	if strings.HasPrefix(cmd.PeerRepositoryLocation, "@") {
-		remote, ok := ctx.Config.GetRepository(cmd.PeerRepositoryLocation[1:])
-		if !ok {
-			return 1, fmt.Errorf("could not resolve repository: %s", cmd.PeerRepositoryLocation)
-		}
-		if _, ok := remote["location"]; !ok {
-			return 1, fmt.Errorf("could not resolve repository location: %s", cmd.PeerRepositoryLocation)
-		} else {
-			storeConfig = remote
-		}
+	storeConfig, err := ctx.Config.GetRepository(cmd.PeerRepositoryLocation)
+	if err != nil {
+		return 1, fmt.Errorf("peer repository: %w", err)
 	}
 
 	peerStore, peerStoreSerializedConfig, err := storage.Open(storeConfig)

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -121,18 +121,16 @@ func parse_cmd_sync(ctx *appcontext.AppContext, repo *repository.Repository, arg
 	}
 
 	return &Sync{
-		SourceRepositoryLocation: repo.Location(),
-		SourceRepositorySecret:   ctx.GetSecret(),
-		PeerRepositoryLocation:   peerRepositoryPath,
-		PeerRepositorySecret:     peerSecret,
-		Direction:                direction,
-		SnapshotPrefix:           syncSnapshotID,
+		SourceRepositorySecret: ctx.GetSecret(),
+		PeerRepositoryLocation: peerRepositoryPath,
+		PeerRepositorySecret:   peerSecret,
+		Direction:              direction,
+		SnapshotPrefix:         syncSnapshotID,
 	}, nil
 }
 
 type Sync struct {
-	SourceRepositoryLocation string
-	SourceRepositorySecret   []byte
+	SourceRepositorySecret []byte
 
 	PeerRepositoryLocation string
 	PeerRepositorySecret   []byte

--- a/cmd/plakar/subcommands/ui/ui.go
+++ b/cmd/plakar/subcommands/ui/ui.go
@@ -55,18 +55,16 @@ func parse_cmd_ui(ctx *appcontext.AppContext, repo *repository.Repository, args 
 	flags.Parse(args)
 
 	return &Ui{
-		RepositoryLocation: repo.Location(),
-		RepositorySecret:   ctx.GetSecret(),
-		Addr:               opt_addr,
-		Cors:               opt_cors,
-		NoAuth:             opt_noauth,
-		NoSpawn:            opt_nospawn,
+		RepositorySecret: ctx.GetSecret(),
+		Addr:             opt_addr,
+		Cors:             opt_cors,
+		NoAuth:           opt_noauth,
+		NoSpawn:          opt_nospawn,
 	}, nil
 }
 
 type Ui struct {
-	RepositoryLocation string
-	RepositorySecret   []byte
+	RepositorySecret []byte
 
 	Addr    string
 	Cors    bool

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -72,9 +73,19 @@ func (c *Config) HasRepository(name string) bool {
 	return ok
 }
 
-func (c *Config) GetRepository(name string) (map[string]string, bool) {
-	kv, ok := c.Repositories[name]
-	return kv, ok
+func (c *Config) GetRepository(name string) (map[string]string, error) {
+	if !strings.HasPrefix(name, "@") {
+		return map[string]string{"location": name}, nil
+	}
+
+	kv, ok := c.Repositories[name[1:]]
+	if !ok {
+		return nil, fmt.Errorf("could not resolve repository: %s", name)
+	}
+	if _, ok := kv["location"]; !ok {
+		return nil, fmt.Errorf("repository %s has no location", name)
+	}
+	return kv, nil
 }
 
 func (c *Config) HasRemote(name string) bool {

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -30,7 +30,6 @@ func (s *Scheduler) backupTask(taskset Task, task BackupConfig) error {
 	}
 
 	backupSubcommand := &backup.Backup{}
-	backupSubcommand.RepositoryLocation = taskset.Repository.Location
 	if taskset.Repository.Passphrase != "" {
 		backupSubcommand.RepositorySecret = []byte(taskset.Repository.Passphrase)
 		_ = backupSubcommand.RepositorySecret
@@ -44,7 +43,6 @@ func (s *Scheduler) backupTask(taskset Task, task BackupConfig) error {
 	}
 
 	rmSubcommand := &rm.Rm{}
-	rmSubcommand.RepositoryLocation = taskset.Repository.Location
 	if taskset.Repository.Passphrase != "" {
 		rmSubcommand.RepositorySecret = []byte(taskset.Repository.Passphrase)
 		_ = rmSubcommand.RepositorySecret
@@ -62,7 +60,7 @@ func (s *Scheduler) backupTask(taskset Task, task BackupConfig) error {
 				time.Sleep(interval)
 			}
 
-			store, config, err := storage.Open(map[string]string{"location": backupSubcommand.RepositoryLocation})
+			store, config, err := storage.Open(map[string]string{"location": taskset.Repository.Location})
 			if err != nil {
 				s.ctx.GetLogger().Error("Error opening storage: %s", err)
 				continue
@@ -113,7 +111,6 @@ func (s *Scheduler) checkTask(taskset Task, task CheckConfig) error {
 	}
 
 	checkSubcommand := &check.Check{}
-	checkSubcommand.RepositoryLocation = taskset.Repository.Location
 	if taskset.Repository.Passphrase != "" {
 		checkSubcommand.RepositorySecret = []byte(taskset.Repository.Passphrase)
 		_ = checkSubcommand.RepositorySecret
@@ -136,7 +133,7 @@ func (s *Scheduler) checkTask(taskset Task, task CheckConfig) error {
 				time.Sleep(interval)
 			}
 
-			store, config, err := storage.Open(map[string]string{"location": checkSubcommand.RepositoryLocation})
+			store, config, err := storage.Open(map[string]string{"location": taskset.Repository.Location})
 			if err != nil {
 				s.ctx.GetLogger().Error("Error opening storage: %s", err)
 				continue
@@ -172,7 +169,6 @@ func (s *Scheduler) restoreTask(taskset Task, task RestoreConfig) error {
 	}
 
 	restoreSubcommand := &restore.Restore{}
-	restoreSubcommand.RepositoryLocation = taskset.Repository.Location
 	if taskset.Repository.Passphrase != "" {
 		restoreSubcommand.RepositorySecret = []byte(taskset.Repository.Passphrase)
 		_ = restoreSubcommand.RepositorySecret
@@ -195,7 +191,7 @@ func (s *Scheduler) restoreTask(taskset Task, task RestoreConfig) error {
 				time.Sleep(interval)
 			}
 
-			store, config, err := storage.Open(map[string]string{"location": restoreSubcommand.RepositoryLocation})
+			store, config, err := storage.Open(map[string]string{"location": taskset.Repository.Location})
 			if err != nil {
 				s.ctx.GetLogger().Error("Error opening storage: %s", err)
 				continue
@@ -231,7 +227,6 @@ func (s *Scheduler) syncTask(taskset Task, task SyncConfig) error {
 	}
 
 	syncSubcommand := &sync.Sync{}
-	syncSubcommand.SourceRepositoryLocation = taskset.Repository.Location
 	if taskset.Repository.Passphrase != "" {
 		syncSubcommand.SourceRepositorySecret = []byte(taskset.Repository.Passphrase)
 		_ = syncSubcommand.SourceRepositorySecret
@@ -266,7 +261,7 @@ func (s *Scheduler) syncTask(taskset Task, task SyncConfig) error {
 				time.Sleep(interval)
 			}
 
-			store, config, err := storage.Open(map[string]string{"location": syncSubcommand.SourceRepositoryLocation})
+			store, config, err := storage.Open(map[string]string{"location": taskset.Repository.Location})
 			if err != nil {
 				s.ctx.GetLogger().Error("sync: error opening storage: %s", err)
 				continue
@@ -304,14 +299,12 @@ func (s *Scheduler) maintenanceTask(task MaintenanceConfig) error {
 	}
 
 	maintenanceSubcommand := &maintenance.Maintenance{}
-	maintenanceSubcommand.RepositoryLocation = task.Repository.Location
 	if task.Repository.Passphrase != "" {
 		maintenanceSubcommand.RepositorySecret = []byte(task.Repository.Passphrase)
 		_ = maintenanceSubcommand.RepositorySecret
 	}
 
 	rmSubcommand := &rm.Rm{}
-	rmSubcommand.RepositoryLocation = task.Repository.Location
 	if task.Repository.Passphrase != "" {
 		rmSubcommand.RepositorySecret = []byte(task.Repository.Passphrase)
 		_ = rmSubcommand.RepositorySecret
@@ -336,7 +329,7 @@ func (s *Scheduler) maintenanceTask(task MaintenanceConfig) error {
 				time.Sleep(interval)
 			}
 
-			store, config, err := storage.Open(map[string]string{"location": maintenanceSubcommand.RepositoryLocation})
+			store, config, err := storage.Open(map[string]string{"location": task.Repository.Location})
 			if err != nil {
 				s.ctx.GetLogger().Error("Error opening storage: %s", err)
 				continue
@@ -355,7 +348,7 @@ func (s *Scheduler) maintenanceTask(task MaintenanceConfig) error {
 			if err != nil || retval != 0 {
 				s.ctx.GetLogger().Error("Error executing maintenance: %s", err)
 			} else {
-				s.ctx.GetLogger().Info("maintenance of repository %s succeeded", maintenanceSubcommand.RepositoryLocation)
+				s.ctx.GetLogger().Info("maintenance of repository %s succeeded", task.Repository.Location)
 			}
 
 			if task.Retention != "" {

--- a/storage/backends/http/client.go
+++ b/storage/backends/http/client.go
@@ -89,10 +89,6 @@ func (s *Store) Close() error {
 	return nil
 }
 
-func (s *Store) Configuration() storage.Configuration {
-	return s.config
-}
-
 // states
 func (s *Store) GetStates() ([]objects.MAC, error) {
 	r, err := s.sendRequest("GET", "/states", network.ReqGetStates{})


### PR DESCRIPTION
Before this PR, the client was only providing the storage location and the repository passphrase to the agent. The agent was unable to open repositories that required more than just the location (access key, secret key, use tls, …).

With these changes, the client sends a RPC requests that contains:
* the name of the RPC (as before)
* the subcommand object (as before)
* the storage parameters (new)

The agent unserializes the storage parameters and use them to open the repository.


Also, to avoid code duplication, I resolve the `@` syntax in `config.GetRepository`. All the callers to `config.GetRepository` were doing the alias resolution, so moving it to `config.Repository` is just avoiding code duplication. @mathieu-plak told me he doesn't like having the resolution there, but I did not know where to put it.
If you want me to move it somewhere else, can you please suggest a place where to put the alias resolution?
