### PR TITLE
better handling of symlinks

### DIFF
--- a/cmd/plakar/subcommands/ls/ls.go
+++ b/cmd/plakar/subcommands/ls/ls.go
@@ -211,14 +211,18 @@ func (cmd *Ls) list_snapshot(ctx *appcontext.AppContext, repo *repository.Reposi
 		return err
 	}
 
-	pathname, err = pvfs.Realpath(pathname)
-	if err != nil {
-		return err
-	}
-
+	resolved := false
 	return pvfs.WalkDir(pathname, func(path string, d *vfs.Entry, err error) error {
 		if err != nil {
 			return err
+		}
+		if !resolved {
+			// pathname might point to a symlink, so we
+			// have to deal with physical vs logical path
+			// in here.  This makes sure we fetch the
+			// right physical path and do our logic on it.
+			resolved = true
+			pathname = d.Path()
 		}
 		if d.IsDir() && path == pathname {
 			return nil

--- a/cmd/plakar/subcommands/ls/ls.go
+++ b/cmd/plakar/subcommands/ls/ls.go
@@ -211,6 +211,11 @@ func (cmd *Ls) list_snapshot(ctx *appcontext.AppContext, repo *repository.Reposi
 		return err
 	}
 
+	pathname, err = pvfs.Realpath(pathname)
+	if err != nil {
+		return err
+	}
+
 	return pvfs.WalkDir(pathname, func(path string, d *vfs.Entry, err error) error {
 		if err != nil {
 			return err

--- a/snapshot/importer/fs/fs.go
+++ b/snapshot/importer/fs/fs.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -88,7 +87,7 @@ func (p *FSImporter) NewExtendedAttributeReader(pathname string, attribute strin
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(bytes.NewReader(data)), nil
+	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
 func (p *FSImporter) GetExtendedAttributes(pathname string) ([]importer.ExtendedAttributes, error) {

--- a/snapshot/importer/fs/walkdir.go
+++ b/snapshot/importer/fs/walkdir.go
@@ -143,27 +143,31 @@ func walkDir_walker(rootDir string, numWorkers int) (<-chan *importer.ScanResult
 	go func() {
 		defer close(jobs)
 
+		orig := rootDir
 		info, err := os.Lstat(rootDir)
 		if err != nil {
 			results <- importer.NewScanError(rootDir, err)
 			return
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			originFile, err := os.Readlink(rootDir)
+			realpath, err := os.Readlink(rootDir)
 			if err != nil {
 				results <- importer.NewScanError(rootDir, err)
 				return
 			}
 
-			if !filepath.IsAbs(originFile) {
-				originFile = filepath.Join(filepath.Dir(rootDir), originFile)
+			if !filepath.IsAbs(realpath) {
+				realpath = filepath.Join(filepath.Dir(rootDir), realpath)
 			}
 			jobs <- rootDir
-			rootDir = originFile
+			rootDir = realpath
 		}
 
 		// Add prefix directories first
 		walkDir_addPrefixDirectories(rootDir, jobs, results)
+		if orig != rootDir {
+			walkDir_addPrefixDirectories(orig, jobs, results)
+		}
 
 		err = filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {

--- a/snapshot/importer/fs/walkdir.go
+++ b/snapshot/importer/fs/walkdir.go
@@ -107,7 +107,7 @@ func walkDir_worker(jobs <-chan string, results chan<- *importer.ScanResult, wg 
 func walkDir_addPrefixDirectories(rootDir string, jobs chan<- string, results chan<- *importer.ScanResult) {
 	atoms := strings.Split(rootDir, string(os.PathSeparator))
 
-	for i := 0; i < len(atoms)-1; i++ {
+	for i := range len(atoms)-1 {
 		path := filepath.Join(atoms[0 : i+1]...)
 
 		if !strings.HasPrefix(path, "/") {
@@ -134,7 +134,7 @@ func walkDir_walker(rootDir string, numWorkers int) (<-chan *importer.ScanResult
 	var wg sync.WaitGroup
 
 	// Launch worker pool
-	for w := 1; w <= numWorkers; w++ {
+	for range numWorkers {
 		wg.Add(1)
 		go walkDir_worker(jobs, results, &wg, namecache)
 	}

--- a/snapshot/importer/fs/walkdir_windows.go
+++ b/snapshot/importer/fs/walkdir_windows.go
@@ -99,7 +99,7 @@ func walkDir_addPrefixDirectories(rootDir string, jobs chan<- string, results ch
 	atoms := strings.Split(rootDir, string(os.PathSeparator))
 
 	jobs <- "/"
-	for i := 0; i < len(atoms)-1; i++ {
+	for i := range len(atoms)-1 {
 		pathname := strings.Join(atoms[0:i+1], string(os.PathSeparator))
 
 		if _, err := os.Stat(pathname); err != nil {

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -166,9 +166,7 @@ func (e *Entry) Open(fs *Filesystem, path string) fs.File {
 }
 
 func (e *Entry) Getdents(fsc *Filesystem) (iter.Seq2[*Entry, error], error) {
-	path := path.Join(e.ParentPath, e.FileInfo.Name())
-
-	prefix := path
+	prefix := e.Path()
 	if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -214,7 +214,7 @@ func (fsc *Filesystem) ResolveXattr(mac objects.MAC) (*Xattr, error) {
 }
 
 func (fsc *Filesystem) Open(path string) (fs.File, error) {
-	entry, err := fsc.lookup(path)
+	entry, err := fsc.GetEntry(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes two things actually:

* add more prefix directories to the backup so that both the user expectations and the backup navigation still works as expected
* fixes the behavior of `ls`; now it implicitly follows the symlinks inside the path.

Still a wip because Realpath() has to go away, we need an API that opens an entry following each symlinks along the path, but need to take care that Walkdir doesn't do that, otherwise we might loop indefinitely.