### PR TITLE
testing: rename the mock "fs" backend "mock"

### DIFF
--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -287,21 +287,21 @@ func _TestSnapshotPathParam(t *testing.T) {
 		{
 			name:     "empty id",
 			id:       "",
-			location: "/test/location",
+			location: "mock:///test/location",
 			config:   ptesting.NewConfiguration(),
 			err:      "invalid_params: Invalid parameter",
 		},
 		{
 			name:     "empty id",
 			id:       "12345:/dummy",
-			location: "/test/location?behavior=oneState",
+			location: "mock:///test/location?behavior=oneState",
 			config:   ptesting.NewConfiguration(),
 			err:      "invalid_params: Invalid parameter",
 		},
 		{
 			name:     "working",
 			id:       "1000000000000000000000000000000000000000000000000000000000000000:/dummy",
-			location: "/test/location?behavior=oneState",
+			location: "mock:///test/location?behavior=oneState",
 			config:   ptesting.NewConfiguration(),
 		},
 	}
@@ -323,7 +323,7 @@ func _TestSnapshotPathParam(t *testing.T) {
 			require.NoError(t, err, "creating storage")
 
 			ctx := appcontext.NewAppContext()
-			cache := caching.NewManager("/tmp/test_plakar")
+			cache := caching.NewManager("mock:///tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -38,7 +38,7 @@ func _Test_RepositoryConfiguration(t *testing.T) {
 	require.NoError(t, err)
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
-	lstore, err := storage.Create(map[string]string{"location": "/test/location"}, wrappedConfig)
+	lstore, err := storage.Create(map[string]string{"location": "mock:///test/location"}, wrappedConfig)
 	require.NoError(t, err, "creating storage")
 
 	ctx := appcontext.NewAppContext()
@@ -104,13 +104,13 @@ func _Test_RepositorySnapshots(t *testing.T) {
 	}{
 		{
 			name:     "no snapshots",
-			location: "/test/location",
+			location: "mock:///test/location",
 			config:   ptesting.NewConfiguration(),
 			expected: `{"items": [], "total": 0}`,
 		},
 		{
 			name:     "one snapshot with compression",
-			location: "/test/location?behavior=oneSnapshot",
+			location: "mock:///test/location?behavior=oneSnapshot",
 			config:   ptesting.NewConfiguration(),
 			expected: `{
 						"total": 1,
@@ -207,7 +207,7 @@ func _Test_RepositorySnapshots(t *testing.T) {
 		},
 		{
 			name:     "one snapshot without compression",
-			location: "/test/location?behavior=oneSnapshot",
+			location: "mock:///test/location?behavior=oneSnapshot",
 			config:   ptesting.NewConfiguration(ptesting.WithConfigurationCompression(nil)),
 			expected: `{
 						"total": 1,
@@ -364,38 +364,38 @@ func _Test_RepositorySnapshotsErrors(t *testing.T) {
 	}{
 		{
 			name:     "wrong offset",
-			location: "/test/location",
+			location: "mock:///test/location",
 			params:   url.Values{"offset": []string{"abc"}}.Encode(),
 			status:   http.StatusInternalServerError,
 		},
 		{
 			name:     "offset too big",
-			location: "/test/location",
+			location: "mock:///test/location",
 			params:   url.Values{"offset": []string{"5"}}.Encode(),
 			status:   http.StatusOK,
 			expected: `{"items": [], "total": 0}`,
 		},
 		{
 			name:     "offset + limit too big",
-			location: "/test/location?behavior=oneSnapshot",
+			location: "mock:///test/location?behavior=oneSnapshot",
 			params:   url.Values{"offset": []string{"1"}, "limit": []string{"1"}}.Encode(),
 			status:   http.StatusOK,
 			expected: `{"items": [], "total": 1}`,
 		},
 		{
 			name:     "wrong packfile",
-			location: "/test/location?behavior=nopackfile",
+			location: "mock:///test/location?behavior=nopackfile",
 			status:   http.StatusInternalServerError,
 		},
 		{
 			name:     "wrong limit",
-			location: "/test/location",
+			location: "mock:///test/location",
 			params:   url.Values{"limit": []string{"abc"}}.Encode(),
 			status:   http.StatusInternalServerError,
 		},
 		{
 			name:     "wrong sort",
-			location: "/test/location",
+			location: "mock:///test/location",
 			params:   url.Values{"sort": []string{"abc"}}.Encode(),
 			expected: `{"error":{"code":"invalid_params","message":"Invalid parameter","params":{"sort":{"code":"invalid_argument","message":"invalid sort key: abc"}}}}`,
 			status:   http.StatusBadRequest,
@@ -605,13 +605,13 @@ func Test_RepositoryStateErrors(t *testing.T) {
 	}{
 		{
 			name:     "wrong state id format",
-			location: "/test/location",
+			location: "mock:///test/location",
 			stateId:  "abc",
 			status:   http.StatusBadRequest,
 		},
 		{
 			name:     "wrong state",
-			location: "/test/location?behavior=brokenGetState",
+			location: "mock:///test/location?behavior=brokenGetState",
 			stateId:  "0100000000000000000000000000000000000000000000000000000000000000",
 			status:   http.StatusInternalServerError,
 		},

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -34,7 +34,7 @@ func _TestSnapshotHeader(t *testing.T) {
 	}{
 		{
 			name:       "snapshot id valid",
-			location:   "/test/location?behavior=oneState",
+			location:   "mock:///test/location?behavior=oneState",
 			snapshotId: "0100000000000000000000000000000000000000000000000000000000000000",
 			status:     http.StatusOK,
 			expected: `{
@@ -191,13 +191,13 @@ func TestSnapshotHeaderErrors(t *testing.T) {
 	}{
 		{
 			name:       "wrong snapshot id format",
-			location:   "/test/location",
+			location:   "mock:///test/location",
 			snapshotId: "abc",
 			status:     http.StatusBadRequest,
 		},
 		{
 			name:       "snapshot id valid but not found",
-			location:   "/test/location",
+			location:   "mock:///test/location",
 			snapshotId: "7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c",
 			status:     http.StatusNotFound,
 		},
@@ -254,7 +254,7 @@ func _TestSnapshotSign(t *testing.T) {
 	}{
 		{
 			name:         "working",
-			location:     "/test/location?behavior=oneState",
+			location:     "mock:///test/location?behavior=oneState",
 			snapshotPath: "0100000000000000000000000000000000000000000000000000000000000000:/dummy",
 			status:       http.StatusOK,
 			expected:     `{}`,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -42,7 +42,7 @@ func TestAuthMiddleware(t *testing.T) {
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	lstore, err := storage.Create(map[string]string{"location": "/test/location"}, wrappedConfig)
+	lstore, err := storage.Create(map[string]string{"location": "mock:///test/location"}, wrappedConfig)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -99,7 +99,7 @@ func Test_UnknownEndpoint(t *testing.T) {
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	lstore, err := storage.Create(map[string]string{"location": "/test/location"}, wrappedConfig)
+	lstore, err := storage.Create(map[string]string{"location": "mock:///test/location"}, wrappedConfig)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	storage.Register(func(storeConfig map[string]string) (storage.Store, error) {
 		return &MockBackend{location: storeConfig["location"]}, nil
-	}, "fs")
+	}, "mock")
 }
 
 type mockedBackendBehavior struct {


### PR DESCRIPTION
Now that we have proper checking in storage.New() we can finally call it what it is.