### PR TITLE
check jwt token before processing snapshot_path parameter

### DIFF
--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -203,13 +203,6 @@ func (signer SnapshotReaderURLSigner) VerifyMiddleware(next http.Handler) http.H
 			return
 		}
 
-		snapshotID32, path, err := SnapshotPathParam(r, lrepository, "snapshot_path")
-		if err != nil {
-			handleError(w, r, parameterError("snapshot_path", InvalidArgument, err))
-			return
-		}
-		snapshotId := fmt.Sprintf("%0x", snapshotID32[:])
-
 		jwtToken, err := jwt.ParseWithClaims(signature, &SnapshotSignedURLClaims{}, func(jwtToken *jwt.Token) (interface{}, error) {
 			if _, ok := jwtToken.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, authError(fmt.Sprintf("unexpected signing method: %v", jwtToken.Header["alg"]))
@@ -225,6 +218,13 @@ func (signer SnapshotReaderURLSigner) VerifyMiddleware(next http.Handler) http.H
 			handleError(w, r, authError(fmt.Sprintf("unable to parse JWT token: %v", err)))
 			return
 		}
+
+		snapshotID32, path, err := SnapshotPathParam(r, lrepository, "snapshot_path")
+		if err != nil {
+			handleError(w, r, parameterError("snapshot_path", InvalidArgument, err))
+			return
+		}
+		snapshotId := fmt.Sprintf("%0x", snapshotID32[:])
 
 		if claims, ok := jwtToken.Claims.(*SnapshotSignedURLClaims); ok {
 			if claims.Path != path {


### PR DESCRIPTION
Move the `SnapshotPathParam()` block to after JWT cookie validity checking.

It avoids:
- parsing untrusted stuff before auth
- leaking if a particular snapshot is present in the repo or not