### PR TITLE
sprinkle some go:build comments where needed

### DIFF
--- a/cmd/plakar/subcommands/mount/mount_test.go
+++ b/cmd/plakar/subcommands/mount/mount_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 package mount
 
 import (

--- a/plakarfs/dir.go
+++ b/plakarfs/dir.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 package plakarfs
 
 import (

--- a/plakarfs/file.go
+++ b/plakarfs/file.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 package plakarfs
 
 import (

--- a/plakarfs/fs.go
+++ b/plakarfs/fs.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 package plakarfs
 
 import (


### PR DESCRIPTION
Don’t attempt to run tests / build for mount and plakarfs since these require FUSE which at the moment is {linux,darwin}-only for us.

‘make check’ succeeds on OpenBSD now \o/