### PR TITLE
tests/mount: Repair darwin.

### DIFF
--- a/cmd/plakar/subcommands/mount/mount_test.go
+++ b/cmd/plakar/subcommands/mount/mount_test.go
@@ -1,4 +1,5 @@
-//go:build linux || darwin
+//go:build linux
+
 package mount
 
 import (


### PR DESCRIPTION
* On macos/darwin mount needs a kext loaded, this is too much of a high entry barrier for tests. Let's disable the mount test on darwin.