### PR TITLE
vfs: add entry.MAC()

### DIFF
--- a/snapshot/synchronize.go
+++ b/snapshot/synchronize.go
@@ -186,8 +186,8 @@ func (src *Snapshot) Synchronize(dst *Snapshot) error {
 	})
 	dst.Header.GetSource(0).Indexes = []header.Index{
 		{
-			Name: "content-type",
-			Type: "btree",
+			Name:  "content-type",
+			Type:  "btree",
 			Value: ctsum,
 		},
 	}

--- a/snapshot/synchronize.go
+++ b/snapshot/synchronize.go
@@ -73,13 +73,12 @@ func persistVFS(src *Snapshot, dst *Snapshot, fs *vfs.Filesystem, ctidx *btree.B
 			}
 		}
 
-		serializedEntry, err := entry.ToBytes()
-		if err != nil {
-			return objects.MAC{}, err
-		}
-
-		entryMAC := dst.Repository().ComputeMAC(serializedEntry)
+		entryMAC := entry.MAC()
 		if !dst.BlobExists(resources.RT_VFS_ENTRY, entryMAC) {
+			serializedEntry, err := entry.ToBytes()
+			if err != nil {
+				return objects.MAC{}, err
+			}
 			err = dst.PutBlob(resources.RT_VFS_ENTRY, entryMAC, serializedEntry)
 			if err != nil {
 				return objects.MAC{}, err

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -55,6 +55,15 @@ type Entry struct {
 	Classifications []Classification `msgpack:"classifications,omitempty" json:"classifications"`
 	CustomMetadata  []CustomMetadata `msgpack:"custom_metadata,omitempty" json:"custom_metadata"`
 	Tags            []string         `msgpack:"tags,omitempty" json:"tags"`
+
+	// mac of the entry itself
+	mac objects.MAC
+}
+
+// MAC return the entry' MAC.  It only works for entries returned by
+// the VFS layer.
+func (e *Entry) MAC() objects.MAC {
+	return e.mac
 }
 
 func (e *Entry) HasObject() bool {

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -160,6 +160,8 @@ func (fsc *Filesystem) ResolveEntry(csum objects.MAC) (*Entry, error) {
 		return nil, err
 	}
 
+	entry.mac = csum
+
 	if entry.HasObject() {
 		rd, err := fsc.repo.GetBlob(resources.RT_OBJECT, entry.Object)
 		if err != nil {


### PR DESCRIPTION
Only works for entries returned by the VFS layer.