### PR TITLE
importer/sftp: remove bogus username/groupname lookup

### DIFF
--- a/snapshot/importer/sftp/walkdir.go
+++ b/snapshot/importer/sftp/walkdir.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 /*
  * Copyright (c) 2023 Gilles Chehade <gilles@poolp.org>
  *

--- a/snapshot/importer/sftp/walkdir.go
+++ b/snapshot/importer/sftp/walkdir.go
@@ -58,7 +58,7 @@ func (p *SFTPImporter) walkDir_addPrefixDirectories(jobs chan<- string, results 
 	directory := filepath.Clean(p.rootDir)
 	atoms := strings.Split(directory, string(os.PathSeparator))
 
-	for i := 0; i < len(atoms)-1; i++ {
+	for i := range len(atoms)-1 {
 		path := filepath.Join(atoms[0 : i+1]...)
 
 		if !strings.HasPrefix(path, "/") {


### PR DESCRIPTION
We'd need to fetch the *remote* names, not resolving them locally.  The library we're using doesn't expose this, and it actually seems a bit hard generally speaking in SFTP, so for now better axe this code than providing a wrong info.

While here also remove the `go:build` directive and "modernize" a loop so LSP is happy!