### PR TITLE
entry: Make the MAC a public member.

### DIFF
--- a/snapshot/check.go
+++ b/snapshot/check.go
@@ -24,7 +24,7 @@ func snapshotCheckPath(snap *Snapshot, opts *CheckOptions, concurrency chan bool
 			return err
 		}
 
-		entryMAC := e.MAC()
+		entryMAC := e.MAC
 		entryStatus, err := snap.checkCache.GetVFSEntryStatus(entryMAC)
 		if err != nil {
 			return err

--- a/snapshot/synchronize.go
+++ b/snapshot/synchronize.go
@@ -73,7 +73,7 @@ func persistVFS(src *Snapshot, dst *Snapshot, fs *vfs.Filesystem, ctidx *btree.B
 			}
 		}
 
-		entryMAC := entry.MAC()
+		entryMAC := entry.MAC
 		if !dst.BlobExists(resources.RT_VFS_ENTRY, entryMAC) {
 			serializedEntry, err := entry.ToBytes()
 			if err != nil {

--- a/snapshot/vfs/entry.go
+++ b/snapshot/vfs/entry.go
@@ -57,13 +57,7 @@ type Entry struct {
 	Tags            []string         `msgpack:"tags,omitempty" json:"tags"`
 
 	// mac of the entry itself
-	mac objects.MAC
-}
-
-// MAC return the entry' MAC.  It only works for entries returned by
-// the VFS layer.
-func (e *Entry) MAC() objects.MAC {
-	return e.mac
+	MAC objects.MAC `msgpack:"-" json:"mac"`
 }
 
 func (e *Entry) HasObject() bool {

--- a/snapshot/vfs/vfs.go
+++ b/snapshot/vfs/vfs.go
@@ -160,7 +160,7 @@ func (fsc *Filesystem) ResolveEntry(csum objects.MAC) (*Entry, error) {
 		return nil, err
 	}
 
-	entry.mac = csum
+	entry.MAC = csum
 
 	if entry.HasObject() {
 		rd, err := fsc.repo.GetBlob(resources.RT_OBJECT, entry.Object)


### PR DESCRIPTION
* The only accessor does nothing with it so no need for it to be private.

* We need it in the API so serialize it for json and omit it in msgpack to avoid recursing data structures!