### PR TITLE
add subcommand agent test

### DIFF
--- a/cmd/plakar/subcommands/agent/agent_test.go
+++ b/cmd/plakar/subcommands/agent/agent_test.go
@@ -111,7 +111,7 @@ func TestCmdAgentForegroundInit(t *testing.T) {
 		}
 	}()
 
-	client, err := agent.NewClient(filepath.Join(ctx.CacheDir, "agent.sock"))
+	client, err := agent.NewClient(filepath.Join(ctx.CacheDir, "agent.sock"), false)
 	require.NoError(t, err)
 	defer client.Close()
 


### PR DESCRIPTION
only test one command for now

couldn't test the daemonized version because of all the os.exit(0) used in the agent code causes a panic in tests each time they are called and the test stops his execution.