### PR TITLE
api: introduce a snapshot LRU cache

### DIFF
--- a/btree/btree.go
+++ b/btree/btree.go
@@ -102,7 +102,7 @@ func Deserialize[K any, P comparable, V any](rd io.Reader, store Storer[K, P, V]
 }
 
 func (b *BTree[K, P, V]) Close() error {
-	return b.cache.flushall()
+	return b.cache.Close()
 }
 
 func newNodeFrom[K any, P comparable, V any](keys []K, pointers []P, values []V) *Node[K, P, V] {
@@ -306,6 +306,6 @@ func (b *BTree[K, P, V]) insertUpwards(key K, ptr P, path []P) error {
 	return nil
 }
 
-func (b *BTree[K, P, V]) Stats() (hits, miss, size int) {
-	return b.cache.hits, b.cache.miss, b.cache.size
+func (b *BTree[K, P, V]) Stats() (hits, miss, size uint64) {
+	return b.cache.lru.Stats()
 }

--- a/btree/cache.go
+++ b/btree/cache.go
@@ -1,126 +1,53 @@
 package btree
 
-import "sync"
+import (
+	"github.com/PlakarKorp/plakar/caching/lru"
+)
 
-type item[K any, P comparable, V any] struct {
+type cacheitem[K any, P comparable, V any] struct {
 	dirty bool
 	node  *Node[K, P, V]
 }
 
-type lru[P comparable] struct {
-	ptr  P
-	next *lru[P]
-}
-
 type cache[K any, P comparable, V any] struct {
-	mtx sync.RWMutex
-
-	size   int
-	target int
-	store  Storer[K, P, V]
-	items  map[P]*item[K, P, V]
-	head   *lru[P]
-	tail   *lru[P]
-
-	hits int
-	miss int
+	store Storer[K, P, V]
+	lru   *lru.Cache[P, *cacheitem[K, P, V]]
 }
 
 func cachefor[K any, P comparable, V any](store Storer[K, P, V], order int) *cache[K, P, V] {
-	target := order
 	return &cache[K, P, V]{
-		target: target,
-		store:  store,
-		items:  make(map[P]*item[K, P, V], target),
+		store: store,
+		lru: lru.New(order, func(ptr P, n *cacheitem[K, P, V]) error {
+			return store.Update(ptr, n.node)
+		}),
 	}
-}
-
-func (c *cache[K, P, V]) cache(ptr P, node *Node[K, P, V]) {
-	c.size++
-	c.items[ptr] = &item[K, P, V]{node: node}
-	lru := &lru[P]{ptr: ptr}
-
-	if c.head == nil {
-		c.head = lru
-		c.tail = lru
-	} else {
-		c.tail.next = lru
-		c.tail = lru
-	}
-}
-
-func (c *cache[K, P, V]) flush(ptr P) error {
-	item := c.items[ptr]
-	if item.dirty {
-		if err := c.store.Update(ptr, item.node); err != nil {
-			return err
-		}
-	}
-
-	delete(c.items, ptr)
-	c.size--
-	return nil
 }
 
 func (c *cache[K, P, V]) Get(ptr P) (*Node[K, P, V], error) {
-	c.mtx.RLock()
-	item, ok := c.items[ptr]
-	c.mtx.RUnlock()
+	it, ok := c.lru.Get(ptr)
 	if ok {
-		c.hits++
-		return item.node, nil
+		return it.node, nil
 	}
-
-	c.miss++
 
 	node, err := c.store.Get(ptr)
 	if err != nil {
 		return nil, err
 	}
 
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	if item, ok := c.items[ptr]; ok {
-		return item.node, nil
+	if err := c.lru.Put(ptr, &cacheitem[K, P, V]{node: node}); err != nil {
+		return nil, err
 	}
-
-	if c.size == c.target {
-		if err := c.flush(c.head.ptr); err != nil {
-			return nil, err
-		}
-		c.head = c.head.next
-	}
-
-	c.cache(ptr, node)
 	return node, nil
 }
 
 func (c *cache[K, P, V]) Update(ptr P, node *Node[K, P, V]) error {
-	c.mtx.Lock()
-	if item, ok := c.items[ptr]; ok {
-		item.node = node
-		item.dirty = true
-		c.mtx.Unlock()
-		return nil
-	}
-	c.mtx.Unlock()
-
-	return c.store.Update(ptr, node)
+	return c.lru.Put(ptr, &cacheitem[K, P, V]{node: node, dirty: true})
 }
 
 func (c *cache[K, P, V]) Put(node *Node[K, P, V]) (P, error) {
 	return c.store.Put(node)
 }
 
-func (c *cache[K, P, V]) flushall() error {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	for el := c.head; el != nil; el = el.next {
-		if err := c.flush(el.ptr); err != nil {
-			return err
-		}
-	}
-	c.head = nil
-	c.tail = nil
-	return nil
+func (c *cache[K, P, V]) Close() error {
+	return c.lru.Close()
 }

--- a/caching/lru/lru.go
+++ b/caching/lru/lru.go
@@ -1,0 +1,116 @@
+package lru
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type node[K comparable] struct {
+	key  K
+	next *node[K]
+}
+
+type Cache[K comparable, V any] struct {
+	mtx sync.RWMutex
+
+	size   int
+	target int
+
+	onevict func(K, V) error
+
+	items map[K]V
+	head  *node[K]
+	tail  *node[K]
+
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+func New[K comparable, V any](target int, onevict func(K, V) error) *Cache[K, V] {
+	return &Cache[K, V]{
+		target: target,
+		onevict: onevict,
+		items: make(map[K]V, target),
+	}
+}
+
+func (c *Cache[K, V]) put(key K, val V) {
+	c.size++
+	c.items[key] = val
+
+	n := &node[K]{key: key}
+	if c.head == nil {
+		c.head = n
+		c.tail = n
+	} else {
+		c.tail.next = n
+		c.tail = n
+	}
+}
+
+// assume that the item was just removed from the linked list
+func (c *Cache[K, V]) flush(key K) error {
+	val := c.items[key]
+	if c.onevict != nil {
+		if err := c.onevict(key, val); err != nil {
+			return err
+		}
+	}
+
+	delete(c.items, key)
+	c.size--
+	return nil
+}
+
+func (c *Cache[K, V]) Get(key K) (V, bool) {
+	c.mtx.RLock()
+	val, ok := c.items[key]
+	c.mtx.RUnlock()
+
+	if ok {
+		c.hits.Add(1)
+	} else {
+		c.misses.Add(1)
+	}
+
+	return val, ok
+}
+
+// Put adds or overrides an element in the cache.
+func (c *Cache[K, V]) Put(key K, val V) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if _, ok := c.items[key]; ok {
+		c.items[key] = val
+		return nil
+	}
+
+	if c.size == c.target {
+		if err := c.flush(c.head.key); err != nil {
+			return err
+		}
+		c.head = c.head.next
+	}
+
+	c.put(key, val)
+	return nil
+}
+
+func (c *Cache[K, V]) Close() error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	var err error
+	for n := c.head; n != nil; n = n.next {
+		if e := c.flush(n.key); e != nil {
+			err = e
+		}
+	}
+	c.head = nil
+	c.tail = nil
+	return err
+}
+
+func (c *Cache[K, V]) Stats() (hit, miss, size uint64) {
+	return c.hits.Load(), c.misses.Load(), uint64(c.size)
+}


### PR DESCRIPTION
This moves the btree LRU node cache to a standalone package and reuses it in the APIs as well.