### PR TITLE
Fix plakar backup usage

### DIFF
--- a/cmd/plakar/subcommands/backup/backup.go
+++ b/cmd/plakar/subcommands/backup/backup.go
@@ -63,7 +63,7 @@ func parse_cmd_backup(ctx *appcontext.AppContext, args []string) (subcommands.Su
 	flags := flag.NewFlagSet("backup", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s [OPTIONS] path\n", flags.Name())
-		fmt.Fprintf(flags.Output(), "       %s [OPTIONS] s3://path\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "       %s [OPTIONS] @LOCATION\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")
 		flags.PrintDefaults()
 	}

--- a/cmd/plakar/subcommands/backup/plakar-backup.1
+++ b/cmd/plakar/subcommands/backup/plakar-backup.1
@@ -1,4 +1,4 @@
-.Dd March 3, 2025
+.Dd April 4, 2025
 .Dt PLAKAR-BACKUP 1
 .Os
 .Sh NAME
@@ -12,16 +12,21 @@
 .Op Fl check
 .Op Fl quiet
 .Op Fl tag Ar tag
-.Op Ar directory
+.Op Ar place
 .Sh DESCRIPTION
 The
 .Nm
 command creates a new snapshot of
-.Ar directory ,
-or the current directory,
-in a Plakar repository.
+.Ar place ,
+or the current directory.
 Snapshots can be filtered to exclude specific files or directories
 based on patterns provided through options.
+.Pp
+.Ar place
+can be either a path, an URI, or a label on the form
+.Dq @ Ns Ar name
+to reference a remote configured with
+.Xr plakar-config 1 .
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
@@ -68,4 +73,5 @@ An error occurred, such as failure to access the repository or issues
 with exclusion patterns.
 .El
 .Sh SEE ALSO
-.Xr plakar 1
+.Xr plakar 1 ,
+.Xr plakar-config 1

--- a/cmd/plakar/subcommands/help/docs/plakar-backup.md
+++ b/cmd/plakar/subcommands/help/docs/plakar-backup.md
@@ -13,18 +13,23 @@ PLAKAR-BACKUP(1) - General Commands Manual
 \[**-check**]
 \[**-quiet**]
 \[**-tag**&nbsp;*tag*]
-\[*directory*]
+\[*place*]
 
 # DESCRIPTION
 
 The
 **plakar backup**
 command creates a new snapshot of
-*directory*,
-or the current directory,
-in a Plakar repository.
+*place*,
+or the current directory.
 Snapshots can be filtered to exclude specific files or directories
 based on patterns provided through options.
+
+*place*
+can be either a path, an URI, or a label on the form
+"@*name*"
+to reference a remote configured with
+plakar-config(1).
 
 The options are as follows:
 
@@ -86,6 +91,7 @@ The **plakar backup** utility exits&#160;0 on success, and&#160;&gt;0 if an erro
 
 # SEE ALSO
 
-plakar(1)
+plakar(1),
+plakar-config(1)
 
-Plakar - March 3, 2025
+Plakar - April 4, 2025


### PR DESCRIPTION
The syntax `plakar backup s3://...` is not valid anymore. To backup a remote, you should use the @ syntax and configure the remote in ~/.config/plakar/plakar.yml.