### PR TITLE
btree/cache: actually respect the dirty flag

### DIFF
--- a/btree/cache.go
+++ b/btree/cache.go
@@ -18,6 +18,9 @@ func cachefor[K any, P comparable, V any](store Storer[K, P, V], order int) *cac
 	return &cache[K, P, V]{
 		store: store,
 		lru: lru.New(order, func(ptr P, n *cacheitem[K, P, V]) error {
+			if !n.dirty {
+				return nil
+			}
 			return store.Update(ptr, n.node)
 		}),
 	}


### PR DESCRIPTION
Don't write the node back to the underlying store when it's evicted from the cache if it's not dirty.  It's a waste of I/O at best and a violation of some read-only stores at worst.