### PR TITLE
backup: Provide a check cache if check is specified.

### DIFF
--- a/cmd/plakar/subcommands/backup/backup.go
+++ b/cmd/plakar/subcommands/backup/backup.go
@@ -228,6 +228,14 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 		}
 		defer checkSnap.Close()
 
+		checkCache, err := ctx.GetCache().Check()
+		if err != nil {
+			return 1, err
+		}
+		defer checkCache.Close()
+
+		checkSnap.SetCheckCache(checkCache)
+
 		ok, err := checkSnap.Check("/", checkOptions)
 		if err != nil {
 			return 1, fmt.Errorf("failed to check snapshot: %w", err)


### PR DESCRIPTION
* When backing up we allow the user to ask for a check of the just created snapshot. Our check code now uses a cache, so let's specify one here before running it otherwise it crashes.

* We could also make the check code work without cache, but there are benefits (speed benefits) to running with a cache, even for a single snap check.

* Crash reported by niluje@