### PR TITLE
use mime.TypeByExtension only as last resort

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -782,7 +782,6 @@ func (snap *Builder) chunkify(imp importer.Importer, cf *classifier.Classifier, 
 	defer rd.Close()
 
 	object := objects.NewObject()
-	object.ContentType = mime.TypeByExtension(path.Ext(record.Pathname))
 
 	objectHasher := snap.repository.GetMACHasher()
 
@@ -872,6 +871,10 @@ func (snap *Builder) chunkify(imp importer.Importer, cf *classifier.Classifier, 
 		object.Entropy = totalEntropy / float64(totalDataSize)
 	} else {
 		object.Entropy = 0.0
+	}
+
+	if object.ContentType == "" {
+		object.ContentType = mime.TypeByExtension(path.Ext(record.Pathname))
 	}
 
 	copy(object_t32[:], objectHasher.Sum(nil))


### PR DESCRIPTION
if we're chunkify the file anyway, it doesn't cost us much to do the magic check instead of relying on the extension alone.

This fixes, among other things, `go.mod` being reported as an audio file.

Since snapshots are immutable, this doesn't retroactively fix the content-type association.