### PR TITLE
ptar: Fix command line parsing.

### DIFF
--- a/cmd/plakar/subcommands/ptar/ptar.go
+++ b/cmd/plakar/subcommands/ptar/ptar.go
@@ -133,7 +133,7 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	cmd.SyncSrcSecret = peerSecret
 	cmd.SyncFrom = opt_sync
-	cmd.Location = flag.Args()
+	cmd.Location = flags.Args()
 
 	return nil
 }


### PR DESCRIPTION
* Another case of using flag.Args() which is the _global_ list of non flag args, not the one parsed by the specific command (which is in flags....)

* After this a quick grep show only occurences of flag.Args() in plakar.go which is legit.