### PR TITLE
backup: Remove a erroneous PutBlob(OBJECT)

### DIFF
--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -647,12 +647,6 @@ func (snap *Builder) processFileRecord(backupCtx *BackupContext, record *importe
 		}
 	}
 
-	if object != nil {
-		if err := snap.repository.PutBlobIfNotExists(resources.RT_OBJECT, objectMAC, objectSerialized); err != nil {
-			return err
-		}
-	}
-
 	// Chunkify the file if it is a regular file and we don't have a cached object
 	if record.FileInfo.Mode().IsRegular() {
 		if object == nil || !snap.repository.BlobExists(resources.RT_OBJECT, objectMAC) {


### PR DESCRIPTION
* Discussed with gilles@ and op@.

* This would lead to corruption in case of an aborted backup then doing it again. Because we would fetch the RT_OBJECT out of the VFS cache but then the first thing was putting it in the repository, therefore bypassing chunkify-cation of the object.