### PR TITLE
assorted command line fixes

### DIFF
--- a/cli/entrypoint.go
+++ b/cli/entrypoint.go
@@ -458,7 +458,7 @@ func EntryPoint() int {
 	}
 
 	var status int
-	if opt_agentless {
+	if opt_agentless || cmd.GetFlags() & subcommands.AgentSupport == 0 {
 		status, err = cmd.Execute(ctx, repo)
 	} else {
 		status, err = agent.ExecuteRPC(ctx, name, cmd, storeConfig)

--- a/cli/entrypoint.go
+++ b/cli/entrypoint.go
@@ -314,10 +314,15 @@ func EntryPoint() int {
 		return 1
 	}
 
-	command := args[0]
+	cmd, name, args := subcommands.Lookup(args)
+	if cmd == nil {
+		fmt.Fprintf(os.Stderr, "command not found: %s\n", args[0])
+		return 1
+	}
+	
 	// create is a special case, it operates without a repository...
 	// but needs a repository location to store the new repository
-	if command == "create" || command == "ptar" || command == "server" {
+	if cmd.GetFlags() & subcommands.BeforeRepositoryWithStorage != 0 {
 		repo, err := repository.Inexistent(ctx, storeConfig)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
@@ -325,11 +330,6 @@ func EntryPoint() int {
 		}
 		defer repo.Close()
 
-		cmd, _, args := subcommands.Lookup(args)
-		if cmd == nil {
-			fmt.Fprintf(os.Stderr, "command not found: %s\n", command)
-			return 1
-		}
 		if err := cmd.Parse(ctx, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 			return 1
@@ -343,12 +343,7 @@ func EntryPoint() int {
 	}
 
 	// these commands need to be ran before the repository is opened
-	if command == "agent" || command == "config" || command == "version" || command == "help" {
-		cmd, _, args := subcommands.Lookup(args)
-		if cmd == nil {
-			fmt.Fprintf(os.Stderr, "command not found: %s\n", command)
-			return 1
-		}
+	if cmd.GetFlags() & subcommands.BeforeRepositoryOpen != 0 {
 		if err := cmd.Parse(ctx, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 			return 1
@@ -452,11 +447,6 @@ func EntryPoint() int {
 
 	// commands below all operate on an open repository
 	t0 := time.Now()
-	cmd, name, args := subcommands.Lookup(args)
-	if cmd == nil {
-		fmt.Fprintf(os.Stderr, "command not found: %s\n", command)
-		return 1
-	}
 	if err := cmd.Parse(ctx, args); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 		return 1

--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"syscall"
 
@@ -45,7 +44,8 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &AgentStop{} }, subcommands.AgentSupport, "agent", "stop")
+	subcommands.Register(func() subcommands.Subcommand { return &AgentStop{} },
+		subcommands.AgentSupport|subcommands.IgnoreVersion, "agent", "stop")
 	subcommands.Register(func() subcommands.Subcommand { return &Agent{} }, 0, "agent")
 }
 
@@ -269,9 +269,6 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 				return
 			}
 			if err := encoder.Encode(ourvers); err != nil {
-				return
-			}
-			if !slices.Equal(clientvers, ourvers) {
 				return
 			}
 

--- a/cmd/plakar/subcommands/agent/plakar-agent.1
+++ b/cmd/plakar/subcommands/agent/plakar-agent.1
@@ -8,7 +8,7 @@
 .Nm
 .Op Fl foreground
 .Op Fl log Ar filename
-.Op Fl stop
+.Op Cm stop
 .Sh DESCRIPTION
 The
 .Nm
@@ -26,9 +26,13 @@ run in foreground.
 .It Fl log Ar filename
 Redirect all output to
 .Ar filename .
-.It Fl stop
-Terminate an agent running in the background.
 .El
+.Pp
+With the
+.Cm stop
+argument,
+.Nm
+will be stopped.
 .Sh DIAGNOSTICS
 .Ex -std
 .Bl -tag -width Ds

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -38,7 +38,7 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &Create{} }, 0, "create")
+	subcommands.Register(func() subcommands.Subcommand { return &Create{} }, subcommands.BeforeRepositoryWithStorage, "create")
 }
 
 func (cmd *Create) Parse(ctx *appcontext.AppContext, args []string) error {

--- a/cmd/plakar/subcommands/help/docs/plakar-agent.md
+++ b/cmd/plakar/subcommands/help/docs/plakar-agent.md
@@ -9,7 +9,7 @@ PLAKAR-AGENT(1) - General Commands Manual
 **plakar agent**
 \[**-foreground**]
 \[**-log**&nbsp;*filename*]
-\[**-stop**]
+\[**stop**]
 
 # DESCRIPTION
 
@@ -33,9 +33,11 @@ The options are as follows:
 > Redirect all output to
 > *filename*.
 
-**-stop**
-
-> Terminate an agent running in the background.
+With the
+**stop**
+argument,
+**plakar agent**
+will be stopped.
 
 # DIAGNOSTICS
 

--- a/cmd/plakar/subcommands/ptar/ptar.go
+++ b/cmd/plakar/subcommands/ptar/ptar.go
@@ -42,7 +42,7 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &Ptar{} }, subcommands.AgentSupport, "ptar")
+	subcommands.Register(func() subcommands.Subcommand { return &Ptar{} }, subcommands.BeforeRepositoryWithStorage, "ptar")
 }
 
 func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {

--- a/cmd/plakar/subcommands/server/server.go
+++ b/cmd/plakar/subcommands/server/server.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &Server{} }, subcommands.AgentSupport, "server")
+	subcommands.Register(func() subcommands.Subcommand { return &Server{} }, subcommands.BeforeRepositoryWithStorage, "server")
 }
 
 func (cmd *Server) Parse(ctx *appcontext.AppContext, args []string) error {

--- a/cmd/plakar/subcommands/subcommands.go
+++ b/cmd/plakar/subcommands/subcommands.go
@@ -18,6 +18,7 @@ const (
 	BeforeRepositoryWithStorage
 	BeforeRepositoryOpen
 	AgentSupport
+	IgnoreVersion
 )
 
 type Subcommand interface {

--- a/cmd/plakar/subcommands/subcommands.go
+++ b/cmd/plakar/subcommands/subcommands.go
@@ -15,6 +15,7 @@ type CommandFlags uint32
 
 const (
 	NeedRepositoryKey CommandFlags = 1 << iota
+	BeforeRepositoryWithStorage
 	BeforeRepositoryOpen
 	AgentSupport
 )
@@ -83,7 +84,7 @@ func Lookup(arguments []string) (Subcommand, []string, []string) {
 		return cmd, arguments[:subcmd.nargs], arguments[subcmd.nargs:]
 	}
 
-	return nil, nil, nil
+	return nil, nil, arguments
 }
 
 func List() []string {


### PR DESCRIPTION
* actually use the subcommands flags instead of special casing on the command name
* honour the AgentSupport flag
* change `agent -stop` into `agent stop` so that it can get properly registered
* make `agent stop` working across version bumps

`agent stop` is still issuing an `os.Exit`, this will be fixed afterwards, now the behaviour is the same as before the big cli overhaul.
