### PR TITLE
properly pass down the context and fix NewAppContextFrom

### DIFF
--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -306,6 +306,8 @@ func _TestSnapshotPathParam(t *testing.T) {
 		},
 	}
 
+	ctx := appcontext.NewAppContext()
+
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 
@@ -319,10 +321,9 @@ func _TestSnapshotPathParam(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
 
-			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("mock:///tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -28,6 +28,7 @@ func init() {
 
 // XXX: re-add once we move to non-mocked state object.
 func _Test_RepositoryConfiguration(t *testing.T) {
+	ctx := appcontext.NewAppContext()
 
 	config := ptesting.NewConfiguration()
 	serializedConfig, err := config.ToBytes()
@@ -38,10 +39,9 @@ func _Test_RepositoryConfiguration(t *testing.T) {
 	require.NoError(t, err)
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
-	lstore, err := storage.Create(map[string]string{"location": "mock:///test/location"}, wrappedConfig)
+	lstore, err := storage.Create(ctx, map[string]string{"location": "mock:///test/location"}, wrappedConfig)
 	require.NoError(t, err, "creating storage")
 
-	ctx := appcontext.NewAppContext()
 	cache := caching.NewManager("/tmp/test_plakar")
 	defer cache.Close()
 	ctx.SetCache(cache)
@@ -317,14 +317,14 @@ func _Test_RepositorySnapshots(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
@@ -416,14 +416,14 @@ func _Test_RepositorySnapshotsErrors(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
@@ -490,14 +490,14 @@ func _Test_RepositoryStates(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
@@ -558,14 +558,14 @@ func _Test_RepositoryState(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
@@ -631,14 +631,14 @@ func Test_RepositoryStateErrors(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -144,14 +144,14 @@ func _TestSnapshotHeader(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
@@ -217,14 +217,14 @@ func TestSnapshotHeaderErrors(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
@@ -275,14 +275,14 @@ func _TestSnapshotSign(t *testing.T) {
 			wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 			require.NoError(t, err)
 
-			lstore, err := storage.Create(map[string]string{"location": c.location}, wrappedConfig)
-			require.NoError(t, err, "creating storage")
-
 			ctx := appcontext.NewAppContext()
 			cache := caching.NewManager("/tmp/test_plakar")
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+			lstore, err := storage.Create(ctx, map[string]string{"location": c.location}, wrappedConfig)
+			require.NoError(t, err, "creating storage")
 			repo, err := repository.New(ctx, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -42,15 +42,14 @@ func TestAuthMiddleware(t *testing.T) {
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	lstore, err := storage.Create(map[string]string{"location": "mock:///test/location"}, wrappedConfig)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
 	ctx := appcontext.NewAppContext()
 	cache := caching.NewManager("/tmp/test_plakar")
 	defer cache.Close()
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+	lstore, err := storage.Create(ctx, map[string]string{"location": "mock:///test/location"}, wrappedConfig)
+	require.NoError(t, err)
 	repo, err := repository.New(ctx, lstore, wrappedConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -99,15 +98,14 @@ func Test_UnknownEndpoint(t *testing.T) {
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	lstore, err := storage.Create(map[string]string{"location": "mock:///test/location"}, wrappedConfig)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
 	ctx := appcontext.NewAppContext()
 	cache := caching.NewManager("/tmp/test_plakar")
 	defer cache.Close()
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
+
+	lstore, err := storage.Create(ctx, map[string]string{"location": "mock:///test/location"}, wrappedConfig)
+	require.NoError(t, err)
 	repo, err := repository.New(ctx, lstore, wrappedConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -14,12 +14,14 @@ import (
 )
 
 type AppContext struct {
-	events  *events.Receiver `msgpack:"-"`
-	cache   *caching.Manager `msgpack:"-"`
-	logger  *logging.Logger  `msgpack:"-"`
-	context context.Context  `msgpack:"-"`
-	secret  []byte           `msgpack:"-"`
-	Config  *config.Config   `msgpack:"-"`
+	events *events.Receiver `msgpack:"-"`
+	cache  *caching.Manager `msgpack:"-"`
+	logger *logging.Logger  `msgpack:"-"`
+	secret []byte           `msgpack:"-"`
+	Config *config.Config   `msgpack:"-"`
+
+	Context context.Context    `msgpack:"-"`
+	Cancel  context.CancelFunc `msgpack:"-"`
 
 	Stdout io.Writer `msgpack:"-"`
 	Stderr io.Writer `msgpack:"-"`
@@ -48,26 +50,35 @@ type AppContext struct {
 }
 
 func NewAppContext() *AppContext {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	return &AppContext{
 		events:  events.New(),
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
-		context: context.Background(),
+		Context: ctx,
+		Cancel:  cancel,
 	}
 }
 
 func NewAppContextFrom(template *AppContext) *AppContext {
-	ctx := NewAppContext()
-	events := ctx.events
-	*ctx = *template
-	ctx.SetCache(template.GetCache())
-	ctx.SetLogger(template.GetLogger())
-	ctx.events = events
-	return ctx
+	ctx := *template
+	ctx.events = events.New()
+	ctx.Context, ctx.Cancel = context.WithCancel(template.Context)
+	return &ctx
+}
+
+func (c *AppContext) Done() <-chan struct{} {
+	return c.Context.Done()
+}
+
+func (c *AppContext) Err() error {
+	return c.Context.Err()
 }
 
 func (c *AppContext) Close() {
 	c.events.Close()
+	c.Cancel()
 }
 
 func (c *AppContext) Events() *events.Receiver {
@@ -88,14 +99,6 @@ func (c *AppContext) SetLogger(logger *logging.Logger) {
 
 func (c *AppContext) GetLogger() *logging.Logger {
 	return c.logger
-}
-
-func (c *AppContext) SetContext(ctx context.Context) {
-	c.context = ctx
-}
-
-func (c *AppContext) GetContext() context.Context {
-	return c.context
 }
 
 func (c *AppContext) SetSecret(secret []byte) {

--- a/cmd/plakar/subcommands/agent/agent_test.go
+++ b/cmd/plakar/subcommands/agent/agent_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,10 +85,6 @@ func TestCmdAgentForegroundInit(t *testing.T) {
 
 	_, err = os.Stat(logFile)
 	require.NoError(t, err)
-
-	subCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx.SetContext(subCtx)
 
 	go func() {
 		defer func() {

--- a/cmd/plakar/subcommands/backup/backup_test.go
+++ b/cmd/plakar/subcommands/backup/backup_test.go
@@ -54,8 +54,10 @@ func generateFixtures(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) 
 	err = os.WriteFile(tmpBackupDir+"/another_subdir/bar", []byte("hello bar"), 0644)
 	require.NoError(t, err)
 
+	ctx := appcontext.NewAppContext()
+
 	// create a storage
-	r, err := bfs.NewStore(map[string]string{"location": "fs://" + tmpRepoDir})
+	r, err := bfs.NewStore(ctx, map[string]string{"location": "fs://" + tmpRepoDir})
 	require.NotNil(t, r)
 	require.NoError(t, err)
 	config := storage.NewConfiguration()
@@ -69,15 +71,14 @@ func generateFixtures(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) 
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	err = r.Create(wrappedConfig)
+	err = r.Create(ctx, wrappedConfig)
 	require.NoError(t, err)
 
 	// open the storage to load the configuration
-	r, serializedConfig, err := storage.Open(map[string]string{"location": "fs://" + tmpRepoDir})
+	r, serializedConfig, err := storage.Open(ctx, map[string]string{"location": "fs://" + tmpRepoDir})
 	require.NoError(t, err)
 
 	// create a repository
-	ctx := appcontext.NewAppContext()
 	cache := caching.NewManager(tmpCacheDir)
 	ctx.SetCache(cache)
 

--- a/cmd/plakar/subcommands/clone/clone.go
+++ b/cmd/plakar/subcommands/clone/clone.go
@@ -97,7 +97,7 @@ func (cmd *Clone) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 		return 1, err
 	}
 
-	cloneStore, err := storage.Create(storeConfig, wrappedSerializedConfig)
+	cloneStore, err := storage.Create(ctx, storeConfig, wrappedSerializedConfig)
 	if err != nil {
 		return 1, fmt.Errorf("could not create repository: %w", err)
 	}

--- a/cmd/plakar/subcommands/create/create.go
+++ b/cmd/plakar/subcommands/create/create.go
@@ -154,7 +154,7 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 		return 1, err
 	}
 
-	if err := repo.Store().Create(wrappedConfig); err != nil {
+	if err := repo.Store().Create(ctx, wrappedConfig); err != nil {
 		return 1, err
 	}
 

--- a/cmd/plakar/subcommands/help/help_test.go
+++ b/cmd/plakar/subcommands/help/help_test.go
@@ -55,8 +55,10 @@ func TestParseCmdHelpDefault(t *testing.T) {
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
+	ctx := appcontext.NewAppContext()
+
 	// create a storage
-	r, err := bfs.NewStore(map[string]string{"location": "fs://" + tmpRepoDir})
+	r, err := bfs.NewStore(ctx, map[string]string{"location": "fs://" + tmpRepoDir})
 	require.NotNil(t, r)
 	require.NoError(t, err)
 	config := storage.NewConfiguration()
@@ -70,15 +72,14 @@ func TestParseCmdHelpDefault(t *testing.T) {
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	err = r.Create(wrappedConfig)
+	err = r.Create(ctx, wrappedConfig)
 	require.NoError(t, err)
 
 	// open the storage to load the configuration
-	r, serializedConfig, err := storage.Open(map[string]string{"location": tmpRepoDir})
+	r, serializedConfig, err := storage.Open(ctx, map[string]string{"location": tmpRepoDir})
 	require.NoError(t, err)
 
 	// create a repository
-	ctx := appcontext.NewAppContext()
 	cache := caching.NewManager(tmpCacheDir)
 	ctx.SetCache(cache)
 
@@ -150,8 +151,10 @@ func TestParseCmdHelpCommand(t *testing.T) {
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
+	ctx := appcontext.NewAppContext()
+
 	// create a storage
-	r, err := bfs.NewStore(map[string]string{"location": "fs://" + tmpRepoDir})
+	r, err := bfs.NewStore(ctx, map[string]string{"location": "fs://" + tmpRepoDir})
 	require.NotNil(t, r)
 	require.NoError(t, err)
 	config := storage.NewConfiguration()
@@ -165,15 +168,14 @@ func TestParseCmdHelpCommand(t *testing.T) {
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	err = r.Create(wrappedConfig)
+	err = r.Create(ctx, wrappedConfig)
 	require.NoError(t, err)
 
 	// open the storage to load the configuration
-	r, serializedConfig, err := storage.Open(map[string]string{"location": tmpRepoDir})
+	r, serializedConfig, err := storage.Open(ctx, map[string]string{"location": tmpRepoDir})
 	require.NoError(t, err)
 
 	// create a repository
-	ctx := appcontext.NewAppContext()
 	cache := caching.NewManager(tmpCacheDir)
 	ctx.SetCache(cache)
 

--- a/cmd/plakar/subcommands/maintenance/maintenance.go
+++ b/cmd/plakar/subcommands/maintenance/maintenance.go
@@ -60,11 +60,10 @@ type Maintenance struct {
 
 // Builds the local cache of snapshot -> packfiles
 func (cmd *Maintenance) updateCache(ctx *appcontext.AppContext, cache *caching.MaintenanceCache) error {
-	wg, _ := errgroup.WithContext(ctx.GetContext())
+	wg, _ := errgroup.WithContext(ctx.Context)
 	wg.SetLimit(ctx.MaxConcurrency)
 
 	for snapshotID := range cmd.repository.ListSnapshots() {
-
 		wg.Go(func() error {
 			snapshot, err := snapshot.Load(cmd.repository, snapshotID)
 			if err != nil {

--- a/cmd/plakar/subcommands/mount/mount_test.go
+++ b/cmd/plakar/subcommands/mount/mount_test.go
@@ -4,7 +4,6 @@ package mount
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -41,16 +40,14 @@ func TestExecuteCmdMountDefault(t *testing.T) {
 	defer os.RemoveAll(tmpMountPoint)
 
 	ctx := repo.AppContext()
+	defer ctx.Close()
+
 	args := []string{tmpMountPoint}
 
 	subcommand := &Mount{}
 	err = subcommand.Parse(ctx, args)
 	require.NoError(t, err)
 	require.NotNil(t, subcommand)
-
-	subCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx.SetContext(subCtx)
 
 	go func() {
 		status, err := subcommand.Execute(ctx, repo)
@@ -85,7 +82,4 @@ func TestExecuteCmdMountDefault(t *testing.T) {
 	content, err := io.ReadAll(dummyFile)
 	require.NoError(t, err)
 	require.Equal(t, "hello dummy", string(content))
-
-	// Close the goroutine by canceling the context
-	cancel()
 }

--- a/cmd/plakar/subcommands/ptar/ptar.go
+++ b/cmd/plakar/subcommands/ptar/ptar.go
@@ -74,7 +74,7 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 			return fmt.Errorf("peer repository: %w", err)
 		}
 
-		peerStore, peerStoreSerializedConfig, err := storage.Open(storeConfig)
+		peerStore, peerStoreSerializedConfig, err := storage.Open(ctx, storeConfig)
 		if err != nil {
 			return err
 		}
@@ -231,7 +231,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, err
 	}
 
-	st, err := storage.Create(map[string]string{"location": repo.Location()}, wrappedConfig)
+	st, err := storage.Create(ctx, map[string]string{"location": repo.Location()}, wrappedConfig)
 	if err != nil {
 		return 1, err
 	}
@@ -254,7 +254,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 			return 1, fmt.Errorf("source repository: %w", err)
 		}
 
-		peerStore, peerStoreSerializedConfig, err := storage.Open(storeConfig)
+		peerStore, peerStoreSerializedConfig, err := storage.Open(ctx, storeConfig)
 		if err != nil {
 			return 1, fmt.Errorf("could not open source store %s: %s", cmd.SyncFrom, err)
 		}

--- a/cmd/plakar/subcommands/server/server_test.go
+++ b/cmd/plakar/subcommands/server/server_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -41,6 +40,8 @@ func TestExecuteCmdServerDefault(t *testing.T) {
 	snap.Close()
 
 	ctx := repo.AppContext()
+	defer ctx.Close()
+
 	args := []string{"-listen", "127.0.0.1:12345"}
 
 	subcommand := &Server{}
@@ -48,10 +49,6 @@ func TestExecuteCmdServerDefault(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, subcommand)
-
-	subCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx.SetContext(subCtx)
 
 	go func() {
 		status, err := subcommand.Execute(ctx, repo)

--- a/cmd/plakar/subcommands/sync/sync.go
+++ b/cmd/plakar/subcommands/sync/sync.go
@@ -77,7 +77,7 @@ func (cmd *Sync) Parse(ctx *appcontext.AppContext, args []string) error {
 		return fmt.Errorf("peer repository: %w", err)
 	}
 
-	peerStore, peerStoreSerializedConfig, err := storage.Open(storeConfig)
+	peerStore, peerStoreSerializedConfig, err := storage.Open(ctx, storeConfig)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, fmt.Errorf("peer repository: %w", err)
 	}
 
-	peerStore, peerStoreSerializedConfig, err := storage.Open(storeConfig)
+	peerStore, peerStoreSerializedConfig, err := storage.Open(ctx, storeConfig)
 	if err != nil {
 		return 1, fmt.Errorf("could not open peer store %s: %s", cmd.PeerRepositoryLocation, err)
 	}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -86,7 +86,7 @@ type Repository struct {
 }
 
 func Inexistent(ctx *appcontext.AppContext, storeConfig map[string]string) (*Repository, error) {
-	st, err := storage.New(storeConfig)
+	st, err := storage.New(ctx, storeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/server/httpd/httpd.go
+++ b/server/httpd/httpd.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/network"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/storage"
 )
 
 var store storage.Store
+var ctx *appcontext.AppContext
 var lNoDelete bool
 
 func openRepository(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +24,7 @@ func openRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	serializedConfig, err := store.Open()
+	serializedConfig, err := store.Open(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -322,6 +324,7 @@ func deleteLock(w http.ResponseWriter, r *http.Request) {
 func Server(repo *repository.Repository, addr string, noDelete bool) error {
 	lNoDelete = noDelete
 	store = repo.Store()
+	ctx = repo.AppContext()
 
 	http.HandleFunc("GET /", openRepository)
 

--- a/snapshot/backup.go
+++ b/snapshot/backup.go
@@ -572,7 +572,7 @@ func (snap *Builder) processFiles(backupCtx *BackupContext, filesChannel <-chan 
 	var wg sync.WaitGroup
 	semaphore := make(chan struct{}, backupCtx.maxConcurrency)
 
-	ctx := snap.AppContext().GetContext()
+	ctx := snap.AppContext()
 
 	for {
 		select {
@@ -775,8 +775,8 @@ func (snap *Builder) persistVFS(backupCtx *BackupContext) (*header.VFS, *vfs.Sum
 	diriter := backupCtx.scanCache.EnumerateKeysWithPrefix("__directory__:", true)
 	for dirPath, bytes := range diriter {
 		select {
-		case <-snap.AppContext().GetContext().Done():
-			return nil, nil, snap.AppContext().GetContext().Err()
+		case <-snap.AppContext().Done():
+			return nil, nil, snap.AppContext().Err()
 		default:
 		}
 

--- a/storage/backends/database/database.go
+++ b/storage/backends/database/database.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/storage"
@@ -46,7 +47,7 @@ func init() {
 	storage.Register(NewStore, "sqlite")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	return &Store{
 		location: storeConfig["location"],
 	}, nil
@@ -86,7 +87,7 @@ func (s *Store) connect(addr string) error {
 	return nil
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	err := s.connect(s.location)
 	if err != nil {
 		return err
@@ -145,7 +146,7 @@ func (s *Store) Create(config []byte) error {
 	return nil
 }
 
-func (s *Store) Open() ([]byte, error) {
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	err := s.connect(s.location)
 	if err != nil {
 		return nil, err

--- a/storage/backends/database/database_test.go
+++ b/storage/backends/database/database_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 	"github.com/stretchr/testify/require"
@@ -15,11 +16,14 @@ import (
 )
 
 func TestDatabaseBackend(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+
 	t.Cleanup(func() {
 		os.Remove("/tmp/testdb.db")
 	})
 	// create a repository
-	repo, err := NewStore(map[string]string{"location": "sqlite:///tmp/testdb.db"})
+	repo, err := NewStore(ctx, map[string]string{"location": "sqlite:///tmp/testdb.db"})
 	if err != nil {
 		t.Fatal("error creating repository", err)
 	}
@@ -31,10 +35,10 @@ func TestDatabaseBackend(t *testing.T) {
 	serializedConfig, err := config.ToBytes()
 	require.NoError(t, err)
 
-	err = repo.Create(serializedConfig)
+	err = repo.Create(ctx, serializedConfig)
 	require.NoError(t, err)
 
-	_, err = repo.Open()
+	_, err = repo.Open(ctx)
 	require.NoError(t, err)
 	//	require.Equal(t, repo.Configuration().Version, versioning.FromString(storage.VERSION))
 

--- a/storage/backends/fs/fs.go
+++ b/storage/backends/fs/fs.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/storage"
@@ -42,7 +43,7 @@ func init() {
 	storage.Register(NewStore, "fs")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	return &Store{
 		location: storeConfig["location"],
 	}, nil
@@ -62,7 +63,7 @@ func (s *Store) Path(args ...string) string {
 	return filepath.Join(args...)
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	dirfp, err := os.Open(s.Path())
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
@@ -102,8 +103,7 @@ func (s *Store) Create(config []byte) error {
 	return err
 }
 
-func (s *Store) Open() ([]byte, error) {
-
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	s.packfiles = NewBuckets(s.Path("packfiles"))
 	s.states = NewBuckets(s.Path("states"))
 

--- a/storage/backends/fs/fs_test.go
+++ b/storage/backends/fs/fs_test.go
@@ -6,17 +6,20 @@ import (
 	"os"
 	"testing"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFsBackend(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+
 	t.Cleanup(func() {
 		os.RemoveAll("/tmp/testfs")
 	})
 	// create a repository
-	repo, err := NewStore(map[string]string{"location": "fs:///tmp/testfs"})
+	repo, err := NewStore(ctx, map[string]string{"location": "fs:///tmp/testfs"})
 	if err != nil {
 		t.Fatal("error creating repository", err)
 	}
@@ -28,10 +31,10 @@ func TestFsBackend(t *testing.T) {
 	serialized, err := config.ToBytes()
 	require.NoError(t, err)
 
-	err = repo.Create(serialized)
+	err = repo.Create(ctx, serialized)
 	require.NoError(t, err)
 
-	_, err = repo.Open()
+	_, err = repo.Open(ctx)
 	require.NoError(t, err)
 	//require.Equal(t, repo.Configuration().Version, versioning.FromString(storage.VERSION))
 

--- a/storage/backends/http/client.go
+++ b/storage/backends/http/client.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/network"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
@@ -38,7 +39,7 @@ func init() {
 	storage.Register(NewStore, "http", "https")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	return &Store{
 		location: storeConfig["location"],
 	}, nil
@@ -62,11 +63,11 @@ func (s *Store) sendRequest(method string, requestType string, payload interface
 	return client.Do(req)
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	return nil
 }
 
-func (s *Store) Open() ([]byte, error) {
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	s.Repository = s.location
 	r, err := s.sendRequest("GET", "/", network.ReqOpen{
 		Repository: "",

--- a/storage/backends/http/client_test.go
+++ b/storage/backends/http/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/PlakarKorp/plakar/api"
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/network"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
@@ -223,8 +224,11 @@ func TestHttpBackend(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)
 
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+
 	// create a repository
-	repo, err := NewStore(map[string]string{"location": ts.URL})
+	repo, err := NewStore(ctx, map[string]string{"location": ts.URL})
 	if err != nil {
 		t.Fatal("error creating repository", err)
 	}
@@ -236,10 +240,10 @@ func TestHttpBackend(t *testing.T) {
 	serializedConfig, err := config.ToBytes()
 	require.NoError(t, err)
 
-	err = repo.Create(serializedConfig)
+	err = repo.Create(ctx, serializedConfig)
 	require.NoError(t, err)
 
-	_, err = repo.Open()
+	_, err = repo.Open(ctx)
 	require.NoError(t, err)
 	//require.Equal(t, repo.Configuration().Version, versioning.FromString(storage.VERSION))
 

--- a/storage/backends/null/null.go
+++ b/storage/backends/null/null.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 )
@@ -34,7 +35,7 @@ func init() {
 	// storage.Register(NewStore, "null")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	return &Store{
 		location: storeConfig["location"],
 	}, nil
@@ -44,12 +45,12 @@ func (s *Store) Location() string {
 	return s.location
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	s.config = config
 	return nil
 }
 
-func (s *Store) Open() ([]byte, error) {
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	return s.config, nil
 }
 

--- a/storage/backends/null/null_test.go
+++ b/storage/backends/null/null_test.go
@@ -5,14 +5,17 @@ import (
 	"io"
 	"testing"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNullBackend(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+
 	// create a repository
-	repo, err := NewStore(map[string]string{"location": "/test/location"})
+	repo, err := NewStore(ctx, map[string]string{"location": "/test/location"})
 	if err != nil {
 		t.Fatal("error creating repository", err)
 	}
@@ -24,10 +27,10 @@ func TestNullBackend(t *testing.T) {
 	serializedConfig, err := config.ToBytes()
 	require.NoError(t, err)
 
-	err = repo.Create(serializedConfig)
+	err = repo.Create(ctx, serializedConfig)
 	require.NoError(t, err)
 
-	_, err = repo.Open()
+	_, err = repo.Open(ctx)
 	require.NoError(t, err)
 	// only test one field
 	//require.Equal(t, repo.Configuration().Version, versioning.FromString(storage.VERSION))

--- a/storage/backends/ptar/ptar.go
+++ b/storage/backends/ptar/ptar.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 	"github.com/PlakarKorp/plakar/versioning"
@@ -55,7 +56,7 @@ func init() {
 	storage.Register(NewStore, "ptar")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	return &Store{
 		location: storeConfig["location"],
 	}, nil
@@ -65,7 +66,7 @@ func (s *Store) Location() string {
 	return s.location
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	s.config = config
 	s.mode = storage.ModeRead | storage.ModeWrite
 
@@ -94,7 +95,7 @@ func (s *Store) Create(config []byte) error {
 	return nil
 }
 
-func (s *Store) Open() ([]byte, error) {
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	s.mode = storage.ModeRead
 
 	location := strings.TrimPrefix(s.location, "ptar://")

--- a/storage/backends/ptar/ptar_test.go
+++ b/storage/backends/ptar/ptar_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 	"github.com/stretchr/testify/require"
@@ -23,8 +24,10 @@ func TestPtarBackend(t *testing.T) {
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
+	ctx := appcontext.NewAppContext()
+
 	// create a repository
-	repo, err := NewStore(map[string]string{"location": "ptar://" + tmpRepoDir})
+	repo, err := NewStore(ctx, map[string]string{"location": "ptar://" + tmpRepoDir})
 	if err != nil {
 		t.Fatal("error creating repository", err)
 	}
@@ -36,7 +39,7 @@ func TestPtarBackend(t *testing.T) {
 	serializedConfig, err := config.ToBytes()
 	require.NoError(t, err)
 
-	err = repo.Create(serializedConfig)
+	err = repo.Create(ctx, serializedConfig)
 	require.NoError(t, err)
 
 	// packfiles
@@ -84,7 +87,7 @@ func TestPtarBackend(t *testing.T) {
 	err = repo.Close()
 	require.NoError(t, err)
 
-	_, err = repo.Open()
+	_, err = repo.Open(ctx)
 	require.NoError(t, err)
 
 	states, err := repo.GetStates()
@@ -97,7 +100,7 @@ func TestPtarBackend(t *testing.T) {
 	err = repo.Close()
 	require.NoError(t, err)
 
-	_, err = repo.Open()
+	_, err = repo.Open(ctx)
 	require.NoError(t, err)
 
 	rd, err = repo.GetState(stateMAC)

--- a/storage/backends/s3/s3.go
+++ b/storage/backends/s3/s3.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/storage"
 
@@ -53,7 +54,7 @@ func init() {
 	storage.Register(NewStore, "s3")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	var accessKey string
 	if value, ok := storeConfig["access_key"]; !ok {
 		return nil, fmt.Errorf("missing access_key")
@@ -127,7 +128,7 @@ func (s *Store) connect(location *url.URL) error {
 	return nil
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	parsed, err := url.Parse(s.location)
 	if err != nil {
 		return fmt.Errorf("parse location: %w", err)
@@ -181,7 +182,7 @@ func (s *Store) Create(config []byte) error {
 	return nil
 }
 
-func (s *Store) Open() ([]byte, error) {
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	parsed, err := url.Parse(s.location)
 	if err != nil {
 		return nil, fmt.Errorf("parse location: %w", err)

--- a/storage/backends/sftp/sftp.go
+++ b/storage/backends/sftp/sftp.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
 	plakarsftp "github.com/PlakarKorp/plakar/sftp"
@@ -48,7 +49,7 @@ func init() {
 	storage.Register(NewStore, "sftp")
 }
 
-func NewStore(storeConfig map[string]string) (storage.Store, error) {
+func NewStore(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 	location := storeConfig["location"]
 	if location == "" {
 		return nil, fmt.Errorf("missing location")
@@ -88,7 +89,7 @@ func (s *Store) Path(args ...string) string {
 	return path.Join(args...)
 }
 
-func (s *Store) Create(config []byte) error {
+func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	client, err := plakarsftp.Connect(s.endpoint, s.config)
 	if err != nil {
 		return err
@@ -132,7 +133,7 @@ func (s *Store) Create(config []byte) error {
 	return err
 }
 
-func (s *Store) Open() ([]byte, error) {
+func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	client, err := plakarsftp.Connect(s.endpoint, s.config)
 	if err != nil {
 		return nil, err

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/snapshot/header"
 	"github.com/PlakarKorp/plakar/storage"
@@ -16,7 +17,7 @@ import (
 )
 
 func init() {
-	storage.Register(func(storeConfig map[string]string) (storage.Store, error) {
+	storage.Register(func(ctx *appcontext.AppContext, storeConfig map[string]string) (storage.Store, error) {
 		return &MockBackend{location: storeConfig["location"]}, nil
 	}, "mock")
 }
@@ -75,7 +76,7 @@ func NewMockBackend(storeConfig map[string]string) *MockBackend {
 	return &MockBackend{location: storeConfig["location"]}
 }
 
-func (mb *MockBackend) Create(configuration []byte) error {
+func (mb *MockBackend) Create(ctx *appcontext.AppContext, configuration []byte) error {
 	if strings.Contains(mb.location, "musterror") {
 		return errors.New("creating error")
 	}
@@ -98,7 +99,7 @@ func (mb *MockBackend) Create(configuration []byte) error {
 	return nil
 }
 
-func (mb *MockBackend) Open() ([]byte, error) {
+func (mb *MockBackend) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	if strings.Contains(mb.location, "musterror") {
 		return nil, errors.New("opening error")
 	}

--- a/testing/repository.go
+++ b/testing/repository.go
@@ -33,8 +33,10 @@ func GenerateRepository(t *testing.T, bufout *bytes.Buffer, buferr *bytes.Buffer
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
+	ctx := appcontext.NewAppContext()
+
 	// create a storage
-	r, err := bfs.NewStore(map[string]string{"location": "fs://" + tmpRepoDir})
+	r, err := bfs.NewStore(ctx, map[string]string{"location": "fs://" + tmpRepoDir})
 	require.NotNil(t, r)
 	require.NoError(t, err)
 	config := storage.NewConfiguration()
@@ -62,15 +64,14 @@ func GenerateRepository(t *testing.T, bufout *bytes.Buffer, buferr *bytes.Buffer
 	wrappedConfig, err := io.ReadAll(wrappedConfigRd)
 	require.NoError(t, err)
 
-	err = r.Create(wrappedConfig)
+	err = r.Create(ctx, wrappedConfig)
 	require.NoError(t, err)
 
 	// open the storage to load the configuration
-	r, serializedConfig, err := storage.Open(map[string]string{"location": tmpRepoDir})
+	r, serializedConfig, err := storage.Open(ctx, map[string]string{"location": tmpRepoDir})
 	require.NoError(t, err)
 
 	// create a repository
-	ctx := appcontext.NewAppContext()
 	ctx.MaxConcurrency = 1
 	if bufout != nil && buferr != nil {
 		ctx.Stdout = bufout
@@ -117,8 +118,11 @@ func GenerateRepositoryWithoutConfig(t *testing.T, bufout *bytes.Buffer, buferr 
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
+	ctx := appcontext.NewAppContext()
+	ctx.MaxConcurrency = 1
+
 	// create a storage
-	r, err := bfs.NewStore(map[string]string{"location": "fs://" + tmpRepoDir})
+	r, err := bfs.NewStore(ctx, map[string]string{"location": "fs://" + tmpRepoDir})
 	require.NotNil(t, r)
 	require.NoError(t, err)
 	config := storage.NewConfiguration()
@@ -130,8 +134,6 @@ func GenerateRepositoryWithoutConfig(t *testing.T, bufout *bytes.Buffer, buferr 
 	}
 
 	// create a repository
-	ctx := appcontext.NewAppContext()
-	ctx.MaxConcurrency = 1
 	if bufout != nil && buferr != nil {
 		ctx.Stdout = bufout
 		ctx.Stderr = buferr


### PR DESCRIPTION
While here, also get rid of a few new contexts that are not needed: only call NewAppContextFrom when we actually need a "checkpointing" cancellation context, e.g. a network connection, or when we have to set a different secret.

This will be helpful in handling interruptions in the agent.