### PR TITLE
cmd/backup: Provide the snapshot id created by the backup.

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -10,7 +10,6 @@ import (
 	"github.com/PlakarKorp/plakar/encryption/keypair"
 	"github.com/PlakarKorp/plakar/events"
 	"github.com/PlakarKorp/plakar/logging"
-	"github.com/PlakarKorp/plakar/objects"
 	"github.com/google/uuid"
 )
 
@@ -48,8 +47,6 @@ type AppContext struct {
 
 	Identity uuid.UUID
 	Keypair  *keypair.KeyPair
-
-	SnapshotID objects.MAC
 }
 
 func NewAppContext() *AppContext {

--- a/cmd/plakar/subcommands/backup/backup.go
+++ b/cmd/plakar/subcommands/backup/backup.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/cmd/plakar/subcommands"
+	"github.com/PlakarKorp/plakar/objects"
 	"github.com/PlakarKorp/plakar/repository"
 	"github.com/PlakarKorp/plakar/snapshot"
 	"github.com/PlakarKorp/plakar/snapshot/importer"
@@ -120,12 +121,16 @@ type Backup struct {
 }
 
 func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+	ret, err, _ := cmd.DoBackup(ctx, repo)
+	return ret, err
+}
+
+func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Repository) (int, error, objects.MAC) {
 	snap, err := snapshot.Create(repo, repository.DefaultType)
 	if err != nil {
 		ctx.GetLogger().Error("%s", err)
-		return 1, err
+		return 1, err, objects.MAC{}
 	}
-	ctx.SnapshotID = snap.Header.Identifier
 	defer snap.Close()
 
 	if cmd.Job != "" {
@@ -143,7 +148,7 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 	for _, item := range cmd.Excludes {
 		g, err := glob.Compile(item)
 		if err != nil {
-			return 1, fmt.Errorf("failed to compile exclude pattern: %s", item)
+			return 1, fmt.Errorf("failed to compile exclude pattern: %s", item), objects.MAC{}
 		}
 		excludes = append(excludes, g)
 	}
@@ -166,10 +171,10 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 	if strings.HasPrefix(scanDir, "@") {
 		remote, ok := ctx.Config.GetRemote(scanDir[1:])
 		if !ok {
-			return 1, fmt.Errorf("could not resolve importer: %s", scanDir)
+			return 1, fmt.Errorf("could not resolve importer: %s", scanDir), objects.MAC{}
 		}
 		if _, ok := remote["location"]; !ok {
-			return 1, fmt.Errorf("could not resolve importer location: %s", scanDir)
+			return 1, fmt.Errorf("could not resolve importer location: %s", scanDir), objects.MAC{}
 		} else {
 			importerConfig = remote
 		}
@@ -177,19 +182,19 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 
 	imp, err := importer.NewImporter(ctx, importerConfig)
 	if err != nil {
-		return 1, fmt.Errorf("failed to create an importer for %s: %s", scanDir, err)
+		return 1, fmt.Errorf("failed to create an importer for %s: %s", scanDir, err), objects.MAC{}
 	}
 	defer imp.Close()
 
 	if cmd.Silent {
 		if err := snap.Backup(imp, opts); err != nil {
-			return 1, fmt.Errorf("failed to create snapshot: %w", err)
+			return 1, fmt.Errorf("failed to create snapshot: %w", err), objects.MAC{}
 		}
 	} else {
 		ep := startEventsProcessor(ctx, imp.Root(), true, cmd.Quiet)
 		if err := snap.Backup(imp, opts); err != nil {
 			ep.Close()
-			return 1, fmt.Errorf("failed to create snapshot: %w", err)
+			return 1, fmt.Errorf("failed to create snapshot: %w", err), objects.MAC{}
 		}
 		ep.Close()
 	}
@@ -204,13 +209,13 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 
 		checkSnap, err := snapshot.Load(repo, snap.Header.Identifier)
 		if err != nil {
-			return 1, fmt.Errorf("failed to load snapshot: %w", err)
+			return 1, fmt.Errorf("failed to load snapshot: %w", err), objects.MAC{}
 		}
 		defer checkSnap.Close()
 
 		checkCache, err := ctx.GetCache().Check()
 		if err != nil {
-			return 1, err
+			return 1, err, objects.MAC{}
 		}
 		defer checkCache.Close()
 
@@ -218,10 +223,10 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 
 		ok, err := checkSnap.Check("/", checkOptions)
 		if err != nil {
-			return 1, fmt.Errorf("failed to check snapshot: %w", err)
+			return 1, fmt.Errorf("failed to check snapshot: %w", err), objects.MAC{}
 		}
 		if !ok {
-			return 1, fmt.Errorf("snapshot is not valid")
+			return 1, fmt.Errorf("snapshot is not valid"), objects.MAC{}
 		}
 	}
 
@@ -240,5 +245,5 @@ func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 		humanize.Bytes(uint64(snap.Repository().WBytes())),
 		savings,
 	)
-	return 0, nil
+	return 0, nil, snap.Header.Identifier
 }


### PR DESCRIPTION
* For now, as we still tap into the CMD for agent's scheduler, we need to access the snapshot id created out of the backup. To do this, as things usually go in computer, provide another layer of indirection to fix this. Introduce a Do function that returns the needed information, and wraps that in the CMD Execute() func. The scheduler can directly use the Do func.

* While here remove the snapshotID from AppContext, this can't work like this.