### PR TITLE
Potential fix for code scanning alert no. 70: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,9 @@
 #
 name: "CodeQL"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/PlakarKorp/plakar/security/code-scanning/70](https://github.com/PlakarKorp/plakar/security/code-scanning/70)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves analyzing code and does not require write access, we can set the permissions to `contents: read`. This ensures that the workflow has only the minimum required access to the repository contents.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added specifically to the `analyze` job if other jobs in the workflow require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
