### PR TITLE
attempt to please CodeQL in the less horrible way possible

### DIFF
--- a/storage/backends/fs/buckets.go
+++ b/storage/backends/fs/buckets.go
@@ -37,8 +37,7 @@ func NewBuckets(path string) Buckets {
 }
 
 func (buckets *Buckets) Create() error {
-
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		err := os.MkdirAll(filepath.Join(buckets.path, fmt.Sprintf("%02x", i)), 0700)
 		if err != nil {
 			return err


### PR DESCRIPTION
CodeQL is "smart" enough to find out that the MAC passed to, for e.g., buckets.Put might come from the http server, and so it's user controlled.  Great.  Except it completely misses the point that the MAC gets serialized in hex format and so it's only made up of [A-Z].  The constructed path can't escape buckets.path in any way.
