### PR TITLE
continue the check refactoring

### DIFF
--- a/cmd/plakar/subcommands/backup/backup.go
+++ b/cmd/plakar/subcommands/backup/backup.go
@@ -221,12 +221,8 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 
 		checkSnap.SetCheckCache(checkCache)
 
-		ok, err := checkSnap.Check("/", checkOptions)
-		if err != nil {
+		if err := checkSnap.Check("/", checkOptions); err != nil {
 			return 1, fmt.Errorf("failed to check snapshot: %w", err), objects.MAC{}, nil
-		}
-		if !ok {
-			return 1, fmt.Errorf("snapshot is not valid"), objects.MAC{}, nil
 		}
 	}
 

--- a/cmd/plakar/subcommands/check/check.go
+++ b/cmd/plakar/subcommands/check/check.go
@@ -143,10 +143,8 @@ func (cmd *Check) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 			}
 		}
 
-		if ok, err := snap.Check(pathname, opts); err != nil {
+		if err := snap.Check(pathname, opts); err != nil {
 			ctx.GetLogger().Warn("%s", err)
-			failures = true
-		} else if !ok {
 			failures = true
 		}
 

--- a/snapshot/check.go
+++ b/snapshot/check.go
@@ -143,11 +143,10 @@ func checkEntry(snap *Snapshot, opts *CheckOptions, entrypath string, e *vfs.Ent
 		return err
 	}
 	if entryStatus != nil {
-		if len(entryStatus) == 0 {
-			return nil
-		} else {
+		if len(entryStatus) != 0 {
 			return fmt.Errorf("%s", string(entryStatus))
 		}
+		return nil
 	}
 
 	snap.Event(events.PathEvent(snap.Header.Identifier, entrypath))

--- a/snapshot/check_test.go
+++ b/snapshot/check_test.go
@@ -25,9 +25,8 @@ func TestCheck(t *testing.T) {
 	}
 	require.NotEmpty(t, filepath)
 
-	checked, err := snap.Check(filepath, &snapshot.CheckOptions{
+	err = snap.Check(filepath, &snapshot.CheckOptions{
 		MaxConcurrency: 1,
 	})
 	require.NoError(t, err)
-	require.True(t, checked)
 }


### PR DESCRIPTION
This tidies the check code a bit more.  It also includes #918 as a side-effect of the changes, depending on what we decide to do for the release this might wait a bit, or i can rebase it and fix the trivial conflict when #918 will get in.