### PR TITLE
subcommands/agent: fix registration flags

### DIFF
--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -45,7 +45,8 @@ import (
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &AgentStop{} },
 		subcommands.AgentSupport|subcommands.IgnoreVersion, "agent", "stop")
-	subcommands.Register(func() subcommands.Subcommand { return &Agent{} }, 0, "agent")
+	subcommands.Register(func() subcommands.Subcommand { return &Agent{} },
+		subcommands.BeforeRepositoryOpen, "agent")
 }
 
 func daemonize(argv []string) error {


### PR DESCRIPTION
otherwise we try to open the default repository when running the agent which we shouldn't.