### PR TITLE
we know the size of the file we want to restore

### DIFF
--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -14,7 +14,7 @@ import (
 type Exporter interface {
 	Root() string
 	CreateDirectory(pathname string) error
-	StoreFile(pathname string, fp io.Reader) error
+	StoreFile(pathname string, fp io.Reader, size int64) error
 	SetPermissions(pathname string, fileinfo *objects.FileInfo) error
 	Close() error
 }

--- a/snapshot/exporter/exporter_test.go
+++ b/snapshot/exporter/exporter_test.go
@@ -19,7 +19,7 @@ func (m MockedExporter) CreateDirectory(pathname string) error {
 	return nil
 }
 
-func (m MockedExporter) StoreFile(pathname string, fp io.Reader) error {
+func (m MockedExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
 	return nil
 }
 

--- a/snapshot/exporter/fs/fs.go
+++ b/snapshot/exporter/fs/fs.go
@@ -56,7 +56,7 @@ func (p *FSExporter) CreateDirectory(pathname string) error {
 	return os.MkdirAll(pathname, 0700)
 }
 
-func (p *FSExporter) StoreFile(pathname string, fp io.Reader) error {
+func (p *FSExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
 	f, err := os.Create(pathname)
 	if err != nil {
 		return err

--- a/snapshot/exporter/fs/fs_test.go
+++ b/snapshot/exporter/fs/fs_test.go
@@ -31,14 +31,17 @@ func TestExporter(t *testing.T) {
 
 	require.Equal(t, tmpExportDir, exporterInstance.Root())
 
-	err = os.WriteFile(tmpOriginDir+"/dummy.txt", []byte("test exporter fs"), 0644)
+	data := []byte("test exporter fs")
+	datalen := int64(len(data))
+
+	err = os.WriteFile(tmpOriginDir+"/dummy.txt", data, 0644)
 	require.NoError(t, err)
 
 	fpOrigin, err := os.Open(tmpOriginDir + "/dummy.txt")
 	require.NoError(t, err)
 	defer fpOrigin.Close()
 
-	err = exporterInstance.StoreFile(tmpExportDir+"/dummy.txt", fpOrigin)
+	err = exporterInstance.StoreFile(tmpExportDir+"/dummy.txt", fpOrigin, datalen)
 	require.NoError(t, err)
 
 	fpExported, err := os.Open(tmpExportDir + "/dummy.txt")
@@ -48,7 +51,7 @@ func TestExporter(t *testing.T) {
 	newContent, err := io.ReadAll(fpExported)
 	require.NoError(t, err)
 
-	require.Equal(t, "test exporter fs", string(newContent))
+	require.Equal(t, string(data), string(newContent))
 
 	err = exporterInstance.CreateDirectory(tmpExportDir + "/subdir")
 	require.NoError(t, err)

--- a/snapshot/exporter/ftp/ftp.go
+++ b/snapshot/exporter/ftp/ftp.go
@@ -97,7 +97,7 @@ func (p *FTPExporter) CreateDirectory(pathname string) error {
 	return err
 }
 
-func (p *FTPExporter) StoreFile(pathname string, fp io.Reader) error {
+func (p *FTPExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
 	return p.client.Store(pathname, fp)
 }
 

--- a/snapshot/exporter/s3/s3.go
+++ b/snapshot/exporter/s3/s3.go
@@ -108,11 +108,11 @@ func (p *S3Exporter) CreateDirectory(pathname string) error {
 	return nil
 }
 
-func (p *S3Exporter) StoreFile(pathname string, fp io.Reader) error {
+func (p *S3Exporter) StoreFile(pathname string, fp io.Reader, size int64) error {
 	_, err := p.minioClient.PutObject(p.ctx,
 		strings.TrimPrefix(p.rootDir, "/"),
 		strings.TrimPrefix(pathname, p.rootDir+"/"),
-		fp, -1, minio.PutObjectOptions{})
+		fp, size, minio.PutObjectOptions{})
 	return err
 }
 

--- a/snapshot/exporter/s3/s3_test.go
+++ b/snapshot/exporter/s3/s3_test.go
@@ -36,15 +36,18 @@ func TestExporter(t *testing.T) {
 
 	require.Equal(t, "/bucket", exporterInstance.Root())
 
+	data := []byte("test exporter s3")
+	datalen := int64(len(data))
+
 	// create a temporary file to backup later
-	err = os.WriteFile(tmpOriginDir+"/dummy.txt", []byte("test exporter s3"), 0644)
+	err = os.WriteFile(tmpOriginDir+"/dummy.txt", data, 0644)
 	require.NoError(t, err)
 
 	fpOrigin, err := os.Open(tmpOriginDir + "/dummy.txt")
 	require.NoError(t, err)
 	defer fpOrigin.Close()
 
-	err = exporterInstance.StoreFile("dummy.txt", fpOrigin)
+	err = exporterInstance.StoreFile("dummy.txt", fpOrigin, datalen)
 	require.NoError(t, err)
 
 	err = exporterInstance.CreateDirectory("/bucket/subdir")

--- a/snapshot/exporter/sftp/sftp.go
+++ b/snapshot/exporter/sftp/sftp.go
@@ -67,7 +67,7 @@ func (p *SFTPExporter) CreateDirectory(pathname string) error {
 	return p.client.MkdirAll(pathname)
 }
 
-func (p *SFTPExporter) StoreFile(pathname string, fp io.Reader) error {
+func (p *SFTPExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
 	f, err := p.client.Create(pathname)
 	if err != nil {
 		return err

--- a/snapshot/exporter/stdio/stdio.go
+++ b/snapshot/exporter/stdio/stdio.go
@@ -65,7 +65,7 @@ func (p *StdioExporter) CreateDirectory(pathname string) error {
 	return nil
 }
 
-func (p *StdioExporter) StoreFile(pathname string, fp io.Reader) error {
+func (p *StdioExporter) StoreFile(pathname string, fp io.Reader, size int64) error {
 	_, err := io.Copy(p.w, fp)
 	return err
 }

--- a/snapshot/restore.go
+++ b/snapshot/restore.go
@@ -106,7 +106,7 @@ func snapshotRestorePath(snap *Snapshot, exp exporter.Exporter, target string, o
 			}
 
 			// Restore the file content.
-			if err := exp.StoreFile(dest, rd); err != nil {
+			if err := exp.StoreFile(dest, rd, e.Size()); err != nil {
 				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))
 			} else if err := exp.SetPermissions(dest, e.Stat()); err != nil {
 				snap.Event(events.FileErrorEvent(snap.Header.Identifier, entrypath, err.Error()))


### PR DESCRIPTION
the minio client will allocate excessive amounts of memory if the size of a file is unknown at push, ... however in Restore, we always know the size.