### PR TITLE
Fix UI URL

### DIFF
--- a/ui/v2/ui.go
+++ b/ui/v2/ui.go
@@ -92,7 +92,7 @@ func Ui(repo *repository.Repository, addr string, opts *UiOptions) error {
 	if opts.Token == "" {
 		url = fmt.Sprintf("http://%s", addr)
 	} else {
-		url = fmt.Sprintf("http://%s?token=%s", addr, opts.Token)
+		url = fmt.Sprintf("http://%s?plakar_token=%s", addr, opts.Token)
 	}
 
 	var err error


### PR DESCRIPTION
The token must now be provided in plakar_token to avoid conflicting with the token from api.plakar.io.