### PR TITLE
api/repository/info: remove omitempty for encryption and compression

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -59,8 +59,8 @@ type Configuration struct {
 	Packfile    packfile.Configuration     `json:"packfile"`
 	Chunking    chunking.Configuration     `json:"chunking"`
 	Hashing     hashing.Configuration      `json:"hashing"`
-	Compression *compression.Configuration `json:"compression,omitempty"`
-	Encryption  *encryption.Configuration  `json:"encryption,omitempty"`
+	Compression *compression.Configuration `json:"compression"`
+	Encryption  *encryption.Configuration  `json:"encryption"`
 }
 
 func NewConfiguration() *Configuration {


### PR DESCRIPTION
It makes more sense to return "null" when encryption and compression is disabled, rather than omitting the field.