### PR TITLE
s3 importer: fix directories creation

### DIFF
--- a/snapshot/importer/s3/s3.go
+++ b/snapshot/importer/s3/s3.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -152,7 +153,7 @@ func (p *S3Importer) scanRecursive(prefix string, result chan *importer.ScanResu
 		0,
 		0,
 	)
-	result <- importer.NewScanRecord("/"+prefix, "", fi, nil)
+	result <- importer.NewScanRecord(path.Clean("/"+prefix), "", fi, nil)
 }
 
 func (p *S3Importer) Scan() (<-chan *importer.ScanResult, error) {


### PR DESCRIPTION
Records created with importer.NewScanRecord should not contain a trailing slash in the path, otherwise the backup layer fails to retrieve the parent directory.