### PR TITLE
normalize locations to always carry <scheme>://<resource>

### DIFF
--- a/cmd/plakar/subcommands/ptar/ptar.go
+++ b/cmd/plakar/subcommands/ptar/ptar.go
@@ -231,7 +231,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, err
 	}
 
-	st, err := storage.Create(ctx, map[string]string{"location": "ptar://" + repo.Location()}, wrappedConfig)
+	st, err := storage.Create(ctx, map[string]string{"location": repo.Location()}, wrappedConfig)
 	if err != nil {
 		return 1, err
 	}

--- a/cmd/plakar/subcommands/sync/sync_test.go
+++ b/cmd/plakar/subcommands/sync/sync_test.go
@@ -105,7 +105,10 @@ func TestExecuteCmdSyncWithEncryption(t *testing.T) {
 	peerRepo := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
 
 	// need to recreate configuration to store passphrase on peer repo
-	opt_configfile := filepath.Join(peerRepo.Location(), "plakar.yml")
+	fmt.Println("peerRepo", peerRepo.Location())
+	opt_configfile := filepath.Join(strings.TrimPrefix(peerRepo.Location(), "fs://"), "plakar.yml")
+	fmt.Println("opt_configfile", opt_configfile)
+
 	cfg, err := config.LoadOrCreate(opt_configfile)
 	require.NoError(t, err)
 	ctx.Config = cfg

--- a/location/location.go
+++ b/location/location.go
@@ -58,10 +58,7 @@ func (l *Location[T]) Lookup(uri string) (proto, location string, item T, ok boo
 			if i != 0 && strings.HasPrefix(uri[i:], ":") {
 				proto = uri[:i]
 				location = uri[i+1:]
-
-				if strings.HasPrefix(location, "//") {
-					location = location[2:]
-				}
+				location = strings.TrimPrefix(location, "//")
 			}
 			break
 		}

--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -46,8 +46,8 @@ func NewExporter(ctx *appcontext.AppContext, config map[string]string) (Exporter
 
 	if proto == "fs" && !filepath.IsAbs(location) {
 		location = filepath.Join(ctx.CWD, location)
+		config["location"] = "fs://" + location
 	}
 
-	config["location"] = location
 	return backend(ctx, proto, config)
 }

--- a/snapshot/exporter/exporter.go
+++ b/snapshot/exporter/exporter.go
@@ -47,6 +47,8 @@ func NewExporter(ctx *appcontext.AppContext, config map[string]string) (Exporter
 	if proto == "fs" && !filepath.IsAbs(location) {
 		location = filepath.Join(ctx.CWD, location)
 		config["location"] = "fs://" + location
+	} else {
+		config["location"] = proto + "://" + location
 	}
 
 	return backend(ctx, proto, config)

--- a/snapshot/exporter/fs/fs.go
+++ b/snapshot/exporter/fs/fs.go
@@ -36,16 +36,8 @@ func init() {
 
 func NewFSExporter(appCtx *appcontext.AppContext, name string, config map[string]string) (exporter.Exporter, error) {
 	return &FSExporter{
-		rootDir: config["location"],
+		rootDir: strings.TrimPrefix(config["location"], "fs://"),
 	}, nil
-}
-
-func (p *FSExporter) Begin(config string) error {
-	if strings.HasPrefix(config, "fs://") {
-		config = config[4:]
-	}
-	p.rootDir = config // duplicate for now, config might change later
-	return nil
 }
 
 func (p *FSExporter) Root() string {

--- a/snapshot/exporter/ftp/ftp.go
+++ b/snapshot/exporter/ftp/ftp.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 func NewFTPExporter(appCtx *appcontext.AppContext, name string, config map[string]string) (exporter.Exporter, error) {
-	target := name + "://" + config["location"]
+	target := config["location"]
 
 	parsed, err := url.Parse(target)
 	if err != nil {

--- a/snapshot/exporter/s3/s3.go
+++ b/snapshot/exporter/s3/s3.go
@@ -52,7 +52,7 @@ func connect(location *url.URL, useSsl bool, accessKeyID, secretAccessKey string
 }
 
 func NewS3Exporter(ctx *appcontext.AppContext, name string, config map[string]string) (exporter.Exporter, error) {
-	target := name + "://" + config["location"]
+	target := config["location"]
 	var accessKey string
 	if tmp, ok := config["access_key"]; !ok {
 		return nil, fmt.Errorf("missing access_key")

--- a/snapshot/exporter/sftp/sftp.go
+++ b/snapshot/exporter/sftp/sftp.go
@@ -40,7 +40,7 @@ func init() {
 func NewSFTPExporter(appCtx *appcontext.AppContext, name string, config map[string]string) (exporter.Exporter, error) {
 	var err error
 
-	target := name + "://" + config["location"]
+	target := config["location"]
 
 	parsed, err := url.Parse(target)
 	if err != nil {

--- a/snapshot/exporter/stdio/stdio.go
+++ b/snapshot/exporter/stdio/stdio.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
@@ -50,7 +51,7 @@ func NewStdioExporter(appCtx *appcontext.AppContext, name string, config map[str
 	}
 
 	return &StdioExporter{
-		filePath: config["location"],
+		filePath: strings.TrimPrefix(config["location"], name+"://"),
 		appCtx:   appCtx,
 		w:        w,
 	}, nil

--- a/snapshot/importer/fs/fs.go
+++ b/snapshot/importer/fs/fs.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -48,16 +49,17 @@ func init() {
 
 func NewFSImporter(appCtx *appcontext.AppContext, name string, config map[string]string) (importer.Importer, error) {
 	location := config["location"]
+	rootDir := strings.TrimPrefix(location, "fs://")
 
-	if !path.IsAbs(location) {
+	if !path.IsAbs(rootDir) {
 		return nil, fmt.Errorf("not an absolute path %s", location)
 	}
 
-	location = path.Clean(location)
+	rootDir = path.Clean(rootDir)
 
 	return &FSImporter{
 		ctx:       appCtx,
-		rootDir:   location,
+		rootDir:   rootDir,
 		uidToName: make(map[uint64]string),
 		gidToName: make(map[uint64]string),
 	}, nil

--- a/snapshot/importer/ftp/ftp.go
+++ b/snapshot/importer/ftp/ftp.go
@@ -53,7 +53,7 @@ func connectToFTP(host, username, password string) (*goftp.Client, error) {
 }
 
 func NewFTPImporter(appCtx *appcontext.AppContext, name string, config map[string]string) (importer.Importer, error) {
-	target := name + "://" + config["location"]
+	target := config["location"]
 
 	parsed, err := url.Parse(target)
 	if err != nil {

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -90,9 +90,9 @@ func NewImporter(ctx *appcontext.AppContext, config map[string]string) (Importer
 
 	if proto == "fs" && !filepath.IsAbs(location) {
 		location = filepath.Join(ctx.CWD, location)
+		config["location"] = "fs://" + location
 	}
 
-	config["location"] = location
 	return backend(ctx, proto, config)
 }
 

--- a/snapshot/importer/importer.go
+++ b/snapshot/importer/importer.go
@@ -91,8 +91,9 @@ func NewImporter(ctx *appcontext.AppContext, config map[string]string) (Importer
 	if proto == "fs" && !filepath.IsAbs(location) {
 		location = filepath.Join(ctx.CWD, location)
 		config["location"] = "fs://" + location
+	} else {
+		config["location"] = proto + "://" + location
 	}
-
 	return backend(ctx, proto, config)
 }
 

--- a/snapshot/importer/s3/s3.go
+++ b/snapshot/importer/s3/s3.go
@@ -62,7 +62,7 @@ func connect(location *url.URL, useSsl bool, accessKeyID, secretAccessKey string
 }
 
 func NewS3Importer(ctx *appcontext.AppContext, name string, config map[string]string) (importer.Importer, error) {
-	target := name + "://" + config["location"]
+	target := config["location"]
 
 	var accessKey string
 	if tmp, ok := config["access_key"]; !ok {

--- a/snapshot/importer/s3/s3_test.go
+++ b/snapshot/importer/s3/s3_test.go
@@ -32,7 +32,7 @@ func TestS3Importer(t *testing.T) {
 	ts := httptest.NewServer(faker.Server())
 	defer ts.Close()
 
-	tmpImportBucket := ts.Listener.Addr().String() + "/bucket"
+	tmpImportBucket := "s3://" + ts.Listener.Addr().String() + "/bucket"
 
 	backend.CreateBucket("bucket")
 	_, err = backend.PutObject("bucket", "dummy.txt", nil, fpOrigin, 16)

--- a/snapshot/importer/sftp/sftp.go
+++ b/snapshot/importer/sftp/sftp.go
@@ -40,7 +40,7 @@ func init() {
 func NewSFTPImporter(appCtx *appcontext.AppContext, name string, config map[string]string) (importer.Importer, error) {
 	var err error
 
-	target := name + "://" + config["location"]
+	target := config["location"]
 
 	parsed, err := url.Parse(target)
 	if err != nil {

--- a/snapshot/importer/stdio/stdio.go
+++ b/snapshot/importer/stdio/stdio.go
@@ -42,6 +42,7 @@ func init() {
 
 func NewStdioImporter(appCtx *appcontext.AppContext, name string, config map[string]string) (importer.Importer, error) {
 	location := config["location"]
+	location = strings.TrimPrefix(location, "stdin://")
 	if !strings.HasPrefix(location, "/") {
 		location = "/" + location
 	}

--- a/storage/backends/fs/fs.go
+++ b/storage/backends/fs/fs.go
@@ -50,11 +50,11 @@ func NewStore(ctx *appcontext.AppContext, proto string, storeConfig map[string]s
 }
 
 func (s *Store) Location() string {
-	return strings.TrimPrefix(s.location, "fs://")
+	return s.location
 }
 
 func (s *Store) Path(args ...string) string {
-	root := s.Location()
+	root := strings.TrimPrefix(s.Location(), "fs://")
 
 	args = append(args, "")
 	copy(args[1:], args)

--- a/storage/backends/http/client.go
+++ b/storage/backends/http/client.go
@@ -41,7 +41,7 @@ func init() {
 
 func NewStore(ctx *appcontext.AppContext, proto string, storeConfig map[string]string) (storage.Store, error) {
 	return &Store{
-		location: proto + "://" + storeConfig["location"],
+		location: storeConfig["location"],
 	}, nil
 }
 

--- a/storage/backends/http/client_test.go
+++ b/storage/backends/http/client_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/PlakarKorp/plakar/api"
@@ -229,7 +228,7 @@ func TestHttpBackend(t *testing.T) {
 	defer ctx.Close()
 
 	// create a repository
-	repo, err := NewStore(ctx, "http", map[string]string{"location": strings.TrimPrefix(ts.URL, "http://")})
+	repo, err := NewStore(ctx, "http", map[string]string{"location": ts.URL})
 	if err != nil {
 		t.Fatal("error creating repository", err)
 	}

--- a/storage/backends/ptar/ptar.go
+++ b/storage/backends/ptar/ptar.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/objects"
@@ -69,7 +70,8 @@ func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 	s.config = config
 	s.mode = storage.ModeRead | storage.ModeWrite
 
-	fp, err := os.OpenFile(s.location, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+	location := strings.TrimPrefix(s.location, "ptar://")
+	fp, err := os.OpenFile(location, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return err
 	}
@@ -92,7 +94,8 @@ func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
 	s.mode = storage.ModeRead
 
-	fp, err := os.Open(s.location)
+	location := strings.TrimPrefix(s.location, "ptar://")
+	fp, err := os.Open(location)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/backends/s3/s3.go
+++ b/storage/backends/s3/s3.go
@@ -66,7 +66,7 @@ func connect(location *url.URL, useSsl bool, accessKeyID, secretAccessKey string
 }
 
 func NewStore(ctx *appcontext.AppContext, proto string, storeConfig map[string]string) (storage.Store, error) {
-	target := proto + "://" + storeConfig["location"]
+	target := storeConfig["location"]
 
 	var accessKey string
 	if value, ok := storeConfig["access_key"]; !ok {
@@ -114,7 +114,7 @@ func NewStore(ctx *appcontext.AppContext, proto string, storeConfig map[string]s
 	scanDir := path.Clean("/" + strings.Join(atoms[1:], "/"))
 
 	return &Store{
-		location:        proto + "://" + storeConfig["location"],
+		location:        storeConfig["location"],
 		accessKey:       accessKey,
 		secretAccessKey: secretAccessKey,
 		useSsl:          useSsl,

--- a/storage/backends/s3/s3_test.go
+++ b/storage/backends/s3/s3_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -28,7 +27,7 @@ func TestS3Backend(t *testing.T) {
 
 	// create a repository
 	repo, err := NewStore(ctx, "s3", map[string]string{
-		"location":          strings.TrimPrefix(ts.URL, "http://") + "/testbucket",
+		"location":          ts.URL + "/testbucket",
 		"access_key":        "",
 		"secret_access_key": "",
 		"use_tls":           "false",
@@ -39,7 +38,7 @@ func TestS3Backend(t *testing.T) {
 
 	location := repo.Location()
 	fmt.Println(location)
-	require.Equal(t, strings.Replace(ts.URL, "http", "s3", 1)+"/testbucket", location)
+	require.Equal(t, ts.URL+"/testbucket", location)
 
 	config := storage.NewConfiguration()
 	serializedConfig, err := config.ToBytes()

--- a/storage/backends/sftp/sftp.go
+++ b/storage/backends/sftp/sftp.go
@@ -55,7 +55,7 @@ func NewStore(ctx *appcontext.AppContext, proto string, storeConfig map[string]s
 		return nil, fmt.Errorf("missing location")
 	}
 
-	parsed, err := url.Parse(proto + "://" + location)
+	parsed, err := url.Parse(location)
 	if err != nil {
 		return nil, err
 	}
@@ -71,10 +71,7 @@ func (s *Store) Location() string {
 }
 
 func (s *Store) Path(args ...string) string {
-	root := s.Location()
-	if strings.HasPrefix(root, "sftp://") {
-		root = root[7:]
-	}
+	root := strings.TrimPrefix(s.Location(), "sftp://")
 	atoms := strings.Split(root, "/")
 	if len(atoms) == 0 {
 		return "/"

--- a/storage/backends/sqlite/sqlite.go
+++ b/storage/backends/sqlite/sqlite.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -54,10 +53,6 @@ func NewStore(ctx *appcontext.AppContext, proto string, storeConfig map[string]s
 	}
 
 	location := storeConfig["location"]
-	if !filepath.IsAbs(location) {
-		location = filepath.Join(ctx.CWD, location)
-	}
-
 	return &Store{
 		backend:  proto,
 		location: location,

--- a/storage/backends/sqlite/sqlite.go
+++ b/storage/backends/sqlite/sqlite.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -90,7 +91,8 @@ func (s *Store) connect(addr string) error {
 }
 
 func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
-	err := s.connect(s.location)
+	location := strings.TrimPrefix(s.location, "sqlite://")
+	err := s.connect(location)
 	if err != nil {
 		return err
 	}
@@ -149,7 +151,8 @@ func (s *Store) Create(ctx *appcontext.AppContext, config []byte) error {
 }
 
 func (s *Store) Open(ctx *appcontext.AppContext) ([]byte, error) {
-	err := s.connect(s.location)
+	location := strings.TrimPrefix(s.location, "sqlite://")
+	err := s.connect(location)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -172,8 +172,9 @@ func New(ctx *appcontext.AppContext, storeConfig map[string]string) (Store, erro
 	if proto == "fs" && !filepath.IsAbs(location) {
 		location = filepath.Join(ctx.CWD, location)
 		storeConfig["location"] = "fs://" + location
+	} else {
+		storeConfig["location"] = proto + "://" + location
 	}
-
 	return backend(ctx, proto, storeConfig)
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -171,9 +171,9 @@ func New(ctx *appcontext.AppContext, storeConfig map[string]string) (Store, erro
 
 	if proto == "fs" && !filepath.IsAbs(location) {
 		location = filepath.Join(ctx.CWD, location)
+		storeConfig["location"] = "fs://" + location
 	}
 
-	storeConfig["location"] = location
 	return backend(ctx, proto, storeConfig)
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -23,7 +23,7 @@ func TestNewStore(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if store.Location() != "/test/location" {
+	if store.Location() != "mock:///test/location" {
 		t.Errorf("expected location to be '/test/location', got %v", store.Location())
 	}
 
@@ -73,7 +73,7 @@ func TestOpenStore(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if store.Location() != "/test/location" {
+	if store.Location() != "mock:///test/location" {
 		t.Errorf("expected location to be '/test/location', got %v", store.Location())
 	}
 
@@ -129,7 +129,7 @@ func TestNew(t *testing.T) {
 				t.Fatalf("expected no error, got %v", err)
 			}
 
-			if store.Location() != "/test/location" {
+			if store.Location() != location {
 				t.Errorf("expected location to be '%s', got %v", location, store.Location())
 			}
 		})
@@ -158,7 +158,7 @@ func TestNew(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		if store.Location() != "dummy" {
+		if store.Location() != "fs://dummy" {
 			t.Errorf("expected location to be '%s', got %v", "dummy", store.Location())
 		}
 	})


### PR DESCRIPTION
when hitting a storage backend