### PR TITLE
Use a common execution path for all commands with a repository.

### DIFF
--- a/cli/entrypoint.go
+++ b/cli/entrypoint.go
@@ -422,11 +422,6 @@ func EntryPoint() int {
 		return 1
 	}
 
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
-		return 1
-	}
-
 	var status int
 	if opt_agentless || cmd.GetFlags()&subcommands.AgentSupport == 0 {
 		var lerr error

--- a/cli/entrypoint.go
+++ b/cli/entrypoint.go
@@ -431,16 +431,15 @@ func EntryPoint() int {
 			taskKind = "maintenance"
 		}
 
-		doReport := true
-		authToken, lerr := ctx.GetAuthToken(repo.Configuration().RepositoryID)
-		if lerr != nil || authToken == "" {
-			doReport = false
-		} else {
-			sc := services.NewServiceConnector(ctx, authToken)
-			if enabled, lerr := sc.GetServiceStatus("alerting"); lerr != nil {
-				doReport = false
-			} else if !enabled || taskKind == "" {
-				doReport = false
+		var doReport bool
+		if taskKind != "" {
+			authToken, err := ctx.GetAuthToken(repo.Configuration().RepositoryID)
+			if err == nil && authToken != "" {
+				sc := services.NewServiceConnector(ctx, authToken)
+				enabled, err := sc.GetServiceStatus("alerting")
+				if err == nil && enabled {
+					doReport = true
+				}
 			}
 		}
 

--- a/cli/entrypoint.go
+++ b/cli/entrypoint.go
@@ -378,7 +378,8 @@ func EntryPoint() int {
 			return 1
 		}
 	} else {
-		store, serializedConfig, err := storage.Open(ctx, storeConfig)
+		var serializedConfig []byte
+		store, serializedConfig, err = storage.Open(ctx, storeConfig)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: failed to open the repository at %s: %s\n", flag.CommandLine.Name(), storeConfig["location"], err)
 			fmt.Fprintln(os.Stderr, "To specify an alternative repository, please use \"plakar at <location> <command>\".")


### PR DESCRIPTION
Commands with the `BeforeRepositoryWithStorage` flag have their repository set up differently, but use the same exectution path as regular commands.
