### PR TITLE
make the stdin importer work in agent mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -122,6 +122,20 @@ func (c *Client) SendCommand(ctx *appcontext.AppContext, name []string, cmd subc
 			return 1, fmt.Errorf("failed to decode response: %w", err)
 		}
 		switch response.Type {
+		case "stdin":
+			var buf [1024]byte
+			n, err := os.Stdin.Read(buf[:])
+			pkt := &Packet{
+				Type: "stdin",
+				Data: buf[:n],
+			}
+			if err != nil {
+				pkt.Err = err.Error()
+			}
+			err = c.enc.Encode(pkt)
+			if err != nil {
+				return 1, fmt.Errorf("failed to send stdin: %w", err)
+			}
 		case "stdout":
 			fmt.Printf("%s", string(response.Data))
 		case "stderr":
@@ -142,6 +156,7 @@ func (c *Client) SendCommand(ctx *appcontext.AppContext, name []string, cmd subc
 	}
 	return 0, nil
 }
+
 func (c *Client) Close() error {
 	return c.conn.Close()
 }

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -28,6 +28,7 @@ type AppContext struct {
 
 	Stdout io.Writer `msgpack:"-"`
 	Stderr io.Writer `msgpack:"-"`
+	Stdin  io.Reader `msgpack:"-"`
 
 	NumCPU      int
 	Username    string
@@ -60,6 +61,7 @@ func NewAppContext() *AppContext {
 		events:  events.New(),
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
+		Stdin:   os.Stdin,
 		Context: ctx,
 		Cancel:  cancel,
 	}

--- a/snapshot/importer/stdio/stdio.go
+++ b/snapshot/importer/stdio/stdio.go
@@ -109,7 +109,7 @@ func (p *StdioImporter) Scan() (<-chan *importer.ScanResult, error) {
 }
 
 func (p *StdioImporter) NewReader(pathname string) (io.ReadCloser, error) {
-	return os.Stdin, nil
+	return io.NopCloser(p.appCtx.Stdin), nil
 }
 
 func (p *StdioImporter) NewExtendedAttributeReader(pathname string, attribute string) (io.ReadCloser, error) {


### PR DESCRIPTION
This augemnts the agent protocol so that the agent can request chunks from stdin from the client.  The AppContext then gains a new Stdin reader that transparently proxies the request to the client.

In the non-agent case, everything remains the same, we read directly from os.Stdin.

The tricky part is making sure that the EOF error is correctly propagated, but after the serialization we've lost the types, hence the not-so-pretty "EOF" string match.