### PR TITLE
s3: do not store the inode

### DIFF
--- a/snapshot/importer/s3/s3.go
+++ b/snapshot/importer/s3/s3.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -126,7 +125,7 @@ func (p *S3Importer) scanRecursive(prefix string, result chan *importer.ScanResu
 				0700,
 				object.LastModified,
 				1,
-				atomic.AddUint64(&p.ino, 1),
+				0,
 				0,
 				0,
 				0,
@@ -148,7 +147,7 @@ func (p *S3Importer) scanRecursive(prefix string, result chan *importer.ScanResu
 		0700|os.ModeDir,
 		time.Now(),
 		0,
-		atomic.AddUint64(&p.ino, 1),
+		0,
 		0,
 		0,
 		0,


### PR DESCRIPTION
The functions Equal and EqualIgnoreSize of objects/fileinfo.go consider two fileinfo structs as different if the inode number is different.

Since the importer generates an inode per file, in the case a second import has one more file in the middle of the import, all the subsequent files will have a different inode and won't be considered as being cached.

As an alternative, we could also stop comparing the inodes in Equal and EqualIgnoreSize.