### PR TITLE
agent: Disallow agent start with PLAKAR_AGENTLESS.

### DIFF
--- a/subcommands/agent/agent.go
+++ b/subcommands/agent/agent.go
@@ -93,6 +93,11 @@ func (cmd *Agent) Parse(ctx *appcontext.AppContext, args []string) error {
 	var opt_foreground bool
 	var opt_logfile string
 
+	_, envAgentLess := os.LookupEnv("PLAKAR_AGENTLESS")
+	if envAgentLess {
+		return fmt.Errorf("agent can not be start when PLAKAR_AGENTLESS is set")
+	}
+
 	flags := flag.NewFlagSet("agent", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s [OPTIONS]\n", flags.Name())


### PR DESCRIPTION
* This can lead to weird situation like having two agent processes, or failing to send commands (if you unset it after etc).

* It makes no sense anyway so prevent it.