### PR TITLE
Fail if extra arguments are given.

### DIFF
--- a/cmd/plakar/subcommands/agent/agent.go
+++ b/cmd/plakar/subcommands/agent/agent.go
@@ -104,6 +104,9 @@ func (cmd *Agent) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.BoolVar(&opt_foreground, "foreground", false, "run in foreground")
 	flags.StringVar(&opt_logfile, "log", "", "log file")
 	flags.Parse(args)
+	if flags.NArg() != 0 {
+		return fmt.Errorf("too many arguments")
+	}
 
 	if !opt_foreground && os.Getenv("REEXEC") == "" {
 		err := daemonize(os.Args)
@@ -157,6 +160,9 @@ func (cmd *AgentStop) Parse(ctx *appcontext.AppContext, args []string) error {
 		flags.PrintDefaults()
 	}
 	flags.Parse(args)
+	if flags.NArg() != 0 {
+		return fmt.Errorf("too many arguments")
+	}
 
 	return nil
 }
@@ -178,6 +184,9 @@ func (cmd *AgentRestart) Parse(ctx *appcontext.AppContext, args []string) error 
 		flags.PrintDefaults()
 	}
 	flags.Parse(args)
+	if flags.NArg() != 0 {
+		return fmt.Errorf("too many arguments")
+	}
 
 	return nil
 }

--- a/cmd/plakar/subcommands/agent/agent_tasks_configure.go
+++ b/cmd/plakar/subcommands/agent/agent_tasks_configure.go
@@ -30,6 +30,9 @@ func (cmd *AgentTasksConfigure) Parse(ctx *appcontext.AppContext, args []string)
 		flags.Usage()
 		return fmt.Errorf("no configuration file provided")
 	}
+	if flags.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
 
 	if configurationFile, err := filepath.Abs(flags.Arg(0)); err != nil {
 		return fmt.Errorf("failed to get absolute path for configuration file: %w", err)

--- a/cmd/plakar/subcommands/agent/agent_tasks_start.go
+++ b/cmd/plakar/subcommands/agent/agent_tasks_start.go
@@ -22,6 +22,9 @@ func (cmd *AgentTasksStart) Parse(ctx *appcontext.AppContext, args []string) err
 		flags.PrintDefaults()
 	}
 	flags.Parse(args)
+	if flags.NArg() != 0 {
+		return fmt.Errorf("too many arguments")
+	}
 
 	return nil
 }

--- a/cmd/plakar/subcommands/agent/agent_tasks_stop.go
+++ b/cmd/plakar/subcommands/agent/agent_tasks_stop.go
@@ -21,6 +21,9 @@ func (cmd *AgentTasksStop) Parse(ctx *appcontext.AppContext, args []string) erro
 		flags.PrintDefaults()
 	}
 	flags.Parse(args)
+	if flags.NArg() != 0 {
+		return fmt.Errorf("too many arguments")
+	}
 
 	return nil
 }


### PR DESCRIPTION
This fixes the case where running 'plakar agent tasks foobar' will actually try to start the agent.