### PR TITLE
storage/s3: Pool buffers for PutPackfile.

### DIFF
--- a/connectors/s3/storage/s3.go
+++ b/connectors/s3/storage/s3.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/storage"
@@ -46,6 +47,8 @@ type Store struct {
 	secretAccessKey string
 
 	storageClass string
+
+	bufPool sync.Pool
 
 	putObjectOptions minio.PutObjectOptions
 }
@@ -93,6 +96,12 @@ func NewStore(ctx context.Context, proto string, storeConfig map[string]string) 
 		useSsl:          useSsl,
 		storageClass:    storageClass,
 		ctx:             ctx,
+
+		bufPool: sync.Pool{
+			New: func() any {
+				return &bytes.Buffer{}
+			},
+		},
 
 		putObjectOptions: minio.PutObjectOptions{
 			// Some providers (eg. BlackBlaze) return the error
@@ -322,10 +331,19 @@ func (s *Store) GetPackfiles() ([]objects.MAC, error) {
 }
 
 func (s *Store) PutPackfile(mac objects.MAC, rd io.Reader) (int64, error) {
-	info, err := s.minioClient.PutObject(s.ctx, s.bucketName, s.realpath(fmt.Sprintf("packfiles/%02x/%016x", mac[0], mac)), rd, -1, s.putObjectOptions)
+	buf := s.bufPool.Get().(*bytes.Buffer)
+	copied, err := io.Copy(buf, rd)
+	if err != nil {
+		return 0, fmt.Errorf("read packfile: %w", err)
+	}
+
+	info, err := s.minioClient.PutObject(s.ctx, s.bucketName, s.realpath(fmt.Sprintf("packfiles/%02x/%016x", mac[0], mac)), buf, copied, s.putObjectOptions)
 	if err != nil {
 		return 0, fmt.Errorf("put object: %w", err)
 	}
+
+	buf.Reset()
+	s.bufPool.Put(buf)
 	return info.Size, nil
 }
 


### PR DESCRIPTION
* We were reported plakar getting OOM killed on somewhat medium sized backups done on a S3 repository. Turns out since we don't know the size of the file we PutObject, the library uses a default partition size of 512MB. Since we do up to at most 2*CPUs+1 PutPackfile at once, on machines with a lot of cores and relatively small memory we overcommit quickly.

* minio doesn't let you provide a "imprecise" size to better size the default buffer, so we do need to compute the size ourselves. In order to do that we go through a ByteBuffer and do the copy ourselves. It's always faster than them doing the multipart dance, and we can pool it too.