### PR TITLE
appcontext: move the secret in here

### DIFF
--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -328,7 +328,7 @@ func _TestSnapshotPathParam(t *testing.T) {
 			defer cache.Close()
 			ctx.SetCache(cache)
 			ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			req, err := http.NewRequest("GET", "/path/{id}", nil)

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -47,7 +47,7 @@ func _Test_RepositoryConfiguration(t *testing.T) {
 	defer cache.Close()
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
-	repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+	repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 	require.NoError(t, err, "creating repository")
 
 	cookies := cookies.NewManager("/tmp/test_plakar")
@@ -334,7 +334,7 @@ func _Test_RepositorySnapshots(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -437,7 +437,7 @@ func _Test_RepositorySnapshotsErrors(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -515,7 +515,7 @@ func _Test_RepositoryStates(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -587,7 +587,7 @@ func _Test_RepositoryState(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -664,7 +664,7 @@ func Test_RepositoryStateErrors(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -157,7 +157,7 @@ func _TestSnapshotHeader(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -234,7 +234,7 @@ func TestSnapshotHeaderErrors(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			var noToken string
@@ -296,7 +296,7 @@ func _TestSnapshotSign(t *testing.T) {
 
 			lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": c.location}, wrappedConfig)
 			require.NoError(t, err, "creating storage")
-			repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+			repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 			require.NoError(t, err, "creating repository")
 
 			token := "test-token"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -56,7 +56,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 	lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": "mock:///test/location"}, wrappedConfig)
 	require.NoError(t, err)
-	repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+	repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func Test_UnknownEndpoint(t *testing.T) {
 
 	lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": "mock:///test/location"}, wrappedConfig)
 	require.NoError(t, err)
-	repo, err := repository.New(ctx.GetInner(), lstore, wrappedConfig)
+	repo, err := repository.New(ctx.GetInner(), nil, lstore, wrappedConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -6,6 +6,7 @@ import (
 
 type AppContext struct {
 	*kcontext.KContext
+	secret []byte
 }
 
 func NewAppContext() *AppContext {
@@ -23,4 +24,12 @@ func NewAppContextFrom(ctx *AppContext) *AppContext {
 // XXX: This needs to go away progressively by migrating to AppContext.
 func (c *AppContext) GetInner() *kcontext.KContext {
 	return c.KContext
+}
+
+func (c *AppContext) SetSecret(secret []byte) {
+	c.secret = secret
+}
+
+func (c *AppContext) GetSecret() []byte {
+	return c.secret
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/PlakarKorp/plakar
 go 1.23.3
 
 require (
-	github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250526145617-18d82b8c39c4
+	github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250530091739-0e4edcea96e3
 	github.com/alecthomas/chroma v0.10.0
 	github.com/anacrolix/fuse v0.3.1
 	github.com/charmbracelet/bubbletea v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -5,12 +5,8 @@ github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5 h1:5BIUS5
 github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5/go.mod h1:w5D10RxC0NmPYxmQ438CC1S07zaC1zpvuNW7s5sUk2Q=
 github.com/PlakarKorp/go-cdc-chunkers v0.0.10 h1:3LlrN+0ElLIy3bBAxcX4DhgSaAmtDrBxY6m75tkYDJA=
 github.com/PlakarKorp/go-cdc-chunkers v0.0.10/go.mod h1:BfBmO/foiZaqX+Iet67EHnLcLeq9ymOnYJqWzR4b/o8=
-github.com/PlakarKorp/kloset v1.0.1-beta.1 h1:yMv3YdrLrS2rRwzd3bwIH5aQ8Y5ces551q8jLYsQBxk=
-github.com/PlakarKorp/kloset v1.0.1-beta.1/go.mod h1:9f9PmlmoqupYbEmhVItKVs0bGzFtU6XRIYVh1Vs99Pw=
-github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250523083307-fbb1208bc57f h1:xt8Q/r/cJvOD00Lq2C0LesYF5FAd8dkrHxiALGW4DsM=
-github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250523083307-fbb1208bc57f/go.mod h1:9f9PmlmoqupYbEmhVItKVs0bGzFtU6XRIYVh1Vs99Pw=
-github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250526145617-18d82b8c39c4 h1:GYYcQE0BSPFS9QQ//UmEFg94jkk3emH9bV9IVwmEEjU=
-github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250526145617-18d82b8c39c4/go.mod h1:9f9PmlmoqupYbEmhVItKVs0bGzFtU6XRIYVh1Vs99Pw=
+github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250530091739-0e4edcea96e3 h1:T6qbCbWPboD0GP/3snmlA+VaGlPXvnkC1WbKCcWI5Bs=
+github.com/PlakarKorp/kloset v1.0.1-beta.1.0.20250530091739-0e4edcea96e3/go.mod h1:9f9PmlmoqupYbEmhVItKVs0bGzFtU6XRIYVh1Vs99Pw=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f h1:JjxwchlOepwsUWcQwD2mLUAGE9aCp0/ehy6yCHFBOvo=
 github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f/go.mod h1:tMDTce/yLLN/SK8gMOxQfnyeMeCg8KGzp0D1cbECEeo=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/main.go
+++ b/main.go
@@ -398,13 +398,13 @@ func EntryPoint() int {
 		setupEncryption(ctx, repoConfig, storeConfig)
 
 		if opt_agentless {
-			repo, err = repository.New(ctx.GetInner(), store, serializedConfig)
+			repo, err = repository.New(ctx.GetInner(), ctx.GetSecret(), store, serializedConfig)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 				return 1
 			}
 		} else {
-			repo, err = repository.NewNoRebuild(ctx.GetInner(), store, serializedConfig)
+			repo, err = repository.NewNoRebuild(ctx.GetInner(), ctx.GetSecret(), store, serializedConfig)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 				return 1

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -53,7 +53,7 @@ func loadRepository(newCtx *appcontext.AppContext, name string) (*repository.Rep
 		newCtx.SetSecret(key)
 	}
 
-	repo, err := repository.New(newCtx.GetInner(), store, config)
+	repo, err := repository.New(newCtx.GetInner(), newCtx.GetSecret(), store, config)
 	if err != nil {
 		store.Close()
 		return nil, store, fmt.Errorf("unable to open repository: %w", err)

--- a/subcommands/agent/agent.go
+++ b/subcommands/agent/agent.go
@@ -453,7 +453,7 @@ func handleClient(ctx *appcontext.AppContext, wg *sync.WaitGroup, conn net.Conn)
 		}
 		defer store.Close()
 
-		repo, err = repository.New(clientContext.GetInner(), store, serializedConfig)
+		repo, err = repository.New(clientContext.GetInner(), clientContext.GetSecret(), store, serializedConfig)
 		if err != nil {
 			clientContext.GetLogger().Warn("Failed to open repository: %v", err)
 			fmt.Fprintf(clientContext.Stderr, "Failed to open repository: %s\n", err)

--- a/subcommands/backup/backup_test.go
+++ b/subcommands/backup/backup_test.go
@@ -93,7 +93,7 @@ func generateFixtures(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) 
 	logger.EnableInfo()
 	// logger.EnableTrace("all")
 	ctx.SetLogger(logger)
-	repo, err := repository.New(ctx.GetInner(), r, serializedConfig)
+	repo, err := repository.New(ctx.GetInner(), nil, r, serializedConfig)
 	require.NoError(t, err, "creating repository")
 
 	return repo, tmpBackupDir, ctx

--- a/subcommands/help/help_test.go
+++ b/subcommands/help/help_test.go
@@ -92,7 +92,7 @@ func TestParseCmdHelpDefault(t *testing.T) {
 	logger := logging.NewLogger(bytes.NewBuffer(nil), bytes.NewBuffer(nil))
 	logger.EnableInfo()
 	ctx.SetLogger(logger)
-	repo, err := repository.New(ctx.GetInner(), r, serializedConfig)
+	repo, err := repository.New(ctx.GetInner(), nil, r, serializedConfig)
 	// override the homedir to avoid having test overwriting existing home configuration
 	ctx.HomeDir = repo.Location()
 	args := []string{"-style", "notty"}
@@ -192,7 +192,7 @@ func TestParseCmdHelpCommand(t *testing.T) {
 	logger := logging.NewLogger(bytes.NewBuffer(nil), bytes.NewBuffer(nil))
 	logger.EnableInfo()
 	ctx.SetLogger(logger)
-	repo, err := repository.New(ctx.GetInner(), r, serializedConfig)
+	repo, err := repository.New(ctx.GetInner(), nil, r, serializedConfig)
 	// override the homedir to avoid having test overwriting existing home configuration
 	ctx.HomeDir = repo.Location()
 	args := []string{"-style", "notty", "version"}

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -117,7 +117,7 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 
 		peerCtx := appcontext.NewAppContextFrom(ctx)
 		peerCtx.SetSecret(peerSecret)
-		_, err = repository.NewNoRebuild(peerCtx.GetInner(), peerStore, peerStoreSerializedConfig)
+		_, err = repository.NewNoRebuild(peerCtx.GetInner(), peerCtx.GetSecret(), peerStore, peerStoreSerializedConfig)
 		if err != nil {
 			return err
 		}
@@ -236,7 +236,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, err
 	}
 
-	repo, err = repository.New(ctx.GetInner(), st, wrappedConfig)
+	repo, err = repository.New(ctx.GetInner(), ctx.GetSecret(), st, wrappedConfig)
 	if err != nil {
 		return 1, err
 	}
@@ -261,7 +261,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 
 		srcCtx := appcontext.NewAppContextFrom(ctx)
 		srcCtx.SetSecret(cmd.SyncSrcSecret)
-		srcRepository, err := repository.New(srcCtx.GetInner(), peerStore, peerStoreSerializedConfig)
+		srcRepository, err := repository.New(srcCtx.GetInner(), srcCtx.GetSecret(), peerStore, peerStoreSerializedConfig)
 		if err != nil {
 			return 1, fmt.Errorf("could not open source repository %s: %s", cmd.SyncFrom, err)
 		}

--- a/subcommands/sync/sync.go
+++ b/subcommands/sync/sync.go
@@ -121,7 +121,7 @@ func (cmd *Sync) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	peerCtx := appcontext.NewAppContextFrom(ctx)
 	peerCtx.SetSecret(peerSecret)
-	_, err = repository.NewNoRebuild(peerCtx.GetInner(), peerStore, peerStoreSerializedConfig)
+	_, err = repository.NewNoRebuild(peerCtx.GetInner(), peerCtx.GetSecret(), peerStore, peerStoreSerializedConfig)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 
 	peerCtx := appcontext.NewAppContextFrom(ctx)
 	peerCtx.SetSecret(cmd.PeerRepositorySecret)
-	peerRepository, err := repository.New(peerCtx.GetInner(), peerStore, peerStoreSerializedConfig)
+	peerRepository, err := repository.New(peerCtx.GetInner(), peerCtx.GetSecret(), peerStore, peerStoreSerializedConfig)
 	if err != nil {
 		return 1, fmt.Errorf("could not open peer repository %s: %s", cmd.PeerRepositoryLocation, err)
 	}

--- a/testing/repository.go
+++ b/testing/repository.go
@@ -102,7 +102,7 @@ func GenerateRepository(t *testing.T, bufout *bytes.Buffer, buferr *bytes.Buffer
 	}
 	// logger.EnableTrace("all")
 	ctx.SetLogger(logger)
-	repo, err := repository.New(ctx.GetInner(), r, serializedConfig)
+	repo, err := repository.New(ctx.GetInner(), key, r, serializedConfig)
 	require.NoError(t, err, "creating repository")
 
 	// override the homedir to avoid having test overwriting existing home configuration


### PR DESCRIPTION
kloset now takes the secrets in the Repository constructors instead of implicitly thru the kcontext.  To minimize the diff, move it in the appcontext for now.  Its lifetime may be shrunk in a follow-up.

kloset pr: https://github.com/PlakarKorp/kloset/pull/8