### PR TITLE
fix stdio importer options hostname

### DIFF
--- a/connectors/stdio/importer/stdio.go
+++ b/connectors/stdio/importer/stdio.go
@@ -52,6 +52,7 @@ func NewStdioImporter(appCtx context.Context, opts *importer.ImporterOptions, na
 		fileDir: location,
 		appCtx:  appCtx,
 		name:    name,
+		opts:    opts,
 	}, nil
 }
 


### PR DESCRIPTION
we have to store the options in the contructor, to prevent a panic with nil pointer when calling Origin