### PR TITLE
config command update

### DIFF
--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -20,8 +20,8 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/subcommands/agent"
 )
@@ -31,6 +31,10 @@ func init() {
 		subcommands.AgentSupport|subcommands.BeforeRepositoryOpen|subcommands.IgnoreVersion, "config", "reload")
 	subcommands.Register(func() subcommands.Subcommand { return &ConfigCmd{} },
 		subcommands.BeforeRepositoryOpen, "config")
+	subcommands.Register(func() subcommands.Subcommand { return &ConfigKlosetCmd{} },
+		subcommands.BeforeRepositoryOpen, "kloset")
+	subcommands.Register(func() subcommands.Subcommand { return &ConfigRemoteCmd{} },
+		subcommands.BeforeRepositoryOpen, "remote")
 }
 
 func (cmd *ConfigCmd) Parse(ctx *appcontext.AppContext, args []string) error {
@@ -53,137 +57,9 @@ type ConfigCmd struct {
 }
 
 func (cmd *ConfigCmd) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
-	if len(cmd.args) == 0 {
-		ctx.Config.Render(ctx.Stdout)
-		return 0, nil
+	if len(cmd.args) != 0 {
+		return 1, fmt.Errorf("config command takes no argument")
 	}
-
-	var err error
-	switch cmd.args[0] {
-	case "remote":
-		err = cmd_remote(ctx, cmd.args[1:])
-	case "repository", "repo":
-		err = cmd_repository(ctx, cmd.args[1:])
-	default:
-		err = fmt.Errorf("unknown subcommand %s", cmd.args[0])
-	}
-
-	if err != nil {
-		return 1, err
-	}
+	ctx.Config.Render(ctx.Stdout)
 	return 0, nil
-}
-
-func cmd_remote(ctx *appcontext.AppContext, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: plakar config remote [create | set | unset | validate]")
-	}
-
-	switch args[0] {
-	case "create":
-		if len(args) != 2 {
-			return fmt.Errorf("usage: plakar config remote create name")
-		}
-		name := args[1]
-		if ctx.Config.HasRemote(name) {
-			return fmt.Errorf("remote %q already exists", name)
-		}
-		ctx.Config.Remotes[name] = make(map[string]string)
-		return ctx.Config.Save()
-
-	case "set":
-		if len(args) != 4 {
-			return fmt.Errorf("usage: plakar config remote set name option value")
-		}
-		name, option, value := args[1], args[2], args[3]
-		if !ctx.Config.HasRemote(name) {
-			return fmt.Errorf("remote %q does not exists", name)
-		}
-		ctx.Config.Remotes[name][option] = value
-		return ctx.Config.Save()
-
-	case "unset":
-		if len(args) != 3 {
-			return fmt.Errorf("usage: plakar config remote unset name option")
-		}
-		name, option := args[1], args[2]
-		if !ctx.Config.HasRemote(name) {
-			return fmt.Errorf("remote %q does not exists", name)
-		}
-		delete(ctx.Config.Remotes[name], option)
-		return ctx.Config.Save()
-
-	case "validate":
-		if len(args) != 2 {
-			return fmt.Errorf("usage: plakar config remote validate name")
-		}
-		return fmt.Errorf("validation not implemented")
-
-	default:
-		return fmt.Errorf("usage: plakar config remote [create | set | unset | validate]")
-	}
-}
-
-func cmd_repository(ctx *appcontext.AppContext, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: plakar config repository [create | default | set | unset | validate]")
-	}
-
-	switch args[0] {
-	case "create":
-		if len(args) != 2 {
-			return fmt.Errorf("usage: plakar config repository create name")
-		}
-		name := args[1]
-		if ctx.Config.HasRepository(name) {
-			return fmt.Errorf("repository %q already exists", name)
-		}
-		ctx.Config.Repositories[name] = make(map[string]string)
-		return ctx.Config.Save()
-
-	case "default":
-		if len(args) != 2 {
-			return fmt.Errorf("usage: plakar config repository default name")
-		}
-		name := args[1]
-		if !ctx.Config.HasRepository(name) {
-			return fmt.Errorf("repository %q doesn't exist", name)
-		}
-		if _, ok := ctx.Config.Repositories[name]["location"]; !ok {
-			return fmt.Errorf("repository %q doesn't have a location set", name)
-		}
-		ctx.Config.DefaultRepository = name
-		return ctx.Config.Save()
-
-	case "set":
-		if len(args) != 4 {
-			return fmt.Errorf("usage: plakar config repository set name option value")
-		}
-		name, option, value := args[1], args[2], args[3]
-		if !ctx.Config.HasRepository(name) {
-			return fmt.Errorf("repository %q does not exists", name)
-		}
-		ctx.Config.Repositories[name][option] = value
-		return ctx.Config.Save()
-
-	case "unset":
-		if len(args) != 3 {
-			return fmt.Errorf("usage: plakar config repository unset name option")
-		}
-		name, option := args[1], args[2]
-		if !ctx.Config.HasRepository(name) {
-			return fmt.Errorf("repository %q does not exists", name)
-		}
-		delete(ctx.Config.Repositories[name], option)
-		return ctx.Config.Save()
-
-	case "validate":
-		if len(args) != 2 {
-			return fmt.Errorf("usage: plakar config repository validate name")
-		}
-		return fmt.Errorf("validation not implemented")
-
-	default:
-		return fmt.Errorf("usage: plakar config repository [create | default | set | unset | validate]")
-	}
 }

--- a/subcommands/config/kloset.go
+++ b/subcommands/config/kloset.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+)
+
+type ConfigKlosetCmd struct {
+	subcommands.SubcommandBase
+
+	args []string
+}
+
+func (cmd *ConfigKlosetCmd) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("remote", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintf(flags.Output(), "Usage: %s\n", flags.Name())
+		flags.PrintDefaults()
+	}
+
+	flags.Parse(args)
+	cmd.args = flags.Args()
+
+	return nil
+}
+
+func (cmd *ConfigKlosetCmd) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+
+	err := cmd_kloset_config(ctx, cmd.args)
+	if err != nil {
+		return 1, err
+	}
+	return 0, nil
+}
+
+func cmd_kloset_config(ctx *appcontext.AppContext, args []string) error {
+	usage := "usage: plakar kloset [create | default | set | unset | check]"
+	if len(args) == 0 {
+		return fmt.Errorf(usage)
+	}
+
+	switch args[0] {
+	case "create":
+		usage := "usage: plakar kloset create <name> <location> [<key>=<value>, ...]"
+		if len(args) < 3 {
+			return fmt.Errorf(usage)
+		}
+		name, location := args[1], args[2]
+		if ctx.Config.HasRepository(name) {
+			return fmt.Errorf("kloset %q already exists", name)
+		}
+		ctx.Config.Repositories[name] = make(map[string]string)
+		ctx.Config.Repositories[name]["location"] = location
+		for _, kv := range args[3:] {
+			key, val, found := strings.Cut(kv, "=")
+			if !found {
+				return fmt.Errorf(usage)
+			}
+			if key == "" {
+				return fmt.Errorf(usage)
+			}
+			ctx.Config.Repositories[name][key] = val
+		}
+		return ctx.Config.Save()
+
+	case "default":
+		usage := "usage: plakar kloset default <name>"
+		if len(args) != 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRepository(name) {
+			return fmt.Errorf("kloset %q does not exists", name)
+		}
+		ctx.Config.DefaultRepository = name
+		return ctx.Config.Save()
+
+	case "set":
+		usage := "usage: plakar kloset set <name> [<key>=<value>, ...]"
+		if len(args) < 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRepository(name) {
+			return fmt.Errorf("kloset %q does not exists", name)
+		}
+		for _, kv := range args[2:] {
+			key, val, found := strings.Cut(kv, "=")
+			if !found {
+				return fmt.Errorf(usage)
+			}
+			if key == "" {
+				return fmt.Errorf(usage)
+			}
+			ctx.Config.Repositories[name][key] = val
+		}
+		return ctx.Config.Save()
+
+	case "unset":
+		usage := "usage: plakar kloset unset <name> [<key>, ...]"
+		if len(args) < 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRepository(name) {
+			return fmt.Errorf("kloset %q does not exists", name)
+		}
+		for _, key := range args[2:] {
+			if key == "location" {
+				return fmt.Errorf("cannot unset location")
+			}
+			delete(ctx.Config.Repositories[name], key)
+		}
+		return ctx.Config.Save()
+
+	case "check":
+		usage := "usage: plakar kloset check <name>"
+		if len(args) != 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRepository(name) {
+			return fmt.Errorf("kloset %q does not exists", name)
+		}
+
+		return fmt.Errorf("check not implemented")
+
+	default:
+		return fmt.Errorf(usage)
+	}
+}

--- a/subcommands/config/plakar-config.1
+++ b/subcommands/config/plakar-config.1
@@ -3,98 +3,17 @@
 .Os
 .Sh NAME
 .Nm plakar config
-.Nd Manage Plakar configuration
+.Nd Display Plakar configuration
 .Sh SYNOPSIS
 .Nm
-.Op Cm remote | repository
+.Cm config
 .Sh DESCRIPTION
 The
 .Nm
-command manages configuration of the Plakar software.
-.Pp
-Without arguments show all the configuration options currently set on
-the repository.
-.Pp
-The subcommands are as follows:
-.Bl -tag -width Ds
-.It Cm remote
-Manage remotes configuration.
-The arguments are as follows:
-.Bl -tag -width Ds
-.It Cm create Ar name
-Create a new remote identified by
-.Ar name .
-.It Cm set Ar name option value
-Set the
-.Ar option
-to
-.Ar value
-for the remote identified by
-.Ar name .
-Different remotes have different options available.
-.It Cm unset Ar name option
-Remove the
-.Ar option
-for the remote identified by
-.Ar name .
-.It Cm validate Ar name
-Attempt to validate the configuration for the remote
-.Ar name
-to ensure whether it is working.
-.El
-.It Cm repository No or Cm repo
-Manage repositories configuration.
-The arguments are as follows:
-.Bl -tag -width Ds
-.It Cm create Ar name
-Create a new repository configuration for
-.Ar name .
-.It Cm default Ar name
-Set the repository identified by
-.Ar name
-as the default repository used by
-.Xr plakar 1 .
-.It Cm set Ar name option value
-Set the
-.Ar option
-to
-.Ar value
-for the repository identified by
-.Ar name .
-.It Cm unset Ar name option
-Remove the
-.Ar option
-for the repository
-.Ar name .
-.It Cm validate Ar name
-Attempt to validate the configuration for the repository
-.Ar name
-to ensure whether the parameters are correct.
-.El
-.El
-.Sh EXAMPLES
-Create a new repository configuration called
-.Dq nas
-that connects over SFTP:
-.Bd -literal -offset indent
-$ plakar config repository create nas
-$ plakar config repository set nas location sftp://mynas/var/plakar
-.Ed
-.Pp
-Perform a backup on the
-.Dq nas
-repository:
-.Bd -literal -offset indent
-$ plakar at @nas backup /var/www
-.Ed
-.Pp
-The set the
-.Dq nas
-repository as the default one:
-.Bd -literal -offset indent
-$ plakar config repository default nas
-.Ed
+command displays the configuration of the Plakar software.
 .Sh DIAGNOSTICS
 .Ex -std
 .Sh SEE ALSO
 .Xr plakar 1
+.Xr plakar-kloset 1
+.Xr plakar-remote 1

--- a/subcommands/config/plakar-kloset.1
+++ b/subcommands/config/plakar-kloset.1
@@ -1,0 +1,53 @@
+.Dd February 27, 2025
+.Dt PLAKAR-KLOSET 1
+.Os
+.Sh NAME
+.Nm plakar kloset
+.Nd Manage Plakar repository configurations
+.Sh SYNOPSIS
+.Nm
+.Cm kloset
+.Op subcommand ...
+.Sh DESCRIPTION
+The
+.Nm
+command manages configuration of the Plakar repository configurations.
+.Pp
+The subcommands are as follows:
+.Bl -tag -width Ds
+.It Cm create Ar name Ar location Op option=value ...
+Create a new repository identified by
+.Ar name
+with the specified
+.Ar location .
+Specific additional configuration parameters might be set by adding
+.Ar option=value
+entries.
+Different repositories have different options available.
+.Op key
+.It Cm set Ar name Op option=value ...
+Set the
+.Ar option
+to
+.Ar value
+for the repository identified by
+.Ar name .
+Different repositories have different options available.
+Multiple option/value pairs might be specified.
+.It Cm unset Ar name Op option ...
+Remove the
+.Ar option
+for the repository identified by
+.Ar name .
+.It Cm check Ar name
+Check wether the repository
+.Ar name
+is properly configured.
+.It Cm default Ar name
+Make the repository
+.Ar name
+the default one.
+.Sh DIAGNOSTICS
+.Ex -std
+.Sh SEE ALSO
+.Xr plakar 1

--- a/subcommands/config/plakar-remote.1
+++ b/subcommands/config/plakar-remote.1
@@ -1,0 +1,53 @@
+.Dd February 27, 2025
+.Dt PLAKAR-REMOTE 1
+.Os
+.Sh NAME
+.Nm plakar remote
+.Nd Manage Plakar remote repository configurations
+.Sh SYNOPSIS
+.Nm
+.Cm remote
+.Op subcommand ...
+.Sh DESCRIPTION
+The
+.Nm
+command manages configuration of the remote Plakar repository configurations.
+.Pp
+The subcommands are as follows:
+.Bl -tag -width Ds
+.It Cm create Ar name Ar location Op option=value ...
+Create a new remote identified by
+.Ar name
+with the specified
+.Ar location .
+Specific additional configuration parameters might be set by adding
+.Ar option=value
+entries.
+Different remotes have different options available.
+.Op key
+.It Cm set Ar name Op option=value ...
+Set the
+.Ar option
+to
+.Ar value
+for the remote identified by
+.Ar name .
+Different remotes have different options available.
+Multiple option/value pairs might be specified.
+.It Cm unset Ar name Op option ...
+Remove the
+.Ar option
+for the remote identified by
+.Ar name .
+.It Cm check Ar name
+Check wether the remote
+.Ar name
+is properly configured.
+.It Cm ping Ar name
+Attempt to contact the remote
+.Ar name
+to ensure it is reachable.
+.Sh DIAGNOSTICS
+.Ex -std
+.Sh SEE ALSO
+.Xr plakar 1

--- a/subcommands/config/remote.go
+++ b/subcommands/config/remote.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+)
+
+type ConfigRemoteCmd struct {
+	subcommands.SubcommandBase
+
+	args []string
+}
+
+func (cmd *ConfigRemoteCmd) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("remote", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintf(flags.Output(), "Usage: %s\n", flags.Name())
+		flags.PrintDefaults()
+	}
+
+	flags.Parse(args)
+	cmd.args = flags.Args()
+
+	return nil
+}
+
+func (cmd *ConfigRemoteCmd) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+
+	err := cmd_remote_config(ctx, cmd.args)
+	if err != nil {
+		return 1, err
+	}
+	return 0, nil
+}
+
+func cmd_remote_config(ctx *appcontext.AppContext, args []string) error {
+	usage := "usage: plakar remote [create | set | unset | check | ping]"
+	if len(args) == 0 {
+		return fmt.Errorf(usage)
+	}
+
+	switch args[0] {
+	case "create":
+		usage := "usage: plakar remote create <name> <location> [<key>=<value>, ...]"
+		if len(args) < 3 {
+			return fmt.Errorf(usage)
+		}
+		name, location := args[1], args[2]
+		if ctx.Config.HasRemote(name) {
+			return fmt.Errorf("remote %q already exists", name)
+		}
+		ctx.Config.Remotes[name] = make(map[string]string)
+		ctx.Config.Remotes[name]["location"] = location
+		for _, kv := range args[3:] {
+			key, val, found := strings.Cut(kv, "=")
+			if !found {
+				return fmt.Errorf(usage)
+			}
+			if key == "" {
+				return fmt.Errorf(usage)
+			}
+			ctx.Config.Remotes[name][key] = val
+		}
+		return ctx.Config.Save()
+
+	case "set":
+		usage := "usage: plakar remote set <name> [<key>=<value>, ...]"
+		if len(args) < 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRemote(name) {
+			return fmt.Errorf("remote %q does not exists", name)
+		}
+		for _, kv := range args[2:] {
+			key, val, found := strings.Cut(kv, "=")
+			if !found {
+				return fmt.Errorf(usage)
+			}
+			if key == "" {
+				return fmt.Errorf(usage)
+			}
+			ctx.Config.Remotes[name][key] = val
+		}
+		return ctx.Config.Save()
+
+	case "unset":
+		usage := "usage: plakar remote unset <name> [<key>, ...]"
+		if len(args) < 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRemote(name) {
+			return fmt.Errorf("remote %q does not exists", name)
+		}
+		for _, key := range args[2:] {
+			if key == "location" {
+				return fmt.Errorf("cannot unset location")
+			}
+			delete(ctx.Config.Remotes[name], key)
+		}
+		return ctx.Config.Save()
+
+	case "check":
+		usage := "usage: plakar remote check <name>"
+		if len(args) != 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRemote(name) {
+			return fmt.Errorf("remote %q does not exists", name)
+		}
+
+		return fmt.Errorf("check not implemented")
+
+	case "ping":
+		usage := "usage: plakar remote ping <name>"
+		if len(args) != 2 {
+			return fmt.Errorf(usage)
+		}
+		name := args[1]
+		if !ctx.Config.HasRemote(name) {
+			return fmt.Errorf("remote %q does not exists", name)
+		}
+
+		return fmt.Errorf("ping not implemented")
+
+	default:
+		return fmt.Errorf(usage)
+	}
+}


### PR DESCRIPTION
Change `plakar config repo` and `plakar config remote` to `plakar kloset` and `plakar remote`.

Make the location mandatory on the create command, and allow to specify additionnal options on the command line.
