### PR TITLE
fix some path vs filepath usage

### DIFF
--- a/connectors/fs/importer/fs.go
+++ b/connectors/fs/importer/fs.go
@@ -22,7 +22,6 @@ import (
 	"io/fs"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -52,11 +51,11 @@ func NewFSImporter(appCtx context.Context, opts *importer.Options, name string, 
 	location := config["location"]
 	rootDir := strings.TrimPrefix(location, "fs://")
 
-	if !path.IsAbs(rootDir) {
+	if !filepath.IsAbs(rootDir) {
 		return nil, fmt.Errorf("not an absolute path %s", location)
 	}
 
-	rootDir = path.Clean(rootDir)
+	rootDir = filepath.Clean(rootDir)
 
 	nocrossfs, _ := strconv.ParseBool(config["dont_traverse_fs"])
 

--- a/connectors/ftp/importer/ftp.go
+++ b/connectors/ftp/importer/ftp.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -77,7 +77,7 @@ func (p *FTPImporter) ftpWalker_worker(jobs <-chan string, results chan<- *impor
 
 		fileinfo := objects.FileInfoFromStat(info)
 
-		results <- importer.NewScanRecord(filepath.ToSlash(path), "", fileinfo, nil,
+		results <- importer.NewScanRecord(path, "", fileinfo, nil,
 			func() (io.ReadCloser, error) { return p.NewReader(path) })
 
 		// Handle symlinks separately
@@ -87,17 +87,17 @@ func (p *FTPImporter) ftpWalker_worker(jobs <-chan string, results chan<- *impor
 				results <- importer.NewScanError(path, err)
 				continue
 			}
-			results <- importer.NewScanRecord(filepath.ToSlash(path), originFile, fileinfo, nil, nil)
+			results <- importer.NewScanRecord(path, originFile, fileinfo, nil, nil)
 		}
 	}
 }
 
 func (p *FTPImporter) ftpWalker_addPrefixDirectories(jobs chan<- string, results chan<- *importer.ScanResult) {
-	directory := filepath.Clean(p.rootDir)
+	directory := path.Clean(p.rootDir)
 	atoms := strings.Split(directory, string(os.PathSeparator))
 
 	for i := 0; i < len(atoms); i++ {
-		path := filepath.Join(atoms[0 : i+1]...)
+		path := path.Join(atoms[0 : i+1]...)
 
 		if !strings.HasPrefix(path, "/") {
 			path = "/" + path
@@ -122,7 +122,7 @@ func (p *FTPImporter) walkDir(root string, results chan<- string, wg *sync.WaitG
 	}
 
 	for _, entry := range entries {
-		entryPath := filepath.Join(root, entry.Name())
+		entryPath := path.Join(root, entry.Name())
 
 		// Send the current entry to the results channel
 		results <- entryPath

--- a/connectors/s3/importer/s3.go
+++ b/connectors/s3/importer/s3.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -98,7 +97,7 @@ func NewS3Importer(ctx context.Context, opts *importer.Options, name string, con
 
 	atoms := strings.Split(parsed.RequestURI()[1:], "/")
 	bucket := atoms[0]
-	scanDir := filepath.Clean("/" + strings.Join(atoms[1:], "/"))
+	scanDir := path.Clean("/" + strings.Join(atoms[1:], "/"))
 
 	return &S3Importer{
 		bucket:      bucket,

--- a/connectors/sftp/importer/walkdir.go
+++ b/connectors/sftp/importer/walkdir.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -50,18 +49,18 @@ func (p *SFTPImporter) walkDir_worker(jobs <-chan string, results chan<- *import
 				continue
 			}
 		}
-		results <- importer.NewScanRecord(filepath.ToSlash(path), originFile, fileinfo, []string{},
+		results <- importer.NewScanRecord(path, originFile, fileinfo, []string{},
 			func() (io.ReadCloser, error) { return p.client.Open(path) })
 	}
 }
 
 func (p *SFTPImporter) walkDir_addPrefixDirectories(jobs chan<- string, results chan<- *importer.ScanResult) {
 	// Clean the directory and split the path into components
-	directory := filepath.Clean(p.rootDir)
+	directory := path.Clean(p.rootDir)
 	atoms := strings.Split(directory, string(os.PathSeparator))
 
 	for i := range len(atoms) - 1 {
-		path := filepath.Join(atoms[0 : i+1]...)
+		path := path.Join(atoms[0 : i+1]...)
 
 		if !strings.HasPrefix(path, "/") {
 			path = "/" + path
@@ -103,8 +102,8 @@ func (p *SFTPImporter) walkDir_walker(numWorkers int) (<-chan *importer.ScanResu
 				return
 			}
 
-			if !filepath.IsAbs(originFile) {
-				originFile = filepath.Join(filepath.Dir(p.rootDir), originFile)
+			if !path.IsAbs(originFile) {
+				originFile = path.Join(path.Dir(p.rootDir), originFile)
 			}
 			jobs <- p.rootDir
 			p.rootDir = originFile

--- a/connectors/sftp/storage/sftp.go
+++ b/connectors/sftp/storage/sftp.go
@@ -26,7 +26,6 @@ import (
 	"io/fs"
 	"net/url"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/PlakarKorp/kloset/objects"
@@ -241,11 +240,11 @@ func (s *Store) GetLocks() (ret []objects.MAC, err error) {
 }
 
 func (s *Store) PutLock(lockID objects.MAC, rd io.Reader) (int64, error) {
-	return WriteToFileAtomicTempDir(s.client, filepath.Join(s.Path("locks"), hex.EncodeToString(lockID[:])), rd, s.Path(""))
+	return WriteToFileAtomicTempDir(s.client, path.Join(s.Path("locks"), hex.EncodeToString(lockID[:])), rd, s.Path(""))
 }
 
 func (s *Store) GetLock(lockID objects.MAC) (io.Reader, error) {
-	fp, err := s.client.Open(filepath.Join(s.Path("locks"), hex.EncodeToString(lockID[:])))
+	fp, err := s.client.Open(path.Join(s.Path("locks"), hex.EncodeToString(lockID[:])))
 	if err != nil {
 		return nil, err
 	}
@@ -254,5 +253,5 @@ func (s *Store) GetLock(lockID objects.MAC) (io.Reader, error) {
 }
 
 func (s *Store) DeleteLock(lockID objects.MAC) error {
-	return s.client.Remove(filepath.Join(s.Path("locks"), hex.EncodeToString(lockID[:])))
+	return s.client.Remove(path.Join(s.Path("locks"), hex.EncodeToString(lockID[:])))
 }

--- a/connectors/sftp/storage/utils.go
+++ b/connectors/sftp/storage/utils.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"path/filepath"
+	"path"
 
 	"github.com/pkg/sftp"
 )
@@ -84,7 +84,7 @@ func ClosingLimitedReaderFromOffset(file *sftp.File, offset, length int64) (io.R
 }
 
 func WriteToFileAtomic(sftpClient *sftp.Client, filename string, rd io.Reader) (int64, error) {
-	return WriteToFileAtomicTempDir(sftpClient, filename, rd, filepath.Dir(filename))
+	return WriteToFileAtomicTempDir(sftpClient, filename, rd, path.Dir(filename))
 }
 
 func WriteToFileAtomicTempDir(sftpClient *sftp.Client, filename string, rd io.Reader, tmpdir string) (int64, error) {

--- a/connectors/stdio/importer/stdio.go
+++ b/connectors/stdio/importer/stdio.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -59,11 +58,11 @@ func NewStdioImporter(ctx context.Context, opts *importer.Options, name string, 
 }
 
 func (p *StdioImporter) stdioWalker_addPrefixDirectories(results chan<- *importer.ScanResult) {
-	directory := filepath.Clean(p.fileDir)
+	directory := path.Clean(p.fileDir)
 	atoms := strings.Split(directory, string(os.PathSeparator))
 
 	for i := 0; i < len(atoms)-1; i++ {
-		subpath := filepath.Join(atoms[0 : i+1]...)
+		subpath := path.Join(atoms[0 : i+1]...)
 
 		if !strings.HasPrefix(subpath, "/") {
 			subpath = "/" + subpath


### PR DESCRIPTION
path is used to deal with UNIX-like paths, for e.g. URLs (stretching it a bit but still), while filepath is for the *local* operating system path format.

So, stick with path for remotes like (s)ftp and stdin, while the local fs has to use filepath.