### PR TITLE
for auto-generated paths, prefix "fs:"

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,10 +28,10 @@ import (
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/PlakarKorp/plakar/agent"
 	"github.com/PlakarKorp/plakar/appcontext"
+	_ "github.com/PlakarKorp/plakar/plugins"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/task"
 	"github.com/PlakarKorp/plakar/utils"
-	_ "github.com/PlakarKorp/plakar/plugins"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/google/uuid"
 
@@ -164,7 +164,7 @@ func EntryPoint() int {
 	defer ctx.Close()
 
 	// err = plugins.LoadBackends(ctx.Context, filepath.Join(configDir, "plugins"))
-	// if err != nil {	
+	// if err != nil {
 	// 	fmt.Fprintf(os.Stderr, "%s: could not load plugins: %s\n", flag.CommandLine.Name(), err)
 	// 	return 1
 	// }

--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func EntryPoint() int {
 			if def != "" {
 				repositoryPath = "@" + def
 			} else {
-				repositoryPath = filepath.Join(ctx.HomeDir, ".plakar")
+				repositoryPath = "fs:" + filepath.Join(ctx.HomeDir, ".plakar")
 			}
 		}
 

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -160,7 +160,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		Excludes:       excludes,
 	}
 
-	scanDir := ctx.CWD
+	scanDir := "fs:" + ctx.CWD
 	if cmd.Path != "" {
 		scanDir = cmd.Path
 	}


### PR DESCRIPTION
This is meant to help with windows, where a path like "C:\Users\Omar\" might be mistaken for a remote with "C" protocol.

What to exactly do in the command line when a user types the full path with the device included is still to solve.