### PR TITLE
avoid a cross-device rename

### DIFF
--- a/subcommands/config/config_test.go
+++ b/subcommands/config/config_test.go
@@ -26,6 +26,7 @@ func TestConfigEmpty(t *testing.T) {
 	cfg, err := utils.LoadOldConfigIfExists(configPath)
 	require.NoError(t, err)
 	ctx := appcontext.NewAppContext()
+	ctx.ConfigDir = tmpDir
 	ctx.Config = cfg
 	ctx.Stdout = bufOut
 	ctx.Stderr = bufErr
@@ -90,6 +91,7 @@ func TestCmdRemote(t *testing.T) {
 	require.NoError(t, err)
 	ctx := appcontext.NewAppContext()
 	ctx.Config = cfg
+	ctx.ConfigDir = tmpDir
 	ctx.Stdout = bufOut
 	ctx.Stderr = bufErr
 
@@ -141,6 +143,7 @@ func TestCmdRepository(t *testing.T) {
 	require.NoError(t, err)
 	ctx := appcontext.NewAppContext()
 	ctx.Config = cfg
+	ctx.ConfigDir = tmpDir
 	ctx.Stdout = bufOut
 	ctx.Stderr = bufErr
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -20,7 +20,6 @@ func newConfigHandler(path string) *configHandler {
 }
 
 func (cl *configHandler) Load() (*config.Config, error) {
-
 	cfg := config.NewConfig()
 	err := cl.load("sources.yml", &cfg.Sources)
 	if err != nil {


### PR DESCRIPTION
Not specifying the ConfigDir means we're creating files in the /tmp/ directory which might reside on a different file system.