### PR TITLE
backup: Fix @source notation.

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -170,10 +170,6 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		scanDir = cmd.Path
 	}
 
-	if _, found := cmd.Opts["location"]; !found {
-		cmd.Opts["location"] = scanDir
-	}
-
 	if strings.HasPrefix(scanDir, "@") {
 		remote, ok := ctx.Config.GetSource(scanDir[1:])
 		if !ok {
@@ -191,6 +187,11 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 				}
 			}
 		}
+	}
+
+	// Now that we have resolved the possible @ syntax let's apply the scandir.
+	if _, found := cmd.Opts["location"]; !found {
+		cmd.Opts["location"] = scanDir
 	}
 
 	imp, err := importer.NewImporter(ctx.GetInner(), ctx.ImporterOpts(), cmd.Opts)


### PR DESCRIPTION
* Source notation is broken in backup because when we merge options from the config we give precedence (rightfully) to the command line provided options but we also _always_ fixup the location in the options before doing this, which means we never let the conf get applied.

* Note that there is no way to specify a location if we are resolving a "source" since... we use location to specify the source so this is safe to do (aka we will never _not_ apply a CLI param for the location)

* found by @brmzkw  again! Thx!