### PR TITLE
appcontext: Fix NewAppcontextFrom.

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -26,6 +26,9 @@ func NewAppContext() *AppContext {
 func NewAppContextFrom(ctx *AppContext) *AppContext {
 	return &AppContext{
 		KContext: kcontext.NewKContextFrom(ctx.GetInner()),
+
+		cookies:   ctx.cookies,
+		ConfigDir: ctx.ConfigDir,
 	}
 }
 


### PR DESCRIPTION
* The old kcontext did a full copy of the struct when in NewContextFrom, AppContext doesnt, so migrating the cookies/cookieDir meant that we would not get it set in the client context in agent mode.

* To fix it do a copy of cookiesDir / cookies, rather than copying the whole struct we have better control like this (discussed with eric@)

* reported-by eric@ fix discussed with eric@