### PR TITLE
ptar: Close cache and snapshots.

### DIFF
--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -296,6 +296,8 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, err
 	}
 
+	defer scanCache.Close()
+
 	repoWriter := repo.NewRepositoryWriter(scanCache, identifier, repository.PtarType)
 	for i, syncTarget := range cmd.SyncTargets {
 		storeConfig, err := ctx.Config.GetRepository(syncTarget)
@@ -355,6 +357,11 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 		}
 
 		err = snap.Backup(imp, backupOptions)
+		if err != nil {
+			return err
+		}
+
+		err = snap.Close()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Close the global scan cache we instantiate for the state.

* Close the snapshot which in turns closes the scan cache used by the backup routine.

* Found while working on cache cleanup for VFS.

* Note that in the case of the scan cache, closing it also means _removing_ the folder it was in. Without this we would clutter the .cache/plakar folder a bit.