### PR TITLE
pkg create: add extra_files to the manifest; improve usage

### DIFF
--- a/plugins/plugin_loader.go
+++ b/plugins/plugin_loader.go
@@ -34,8 +34,9 @@ type Manifest struct {
 	Connectors []struct {
 		Type          string   `yaml:"type"`
 		Protocols     []string `yaml:"protocols"`
-		LocationFlags []string `yaml:"locationFlags"`
+		LocationFlags []string `yaml:"location_flags"`
 		Executable    string   `yaml:"executable"`
+		ExtraFiles    []string `yaml:"extra_files"`
 		Homepage      string   `yaml:"homepage"`
 		License       string   `yaml:"license"`
 	} `yaml:"connectors"`

--- a/subcommands/pkg/pkgimporter.go
+++ b/subcommands/pkg/pkgimporter.go
@@ -20,15 +20,19 @@ package pkg
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/snapshot/importer"
+	"github.com/PlakarKorp/plakar/plugins"
 )
 
 type pkgerImporter struct {
-	files []string
+	cwd      string
+	manifest *plugins.Manifest
 }
 
 func (imp *pkgerImporter) Origin() string {
@@ -43,46 +47,88 @@ func (imp *pkgerImporter) Root() string {
 	return "/"
 }
 
+func absolutify(cwd, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(cwd, path)
+}
+
+func mkstruct(p string, ch chan<- *importer.ScanResult) {
+	dir := path.Dir(p)
+	for dir != "/" {
+		fi := objects.FileInfo{
+			Lname: path.Base(dir),
+			Lmode: 0700 | os.ModeDir,
+		}
+		ch <- importer.NewScanRecord(dir, "", fi, nil, nil)
+		dir = path.Dir(dir)
+	}
+}
+
+func (imp *pkgerImporter) dofile(p string, ch chan<- *importer.ScanResult, mustExe bool) {
+	absolute := absolutify(imp.cwd, p)
+
+	relative := absolute
+	relative, _ = strings.CutPrefix(relative, imp.cwd)
+	relative, _ = strings.CutPrefix(relative, string(os.PathSeparator))
+	relative = filepath.ToSlash(relative)
+	name := path.Join("/", relative)
+
+	if !strings.HasPrefix(absolute, imp.cwd) {
+		ch <- importer.NewScanError(name, fmt.Errorf("not below the manifest"))
+		return
+	}
+
+	fp, err := os.Open(absolute)
+	if err != nil {
+		ch <- importer.NewScanError(name, fmt.Errorf("Failed to open file: %w", err))
+		return
+	}
+
+	fi, err := fp.Stat()
+	if err != nil {
+		ch <- importer.NewScanError(name, fmt.Errorf("Failed to stat file: %w", err))
+		return
+	}
+
+	if mustExe && (fi.Mode()&0111) == 0 {
+		ch <- importer.NewScanError(name, fmt.Errorf("Not executable: %s", absolute))
+		return
+	}
+
+	mkstruct(name, ch)
+	ch <- &importer.ScanResult{
+		Record: &importer.ScanRecord{
+			Pathname: name,
+			FileInfo: objects.FileInfoFromStat(fi),
+			Reader:   fp,
+		},
+	}
+}
+
+func (imp *pkgerImporter) scan(ch chan<- *importer.ScanResult) {
+	defer close(ch)
+
+	info := objects.NewFileInfo("/", 0, 0700|os.ModeDir, time.Unix(0, 0), 0, 0, 0, 0, 1)
+	ch <- &importer.ScanResult{
+		Record: &importer.ScanRecord{
+			Pathname: "/",
+			FileInfo: info,
+		},
+	}
+
+	for _, conn := range imp.manifest.Connectors {
+		imp.dofile(conn.Executable, ch, true)
+		for _, file := range conn.ExtraFiles {
+			imp.dofile(file, ch, false)
+		}
+	}
+}
+
 func (imp *pkgerImporter) Scan() (<-chan *importer.ScanResult, error) {
 	ch := make(chan *importer.ScanResult, 1)
-
-	go func() {
-		defer close(ch)
-
-		info := objects.NewFileInfo("/", 0, 0700|os.ModeDir, time.Unix(0, 0), 0, 0, 0, 0, 1)
-		ch <- &importer.ScanResult{
-			Record: &importer.ScanRecord{
-				Pathname: "/",
-				FileInfo: info,
-			},
-		}
-
-		for _, f := range imp.files {
-			fbase := filepath.Base(f)
-			name := filepath.Join("/", fbase)
-
-			fp, err := os.Open(f)
-			if err != nil {
-				ch <- importer.NewScanError(f, fmt.Errorf("Failed to open file"))
-				break
-			}
-
-			fi, err := fp.Stat()
-			if err != nil {
-				ch <- importer.NewScanError(f, fmt.Errorf("Failed to stat file"))
-				break
-			}
-
-			ch <- &importer.ScanResult{
-				Record: &importer.ScanRecord{
-					Pathname: name,
-					FileInfo: objects.FileInfoFromStat(fi),
-					Reader:   fp,
-				},
-			}
-		}
-	}()
-
+	go imp.scan(ch)
 	return ch, nil
 }
 

--- a/subcommands/pkg/stdio.go
+++ b/subcommands/pkg/stdio.go
@@ -1,0 +1,52 @@
+package pkg
+
+import (
+	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	checkMark = lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00")).SetString("✓")
+	crossMark = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).SetString("✘")
+)
+
+type eventsProcessorStdio struct {
+	done chan struct{}
+}
+
+func startEventsProcessorStdio(ctx *appcontext.AppContext, quiet bool) eventsProcessorStdio {
+	done := make(chan struct{})
+	ep := eventsProcessorStdio{done: done}
+
+	go func() {
+		for event := range ctx.Events().Listen() {
+			switch event := event.(type) {
+			case events.PathError:
+				ctx.GetLogger().Stderr("%x: KO %s %s: %s", event.SnapshotID[:4], crossMark, event.Pathname, event.Message)
+			case events.DirectoryOK:
+				if !quiet {
+					ctx.GetLogger().Stdout("%x: OK %s %s", event.SnapshotID[:4], checkMark, event.Pathname)
+				}
+			case events.FileOK:
+				if !quiet {
+					ctx.GetLogger().Stdout("%x: OK %s %s", event.SnapshotID[:4], checkMark, event.Pathname)
+				}
+			case events.DirectoryError:
+				ctx.GetLogger().Stderr("%x: KO %s %s: %s", event.SnapshotID[:4], crossMark, event.Pathname, event.Message)
+			case events.FileError:
+				ctx.GetLogger().Stderr("%x: KO %s %s: %s", event.SnapshotID[:4], crossMark, event.Pathname, event.Message)
+			case events.Done:
+				done <- struct{}{}
+			default:
+				//ctx.GetLogger().Warn("unknown event: %T", event)
+			}
+		}
+	}()
+
+	return ep
+}
+
+func (ep eventsProcessorStdio) Close() {
+	<-ep.done
+}


### PR DESCRIPTION
- now the manifest has to list all the files
- all files listed by the manifest must be at or below the manifest directory
- ensure that the executables are, in fact, executable