### PR TITLE
improve error message on agent version mismatch

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,15 +32,12 @@ type Client struct {
 }
 
 var (
-	ErrWrongVersion = errors.New("agent has a different version, did you restart after update?")
+	ErrWrongVersion = errors.New("agent is running with a different version of plakar")
 )
 
 func ExecuteRPC(ctx *appcontext.AppContext, name []string, cmd subcommands.Subcommand, storeConfig map[string]string) (int, error) {
 	client, err := NewClient(filepath.Join(ctx.CacheDir, "agent.sock"), cmd.GetFlags()&subcommands.IgnoreVersion != 0)
 	if err != nil {
-		if errors.Is(err, ErrWrongVersion) {
-			ctx.GetLogger().Warn("%v", err)
-		}
 		return 1, err
 	}
 	defer client.Close()

--- a/main.go
+++ b/main.go
@@ -419,6 +419,10 @@ func EntryPoint() int {
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), utils.SanitizeText(err.Error()))
+		if errors.Is(err, agent.ErrWrongVersion) {
+			fmt.Fprintln(os.Stderr, "To restart the agent with the current CLI version, run:")
+			fmt.Fprintln(os.Stderr, "\t$ plakar agent restart")
+		}
 	}
 
 	if repo != nil {


### PR DESCRIPTION
- don't print the error twice
- add an advice about plakar agent restart

spotted by @brmzkw, thank you!