### PR TITLE
Fix plakar help output

### DIFF
--- a/plakar.1
+++ b/plakar.1
@@ -173,7 +173,10 @@ $ plakar create
 .Pp
 Create an encrypted Kloset store on AWS S3:
 .Bd -literal -offset indent
-$ plakar store add mys3bucket location=s3://s3.eu-west-3.amazonaws.com/backups access_key="access_key" secret_access_key="secret_key"
+$ plakar store add mys3bucket \\
+    location=s3://s3.eu-west-3.amazonaws.com/backups \\
+    access_key="access_key" \\
+    secret_access_key="secret_key"
 $ plakar at @mys3bucket create
 .Ed
 .Pp

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -244,7 +244,10 @@ Create an encrypted Kloset store at the default location:
 
 Create an encrypted Kloset store on AWS S3:
 
-	$ plakar store add mys3bucket location=s3://s3.eu-west-3.amazonaws.com/backups access_key="access_key" secret_access_key="secret_key"
+	$ plakar store add mys3bucket \
+	    location=s3://s3.eu-west-3.amazonaws.com/backups \
+	    access_key="access_key" \
+	    secret_access_key="secret_key"
 	$ plakar at @mys3bucket create
 
 Create a snapshot of the current directory on the @mys3bucket Kloset store:


### PR DESCRIPTION
mandoc -l plakar.1 displays a nice output, but `plakar help` output is limited to 80 cols and the output is suboptimal.