### PR TITLE
backup subcommand: rename excludes option to exclude-file

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -50,7 +50,7 @@ func (e *excludeFlags) Set(value string) error {
 }
 
 func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
-	var opt_excludes string
+	var opt_exclude_file string
 	var opt_exclude excludeFlags
 	excludes := []string{}
 
@@ -66,7 +66,7 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	flags.Uint64Var(&cmd.Concurrency, "concurrency", uint64(ctx.MaxConcurrency), "maximum number of parallel tasks")
 	flags.StringVar(&cmd.Tags, "tag", "", "tag to assign to this snapshot")
-	flags.StringVar(&opt_excludes, "excludes", "", "path to a file containing newline-separated regex patterns, treated as -exclude")
+	flags.StringVar(&opt_exclude_file, "exclude-file", "", "path to a file containing newline-separated regex patterns, treated as -exclude")
 	flags.Var(&opt_exclude, "exclude", "glob pattern to exclude files, can be specified multiple times to add several exclusion patterns")
 	flags.BoolVar(&cmd.Quiet, "quiet", false, "suppress output")
 	flags.BoolVar(&cmd.Silent, "silent", false, "suppress ALL output")
@@ -83,8 +83,8 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 		excludes = append(excludes, item)
 	}
 
-	if opt_excludes != "" {
-		fp, err := os.Open(opt_excludes)
+	if opt_exclude_file != "" {
+		fp, err := os.Open(opt_exclude_file)
 		if err != nil {
 			return fmt.Errorf("unable to open excludes file: %w", err)
 		}

--- a/subcommands/backup/backup_test.go
+++ b/subcommands/backup/backup_test.go
@@ -139,7 +139,7 @@ func TestExecuteCmdCreateDefaultWithExcludes(t *testing.T) {
 	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
 
 	ctx.MaxConcurrency = 1
-	args := []string{"-excludes", tmpBackupDir + "/subdir/to_exclude", tmpBackupDir}
+	args := []string{"-exclude-file", tmpBackupDir + "/subdir/to_exclude", tmpBackupDir}
 
 	subcommand := &Backup{}
 	err := subcommand.Parse(ctx, args)

--- a/subcommands/backup/plakar-backup.1
+++ b/subcommands/backup/plakar-backup.1
@@ -8,7 +8,7 @@
 .Nm plakar backup
 .Op Fl concurrency Ar number
 .Op Fl exclude Ar pattern
-.Op Fl excludes Ar file
+.Op Fl exclude-file Ar file
 .Op Fl check
 .Op Fl o Ar option
 .Op Fl quiet
@@ -40,7 +40,7 @@ Defaults to
 Specify individual glob exclusion patterns to ignore files or
 directories in the backup.
 This option can be repeated.
-.It Fl excludes Ar file
+.It Fl exclude-file Ar file
 Specify a file containing glob exclusion patterns, one per line, to
 ignore files or directories in the backup.
 .It Fl check
@@ -65,7 +65,7 @@ $ plakar backup -tag daily-backup
 .Pp
 Backup a specific directory with exclusion patterns from a file:
 .Bd -literal -offset indent
-$ plakar backup -excludes ~/my-excludes-file /var/www
+$ plakar backup -exclude-file ~/my-excludes-file /var/www
 .Ed
 .Pp
 Backup a directory with specific file exclusions:

--- a/subcommands/help/docs/plakar-backup.md
+++ b/subcommands/help/docs/plakar-backup.md
@@ -9,7 +9,7 @@ PLAKAR-BACKUP(1) - General Commands Manual
 **plakar&nbsp;backup**
 \[**-concurrency**&nbsp;*number*]
 \[**-exclude**&nbsp;*pattern*]
-\[**-excludes**&nbsp;*file*]
+\[**-exclude-file**&nbsp;*file*]
 \[**-check**]
 \[**-o**&nbsp;*option*]
 \[**-quiet**]
@@ -47,7 +47,7 @@ The options are as follows:
 > directories in the backup.
 > This option can be repeated.
 
-**-excludes** *file*
+**-exclude-file** *file*
 
 > Specify a file containing glob exclusion patterns, one per line, to
 > ignore files or directories in the backup.
@@ -83,7 +83,7 @@ Create a snapshot of the current directory with a tag:
 
 Backup a specific directory with exclusion patterns from a file:
 
-	$ plakar backup -excludes ~/my-excludes-file /var/www
+	$ plakar backup -exclude-file ~/my-excludes-file /var/www
 
 Backup a directory with specific file exclusions:
 


### PR DESCRIPTION
Following discussion in issue #1191 (see https://github.com/PlakarKorp/plakar/issues/1191#issuecomment-3031262053), proposal to rename `excludes` option to `exclude-file` for `backup` subcommand.