### PR TITLE
restore: Log directory events on error.

### DIFF
--- a/subcommands/restore/stdio.go
+++ b/subcommands/restore/stdio.go
@@ -1,8 +1,8 @@
 package restore
 
 import (
-	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -17,6 +17,9 @@ func eventsProcessorStdio(ctx *appcontext.AppContext, quiet bool) chan struct{} 
 		for event := range ctx.Events().Listen() {
 			switch event := event.(type) {
 			case events.PathError:
+				ctx.GetLogger().Warn("%x: KO %s %s: %s", event.SnapshotID[:4], crossMark, event.Pathname, event.Message)
+
+			case events.DirectoryError:
 				ctx.GetLogger().Warn("%x: KO %s %s: %s", event.SnapshotID[:4], crossMark, event.Pathname, event.Message)
 
 			case events.FileError:


### PR DESCRIPTION
* We were missing a type of event for directory errors on the stdio event processor, meaning during restore you'd not see errors during directories handling.