### PR TITLE
prettify command listing

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,9 +148,7 @@ func EntryPoint() int {
 		flag.PrintDefaults()
 
 		fmt.Fprintf(flag.CommandLine.Output(), "\nCOMMANDS:\n")
-		for _, k := range subcommands.List() {
-			fmt.Fprintf(flag.CommandLine.Output(), "  %s\n", k)
-		}
+		listcmds(flag.CommandLine.Output(), "  ")
 		fmt.Fprintf(flag.CommandLine.Output(), "\nFor more information on a command, use '%s help COMMAND'.\n", flag.CommandLine.Name())
 	}
 	flag.Parse()
@@ -267,10 +265,7 @@ func EntryPoint() int {
 
 	if flag.NArg() == 0 {
 		fmt.Fprintf(os.Stderr, "%s: a subcommand must be provided\n", filepath.Base(flag.CommandLine.Name()))
-		for _, k := range subcommands.List() {
-			fmt.Fprintf(os.Stderr, "  %s\n", k)
-		}
-
+		listcmds(os.Stderr, "  ")
 		return 1
 	}
 
@@ -617,6 +612,51 @@ func setupEncryption(ctx *appcontext.AppContext, config *storage.Configuration, 
 	}
 
 	return ErrCantUnlock
+}
+
+func listcmds(out io.Writer, prefix string) {
+	var last string
+	var subs []string
+
+	flush := func() {
+		pre, post := " ", ""
+		if len(subs) > 1 && subs[0] == "" {
+			pre, post = " [", "]"
+			subs = subs[1:]
+		}
+		subcmds := strings.Join(subs, " | ")
+		fmt.Fprint(out, prefix, last, pre, subcmds, post, "\n")
+	}
+
+	all := subcommands.List()
+	for _, cmd := range all {
+		if len(cmd) == 0 {
+			continue
+		}
+
+		if last == "" {
+			goto next
+		}
+
+		if last == cmd[0] {
+			if len(subs) > 0 && subs[len(subs)-1] != cmd[1] {
+				subs = append(subs, cmd[1])
+			}
+			continue
+		}
+
+		flush()
+
+	next:
+		subs = subs[:0]
+		last = cmd[0]
+		if len(cmd) > 1 {
+			subs = append(subs, cmd[1])
+		} else {
+			subs = append(subs, "")
+		}
+	}
+	flush()
 }
 
 func main() {

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -3,7 +3,6 @@ package subcommands
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/PlakarKorp/kloset/repository"
@@ -124,12 +123,28 @@ func Lookup(arguments []string) (Subcommand, []string, []string) {
 	return nil, nil, arguments
 }
 
-func List() []string {
-	var list []string
+func List() [][]string {
+	var list [][]string
+	slices.SortFunc(subcommands, func(a, b subcmd) int {
+		var i int
+		for {
+			n := strings.Compare(a.args[i], b.args[i])
+			if n != 0 {
+				return n
+			}
+
+			i++
+			if i == len(a.args) {
+				return -1
+			}
+			if i == len(b.args) {
+				return +1
+			}
+		}
+	})
 	for _, command := range subcommands {
-		list = append(list, strings.Join(command.args, " "))
+		list = append(list, command.args)
 	}
-	sort.Strings(list)
 	return list
 }
 


### PR DESCRIPTION
This turns this

```
$ plakar
plakar: a subcommand must be provided
  agent
  agent reload
  agent restart
  agent start
  agent stop
  agent tasks configure
  agent tasks start
  agent tasks stop
  archive
  backup
  cat
```

into

```
$ plakar
plakar: a subcommand must be provided
  agent [reload | restart | start | stop | tasks]
  archive
  backup
  cat
  check
  clone
  create
  destination
```

which i think it's more nice :)

In the future I'd also like to show the usage for the commands that don't take any parameter (i.e. `diff snap1[:path1] snap2[:path2]`), but that requires information that right now we don't have at this stage.