### PR TITLE
backup: add GNU-style long options for flags

### DIFF
--- a/subcommands/backup/backup_test.go
+++ b/subcommands/backup/backup_test.go
@@ -139,7 +139,7 @@ func TestExecuteCmdCreateDefaultWithExcludes(t *testing.T) {
 	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
 
 	ctx.MaxConcurrency = 1
-	args := []string{"-exclude-file", tmpBackupDir + "/subdir/to_exclude", tmpBackupDir}
+	args := []string{"--exclude-file", tmpBackupDir + "/subdir/to_exclude", tmpBackupDir}
 
 	subcommand := &Backup{}
 	err := subcommand.Parse(ctx, args)

--- a/subcommands/backup/plakar-backup.1
+++ b/subcommands/backup/plakar-backup.1
@@ -1,4 +1,4 @@
-.Dd July 3, 2025
+.Dd July 11, 2025
 .Dt PLAKAR-BACKUP 1
 .Os
 .Sh NAME
@@ -6,15 +6,16 @@
 .Nd Create a new snapshot in a Kloset store
 .Sh SYNOPSIS
 .Nm plakar backup
-.Op Fl concurrency Ar number
-.Op Fl exclude Ar pattern
-.Op Fl exclude-file Ar file
-.Op Fl check
-.Op Fl o Ar option
-.Op Fl quiet
-.Op Fl silent
-.Op Fl tag Ar tag
-.Op Fl scan
+.Op Fl \-concurrency Ar number
+.Op Fl x | \-exclude Ar pattern
+.Op Fl \-exclude-file Ar file
+.Op Fl c | \-check
+.Op Fl o | \-option Ar option
+.Op Fl q | \-quiet
+.Op Fl s | \-silent
+.Op Fl t | \-tag Ar tag
+.Op Fl n | \-scan
+.Op Fl h | \-help
 .Op Ar place
 .Sh DESCRIPTION
 The
@@ -33,50 +34,52 @@ to reference a source connector configured with
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
-.It Fl concurrency Ar number
+.It Fl \-concurrency Ar number
 Set the maximum number of parallel tasks for faster processing.
 Defaults to
 .Dv 8 * CPU count + 1 .
-.It Fl exclude Ar pattern
+.It Fl x , \-exclude Ar pattern
 Specify individual glob exclusion patterns to ignore files or
 directories in the backup.
 This option can be repeated.
-.It Fl exclude-file Ar file
+.It Fl \-exclude-file Ar file
 Specify a file containing glob exclusion patterns, one per line, to
 ignore files or directories in the backup.
-.It Fl check
+.It Fl c , \-check
 Perform a full check on the backup after success.
-.It Fl o Ar option
+.It Fl o , \-option Ar option
 Can be used to pass extra arguments to the source connector.
 The given
 .Ar option
 takes precedence over the configuration file.
-.It Fl quiet
+.It Fl q , \-quiet
 Suppress output to standard input, only logging errors and warnings.
-.It Fl silent
+.It Fl s , \-silent
 Suppress all output.
-.It Fl tag Ar tag
+.It Fl t , \-tag Ar tag
 Comma-separated list of tags to apply to the snapshot.
-.It Fl scan
+.It Fl n , \-scan
 Do not write a snapshot; instead, perform a dry run by outputting the list of
 files and directories that would be included in the backup.
 Respects all exclude patterns and other options, but makes no changes to the
 Kloset store.
+.It Fl h , \-help
+Displays help/usage.
 .El
 .Sh EXAMPLES
 Create a snapshot of the current directory with two tags:
 .Bd -literal -offset indent
-$ plakar backup -tag daily-backup,production
+$ plakar backup --tag daily-backup,production
 .Ed
 .Pp
 Backup a specific directory with exclusion patterns from a file:
 .Bd -literal -offset indent
-$ plakar backup -exclude-file ~/my-excludes-file /var/www
+$ plakar backup --exclude-file ~/my-excludes-file /var/www
 .Ed
 .Pp
 Backup a directory with specific file exclusions:
 .Bd -literal -offset indent
-$ plakar backup -exclude "*.tmp" -exclude "*.log" /var/www
+$ plakar backup --exclude "*.tmp" --exclude "*.log" /var/www
 .Ed
 .Sh DIAGNOSTICS
 .Ex -std

--- a/subcommands/help/docs/plakar-backup.md
+++ b/subcommands/help/docs/plakar-backup.md
@@ -7,15 +7,15 @@ PLAKAR-BACKUP(1) - General Commands Manual
 # SYNOPSIS
 
 **plakar&nbsp;backup**
-\[**-concurrency**&nbsp;*number*]
-\[**-exclude**&nbsp;*pattern*]
-\[**-exclude-file**&nbsp;*file*]
-\[**-check**]
-\[**-o**&nbsp;*option*]
-\[**-quiet**]
-\[**-silent**]
-\[**-tag**&nbsp;*tag*]
-\[**-scan**]
+\[**--concurrency**&nbsp;*number*]
+\[**-x&nbsp;|&nbsp;--exclude**&nbsp;*pattern*]
+\[**--exclude-file**&nbsp;*file*]
+\[**-c&nbsp;|&nbsp;--check**]
+\[**-o&nbsp;|&nbsp;--option**&nbsp;*option*]
+\[**-q&nbsp;|&nbsp;--quiet**]
+\[**-s&nbsp;|&nbsp;--silent**]
+\[**-t&nbsp;|&nbsp;--tag**&nbsp;*tag*]
+\[**-n&nbsp;|&nbsp;--scan**]
 \[*place*]
 
 # DESCRIPTION
@@ -36,47 +36,47 @@ plakar-source(1).
 
 The options are as follows:
 
-**-concurrency** *number*
+**--concurrency** *number*
 
 > Set the maximum number of parallel tasks for faster processing.
 > Defaults to
 > `8 * CPU count + 1`.
 
-**-exclude** *pattern*
+**-x, --exclude** *pattern*
 
 > Specify individual glob exclusion patterns to ignore files or
 > directories in the backup.
 > This option can be repeated.
 
-**-exclude-file** *file*
+**--exclude-file** *file*
 
 > Specify a file containing glob exclusion patterns, one per line, to
 > ignore files or directories in the backup.
 
-**-check**
+**-c, --check**
 
 > Perform a full check on the backup after success.
 
-**-o** *option*
+**-o, --option** *option*
 
 > Can be used to pass extra arguments to the source connector.
 > The given
 > *option*
 > takes precedence over the configuration file.
 
-**-quiet**
+**-q, --quiet**
 
 > Suppress output to standard input, only logging errors and warnings.
 
-**-silent**
+**-s, --silent**
 
 > Suppress all output.
 
-**-tag** *tag*
+**-t, --tag** *tag*
 
 > Comma-separated list of tags to apply to the snapshot.
 
-**-scan**
+**-n, --scan**
 
 > Do not write a snapshot; instead, perform a dry run by outputting the list of
 > files and directories that would be included in the backup.
@@ -87,15 +87,15 @@ The options are as follows:
 
 Create a snapshot of the current directory with two tags:
 
-	$ plakar backup -tag daily-backup,production
+	$ plakar backup --tag daily-backup,production
 
 Backup a specific directory with exclusion patterns from a file:
 
-	$ plakar backup -exclude-file ~/my-excludes-file /var/www
+	$ plakar backup --exclude-file ~/my-excludes-file /var/www
 
 Backup a directory with specific file exclusions:
 
-	$ plakar backup -exclude "*.tmp" -exclude "*.log" /var/www
+	$ plakar backup --exclude "*.tmp" -exclude "*.log" /var/www
 
 # DIAGNOSTICS
 

--- a/utils/opts.go
+++ b/utils/opts.go
@@ -39,3 +39,8 @@ func (o *OptsFlag) Set(s string) error {
 	o.opts[k] = v
 	return nil
 }
+
+// Type is only used in help text
+func (o *OptsFlag) Type() string {
+	return "option=value"
+}


### PR DESCRIPTION
For `backup` subcommand, use GNU-style long options and one-letter shorthands for flags using [github.com/spf13/pflag](https://github.com/spf13/pflag) package.

- Sync manpage and Markdown doc for `backup` subcommand
- Fix test with `--exclude` in `subcommands/backup/backup_test.go`

**Tests OK** for `backup` subcommand
```bash
$ go test -v github.com/PlakarKorp/plakar/subcommands/backup
=== RUN   TestExecuteCmdCreateDefault
--- PASS: TestExecuteCmdCreateDefault (0.13s)
=== RUN   TestExecuteCmdCreateDefaultWithExcludes
--- PASS: TestExecuteCmdCreateDefaultWithExcludes (0.14s)
PASS
ok      github.com/PlakarKorp/plakar/subcommands/backup 0.281s
```

`backup` subcommand help with `-h / --help` flag (disable sorting of flags):
```bash
$ ./plakar at <PATH> backup -h
Usage: backup [OPTIONS] path
       backup [OPTIONS] @LOCATION

OPTIONS:
  -x, --exclude strings       glob pattern to exclude files, can be specified multiple times to add several exclusion patterns
      --exclude-file string   path to a file containing newline-separated regex patterns, treated as --exclude
  -t, --tag strings           comma-separated list of tags to apply to the snapshot
  -n, --scan                  do not actually perform a backup, just list the files
  -q, --quiet                 suppress output
  -s, --silent                suppress ALL output
  -c, --check                 check the snapshot after creating it
      --concurrency uint      maximum number of parallel tasks (default 57)
  -o, --option option=value   specify extra importer options
      --stdio                 output one line per file to stdout instead of the default interactive output
  -h, --help                  show this help message

Run 'plakar help backup' for details.
```