### PR TITLE
improve pkg naming; add initial docs

### DIFF
--- a/plakar.1
+++ b/plakar.1
@@ -118,6 +118,21 @@ Mount Kloset snapshots as a read-only filesystem, documented in
 .It Cm ptar
 Create a .ptar archive, documented in
 .Xr plakar-ptar 1 .
+.It Cm pkg
+List installed plugins, documented in
+.Xr plakar-pkg 1 .
+.It Cm pkg add
+Install a plugin, documented in
+.Xr plakar-pkg-add 1 .
+.It Cm pkg build
+Build a plugin from source, documented in
+.Xr plakar-pkg-build 1 .
+.It Cm pkg create
+Package a plugin, documented in
+.Xr plakar-pkg-create 1 .
+.It Cm pkg rm
+Unistall a plugin, documented in
+.Xr plakar-pkg-rm 1 .
 .It Cm restore
 Restore files from a Kloset snapshot, documented in
 .Xr plakar-restore 1 .

--- a/subcommands/help/docs/plakar-pkg-add.md
+++ b/subcommands/help/docs/plakar-pkg-add.md
@@ -1,0 +1,46 @@
+PLAKAR-PKG-ADD(1) - General Commands Manual
+
+# NAME
+
+**plakar-pkg-add** - Install Plakar plugins
+
+# SYNOPSIS
+
+**plakar&nbsp;pkg&nbsp;add&nbsp;*plugin&nbsp;...*&zwnj;**
+
+# DESCRIPTION
+
+The
+**plakar pkg add**
+command adds a local or a remote plugin.
+
+If
+*plugin*
+is an absolute path, or if it starts with
+'./',
+then it is considered a path to a local plugin file, otherwise
+it is downloaded from the Plakar plugin server.
+
+# FILES
+
+*~/.cache/plakar/plugins/*
+
+> Plugin cache directory.
+> Respects
+> `XDG_CACHE_HOME`
+> if set.
+
+*~/.local/share/plakar/plugins*
+
+> Plugin directory.
+> Respects
+> `XDG_DATA_HOME`
+> if set.
+
+# SEE ALSO
+
+plakar-pkg(1),
+plakar-pkg-create(1),
+plakar-pkg-rm(1)
+
+Plakar - July 11, 2025

--- a/subcommands/help/docs/plakar-pkg-build.md
+++ b/subcommands/help/docs/plakar-pkg-build.md
@@ -1,0 +1,44 @@
+PLAKAR-PKG-BUILD(1) - General Commands Manual
+
+# NAME
+
+**plakar-pkg-build** - Build Plakar plugins from source
+
+# SYNOPSIS
+
+**plakar&nbsp;pkg&nbsp;build&nbsp;*recipe.yaml*&zwnj;**
+
+# DESCRIPTION
+
+The
+**plakar pkg build**
+fetches the sources and builds the plugin as specified in the given
+plakar-pkg-recipe.yaml(5).
+If it builds successfully, the resulting plugin will be created in the
+current working directory.
+
+# FILES
+
+*~/.cache/plakar/plugins/*
+
+> Plugin cache directory.
+> Respects
+> `XDG_CACHE_HOME`
+> if set.
+
+*~/.local/share/plakar/plugins*
+
+> Plugin directory.
+> Respects
+> `XDG_DATA_HOME`
+> if set.
+
+# SEE ALSO
+
+plakar-pkg(1),
+plakar-pkg-add(1),
+plakar-pkg-create(1),
+plakar-pkg-rm(1),
+plakar-pkg-recipe.yaml(5)
+
+Plakar - July 11, 2025

--- a/subcommands/help/docs/plakar-pkg-create.md
+++ b/subcommands/help/docs/plakar-pkg-create.md
@@ -1,0 +1,32 @@
+PLAKAR-PKG-CREATE(1) - General Commands Manual
+
+# NAME
+
+**plakar-pkg-create** - Create Plakar plugins
+
+# SYNOPSIS
+
+**plakar&nbsp;pkg&nbsp;build&nbsp;*manifest.yaml*&zwnj;**
+
+# DESCRIPTION
+
+The
+**plakar pkg create**
+assembles a plugin using the provided
+plakar-pkg-manifest.yaml(5).
+
+All the files needed for the plugin need to be already available,
+i.e. executables must be already be built.
+
+All external files must reside in the same directory as the
+*manifest.yaml*
+or in subdirectories.
+
+# SEE ALSO
+
+plakar-pkg(1),
+plakar-pkg-add(1),
+plakar-pkg-rm(1),
+plakar-pkg-manifest.yaml(5)
+
+Plakar - July 11, 2025

--- a/subcommands/help/docs/plakar-pkg-rm.md
+++ b/subcommands/help/docs/plakar-pkg-rm.md
@@ -1,0 +1,35 @@
+PLAKAR-PKG-RM(1) - General Commands Manual
+
+# NAME
+
+**plakar-pkg-rm** - Uninstall Plakar plugins
+
+# SYNOPSIS
+
+**plakar&nbsp;pkg&nbsp;rm&nbsp;*plugin&nbsp;...*&zwnj;**
+
+# DESCRIPTION
+
+The
+**plakar pkg rm**
+command removes plugins that have been previously installed with
+plakar-pkg-add(1)
+command.
+
+The list of plugins can be obtained with
+plakar-pkg(1).
+
+# EXAMPLES
+
+Removing a plugin:
+
+	$ plakar pkg
+	epic-v1.2.3
+	$ plakar pkg rm epic-v1.2.3
+
+# SEE ALSO
+
+plakar-pkg(1),
+plakar-pkg-add(1)
+
+Plakar - July 11, 2025

--- a/subcommands/help/docs/plakar-pkg.md
+++ b/subcommands/help/docs/plakar-pkg.md
@@ -1,0 +1,38 @@
+PLAKAR-PKG(1) - General Commands Manual
+
+# NAME
+
+**plakar-pkg** - List installed Plakar plugins
+
+# SYNOPSIS
+
+**plakar&nbsp;pkg**
+
+# DESCRIPTION
+
+The
+**plakar pkg**
+lists the currently installed plugins.
+
+# FILES
+
+*~/.cache/plakar/plugins/*
+
+> Plugin cache directory.
+> Respects
+> `XDG_CACHE_HOME`
+> if set.
+
+*~/.local/share/plakar/plugins*
+
+> Plugin directory.
+> Respects
+> `XDG_DATA_HOME`
+> if set.
+
+# SEE ALSO
+
+plakar-pkg-add(1),
+plakar-pkg-rm(1)
+
+Plakar - July 11, 2025

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -166,6 +166,31 @@ The following commands are available:
 > Create a .ptar archive, documented in
 > plakar-ptar(1).
 
+**pkg**
+
+> List installed plugins, documented in
+> plakar-pkg(1).
+
+**pkg add**
+
+> Install a plugin, documented in
+> plakar-pkg-add(1).
+
+**pkg build**
+
+> Build a plugin from source, documented in
+> plakar-pkg-build(1).
+
+**pkg create**
+
+> Package a plugin, documented in
+> plakar-pkg-create(1).
+
+**pkg rm**
+
+> Unistall a plugin, documented in
+> plakar-pkg-rm(1).
+
 **restore**
 
 > Restore files from a Kloset snapshot, documented in
@@ -269,4 +294,4 @@ Remove snapshots older than 30 days:
 
 	$ plakar rm -before 30d
 
-Plakar - July 2, 2025
+Plakar - July 8, 2025

--- a/subcommands/pkg/add.go
+++ b/subcommands/pkg/add.go
@@ -37,20 +37,20 @@ import (
 var baseURL, _ = url.Parse("https://plugins.plakar.io/pkg/plakar/")
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &PkgInstall{} },
+	subcommands.Register(func() subcommands.Subcommand { return &PkgAdd{} },
 		subcommands.BeforeRepositoryOpen,
-		"pkg", "install")
+		"pkg", "add")
 }
 
-type PkgInstall struct {
+type PkgAdd struct {
 	subcommands.SubcommandBase
 	Out      string
 	Args     []string
 	Manifest plugins.Manifest
 }
 
-func (cmd *PkgInstall) Parse(ctx *appcontext.AppContext, args []string) error {
-	flags := flag.NewFlagSet("pkg install", flag.ExitOnError)
+func (cmd *PkgAdd) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("pkg add", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s plugin.ptar ...",
 			flags.Name())
@@ -84,7 +84,7 @@ func (cmd *PkgInstall) Parse(ctx *appcontext.AppContext, args []string) error {
 	return nil
 }
 
-func (cmd *PkgInstall) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
+func (cmd *PkgAdd) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
 	cachedir, err := utils.GetCacheDir("plakar")
 	if err != nil {
 		return 1, err
@@ -153,7 +153,7 @@ func install(ctx *appcontext.AppContext, plugdir, plugin string) (string, error)
 	defer fp.Close()
 
 	// maybe a different filesystem
-	tmp, err := os.CreateTemp(plugdir, "pkg-install-*")
+	tmp, err := os.CreateTemp(plugdir, "pkg-add-*")
 	if err != nil {
 		return dst, err
 	}

--- a/subcommands/pkg/pkg.go
+++ b/subcommands/pkg/pkg.go
@@ -29,17 +29,17 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &PkgLs{} },
+	subcommands.Register(func() subcommands.Subcommand { return &Pkg{} },
 		subcommands.BeforeRepositoryOpen,
-		"pkg", "ls")
+		"pkg")
 }
 
-type PkgLs struct {
+type Pkg struct {
 	subcommands.SubcommandBase
 }
 
-func (cmd *PkgLs) Parse(ctx *appcontext.AppContext, args []string) error {
-	flags := flag.NewFlagSet("pkg ls", flag.ExitOnError)
+func (cmd *Pkg) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("pkg", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s",
 			flags.Name())
@@ -56,8 +56,7 @@ func (cmd *PkgLs) Parse(ctx *appcontext.AppContext, args []string) error {
 	return nil
 }
 
-func (cmd *PkgLs) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
-
+func (cmd *Pkg) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
 	dataDir, err := utils.GetDataDir("plakar")
 	if err != nil {
 		return 1, err

--- a/subcommands/pkg/plakar-pkg-add.1
+++ b/subcommands/pkg/plakar-pkg-add.1
@@ -1,0 +1,36 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG-ADD 1
+.Os
+.Sh NAME
+.Nm plakar-pkg-add
+.Nd Install Plakar plugins
+.Sh SYNOPSIS
+.Nm plakar pkg add Ar plugin ...
+.Sh DESCRIPTION
+The
+.Nm plakar pkg add
+command adds a local or a remote plugin.
+.Pp
+If
+.Ar plugin
+is an absolute path, or if it starts with
+.Sq ./ ,
+then it is considered a path to a local plugin file, otherwise
+it is downloaded from the Plakar plugin server.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa ~/.cache/plakar/plugins/
+Plugin cache directory.
+Respects
+.Ev XDG_CACHE_HOME
+if set.
+.It Pa ~/.local/share/plakar/plugins
+Plugin directory.
+Respects
+.Ev XDG_DATA_HOME
+if set.
+.El
+.Sh SEE ALSO
+.Xr plakar-pkg 1 ,
+.Xr plakar-pkg-create 1 ,
+.Xr plakar-pkg-rm 1

--- a/subcommands/pkg/plakar-pkg-build.1
+++ b/subcommands/pkg/plakar-pkg-build.1
@@ -1,0 +1,34 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG-BUILD 1
+.Os
+.Sh NAME
+.Nm plakar-pkg-build
+.Nd Build Plakar plugins from source
+.Sh SYNOPSIS
+.Nm plakar pkg build Ar recipe.yaml
+.Sh DESCRIPTION
+The
+.Nm plakar pkg build
+fetches the sources and builds the plugin as specified in the given
+.Xr plakar-pkg-recipe.yml 5 .
+If it builds successfully, the resulting plugin will be created in the
+current working directory.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa ~/.cache/plakar/plugins/
+Plugin cache directory.
+Respects
+.Ev XDG_CACHE_HOME
+if set.
+.It Pa ~/.local/share/plakar/plugins
+Plugin directory.
+Respects
+.Ev XDG_DATA_HOME
+if set.
+.El
+.Sh SEE ALSO
+.Xr plakar-pkg 1 ,
+.Xr plakar-pkg-add 1 ,
+.Xr plakar-pkg-create 1 ,
+.Xr plakar-pkg-rm 1 ,
+.Xr plakar-pkg-recipe.yml 5

--- a/subcommands/pkg/plakar-pkg-build.1
+++ b/subcommands/pkg/plakar-pkg-build.1
@@ -10,7 +10,7 @@
 The
 .Nm plakar pkg build
 fetches the sources and builds the plugin as specified in the given
-.Xr plakar-pkg-recipe.yml 5 .
+.Xr plakar-pkg-recipe.yaml 5 .
 If it builds successfully, the resulting plugin will be created in the
 current working directory.
 .Sh FILES
@@ -31,4 +31,4 @@ if set.
 .Xr plakar-pkg-add 1 ,
 .Xr plakar-pkg-create 1 ,
 .Xr plakar-pkg-rm 1 ,
-.Xr plakar-pkg-recipe.yml 5
+.Xr plakar-pkg-recipe.yaml 5

--- a/subcommands/pkg/plakar-pkg-create.1
+++ b/subcommands/pkg/plakar-pkg-create.1
@@ -22,4 +22,4 @@ or in subdirectories.
 .Xr plakar-pkg 1 ,
 .Xr plakar-pkg-add 1 ,
 .Xr plakar-pkg-rm 1 ,
-.Xr plakar-pkg-manifest.yml 5
+.Xr plakar-pkg-manifest.yaml 5

--- a/subcommands/pkg/plakar-pkg-create.1
+++ b/subcommands/pkg/plakar-pkg-create.1
@@ -1,0 +1,25 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG-CREATE 1
+.Os
+.Sh NAME
+.Nm plakar-pkg-create
+.Nd Create Plakar plugins
+.Sh SYNOPSIS
+.Nm plakar pkg build Ar manifest.yaml
+.Sh DESCRIPTION
+The
+.Nm plakar pkg create
+assembles a plugin using the provided
+.Xr plakar-pkg-manifest.yaml 5 .
+.Pp
+All the files needed for the plugin need to be already available,
+i.e. executables must be already be built.
+.Pp
+All external files must reside in the same directory as the
+.Ar manifest.yaml
+or in subdirectories.
+.Sh SEE ALSO
+.Xr plakar-pkg 1 ,
+.Xr plakar-pkg-add 1 ,
+.Xr plakar-pkg-rm 1 ,
+.Xr plakar-pkg-manifest.yml 5

--- a/subcommands/pkg/plakar-pkg-manifest.yaml.5
+++ b/subcommands/pkg/plakar-pkg-manifest.yaml.5
@@ -1,0 +1,84 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG-MANIFEST.YAML 5
+.Os
+.Sh NAME
+.Nm manifest.yaml
+.Nd Manifest for plugin assemblation
+.Sh DESCRIPTION
+The
+.Nm manifest.yaml
+file format describes how to package a plugin.
+No build or compilation is done, so all executables and other files
+have to be prepared beforehand.
+It must have a top-level YAML object with the following fields:
+.Bl -tag -width repository
+.It Ic name
+The name of the plugins
+.It Ic version
+The plugin version, which doubles as the git tag as well.
+It must follow semantic versioning and have a
+.Sq v
+prefix, e.g.
+.Sq v1.2.3 .
+.It Ic connectors
+A YAML array of objects with the following properties:
+.Bl -tag -width location_flags
+.It Ic type
+The connector type, one of
+.Ic importer ,
+.Ic exporter ,
+or
+.Ic store .
+.It Ic protocols
+An array of YAML strings containing all the protocols that the
+connector supports.
+.It Ic location_flags
+An optional array of YAML strings describing some properties of the
+connector.
+These properties are:
+.Bl -tag -width localfs
+.It Ic localfs
+Whether paths given to this connector have to be made absolute.
+.It Ic file
+Whether this store backend handles a Kloset in a sigle file, for
+e.g. a ptar file.
+.El
+.It Ic executable
+Path to the plugin executable.
+.It Ic extra_file
+An optional array of YAML string.
+These are extra files that need to be included in the package.
+.It Ic homepage
+The plugin homepage.
+.It Ic license
+The plugin license.
+.El
+.El
+.Sh EXAMPLES
+A sample manifest for the
+.Dq fs
+plugin is as follows:
+.Bd -literal -offset indent
+# manifest.yaml
+name: fs
+description: file storage but as external plugin
+version: 1.0.0
+connectors:
+- type: importer
+  executable: fs-importer
+  homepage: https://github.com/PlakarKorp/integration-fs
+  license: ISC
+  protocols: [fs]
+- type: exporter
+  executable: fs-exporter
+  homepage: https://github.com/PlakarKorp/integration-fs
+  license: ISC
+  protocols: [fs]
+- type: storage
+  executable: fs-store
+  homepage: https://github.com/PlakarKorp/integration-fs
+  license: ISC
+  protocols: [fs]
+.Ed
+.Sh SEE ALSO
+.Xr plakar-pkg-create 1

--- a/subcommands/pkg/plakar-pkg-recipe.yaml.5
+++ b/subcommands/pkg/plakar-pkg-recipe.yaml.5
@@ -1,0 +1,35 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG-RECIPE.YAML 5
+.Os
+.Sh NAME
+.Nm recipe.yaml
+.Nd Recipe to build Plakar plugins from source
+.Sh DESCRIPTION
+The
+.Nm recipe.yaml
+file format describes how to fetch and build Plakar plugins.
+It must have a top-level YAML object with the following fields:
+.Bl -tag -width repository
+.It Ic name
+The name of the plugins
+.It Ic version
+The plugin version, which doubles as the git tag as well.
+It must follow semantic versioning and have a
+.Sq v
+prefix, e.g.
+.Sq v1.2.3 .
+.It Ic repository
+URL to the git repository holding the plugin.
+.El
+.Sh EXAMPLES
+A sample recipe to build the
+.Dq fs
+plugin is as follows:
+.Bd -literal -offset indent
+# recipe.yaml
+name: fs
+version: v1.0.0
+repository: https://github.com/PlakarKorp/integrations-fs
+.Ed
+.Sh SEE ALSO
+.Xr plakar-pkg-build 1

--- a/subcommands/pkg/plakar-pkg-rm.1
+++ b/subcommands/pkg/plakar-pkg-rm.1
@@ -1,0 +1,27 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG-RM 1
+.Os
+.Sh NAME
+.Nm plakar-pkg-rm
+.Nd Uninstall Plakar plugins
+.Sh SYNOPSIS
+.Nm plakar pkg rm Ar plugin ...
+.Sh DESCRIPTION
+The
+.Nm plakar pkg rm
+command removes plugins that have been previously installed with
+.Xr plakar-pkg-add 1
+command.
+.Pp
+The list of plugins can be obtained with
+.Xr plakar-pkg 1 .
+.Sh EXAMPLSE
+Removing a plugin:
+.Bd -literal -offset indent
+$ plakar pkg
+epic-v1.2.3
+$ plakar pkg rm epic-v1.2.3
+.Ed
+.Sh SEE ALSO
+.Xr plakar-pkg 1 ,
+.Xr plakar-pkg-add 1

--- a/subcommands/pkg/plakar-pkg-rm.1
+++ b/subcommands/pkg/plakar-pkg-rm.1
@@ -15,7 +15,7 @@ command.
 .Pp
 The list of plugins can be obtained with
 .Xr plakar-pkg 1 .
-.Sh EXAMPLSE
+.Sh EXAMPLES
 Removing a plugin:
 .Bd -literal -offset indent
 $ plakar pkg

--- a/subcommands/pkg/plakar-pkg.1
+++ b/subcommands/pkg/plakar-pkg.1
@@ -1,0 +1,28 @@
+.Dd July 11, 2025
+.Dt PLAKAR-PKG 1
+.Os
+.Sh NAME
+.Nm plakar-pkg
+.Nd List installed Plakar plugins
+.Sh SYNOPSIS
+.Nm plakar pkg
+.Sh DESCRIPTION
+The
+.Nm plakar pkg
+lists the currently installed plugins.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa ~/.cache/plakar/plugins/
+Plugin cache directory.
+Respects
+.Ev XDG_CACHE_HOME
+if set.
+.It Pa ~/.local/share/plakar/plugins
+Plugin directory.
+Respects
+.Ev XDG_DATA_HOME
+if set.
+.El
+.Sh SEE ALSO
+.Xr plakar-pkg-add 1 ,
+.Xr plakar-pkg-rm 1

--- a/subcommands/pkg/rm.go
+++ b/subcommands/pkg/rm.go
@@ -31,18 +31,18 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &PkgUninstall{} },
+	subcommands.Register(func() subcommands.Subcommand { return &PkgRm{} },
 		subcommands.BeforeRepositoryOpen,
-		"pkg", "uninstall")
+		"pkg", "rm")
 }
 
-type PkgUninstall struct {
+type PkgRm struct {
 	subcommands.SubcommandBase
 	Args []string
 }
 
-func (cmd *PkgUninstall) Parse(ctx *appcontext.AppContext, args []string) error {
-	flags := flag.NewFlagSet("pkg uninstall", flag.ExitOnError)
+func (cmd *PkgRm) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("pkg rm", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s",
 			flags.Name())
@@ -57,7 +57,7 @@ func (cmd *PkgUninstall) Parse(ctx *appcontext.AppContext, args []string) error 
 	return nil
 }
 
-func (cmd *PkgUninstall) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
+func (cmd *PkgRm) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
 	cachedir, err := utils.GetCacheDir("plakar")
 	if err != nil {
 		return 1, err


### PR DESCRIPTION
This renames the pkg subcommands:

 - `plakar pkg install` becomes `plakar pkg add`
 - `plakar pkg uninstall` becomes `plakar pkg rm`
 - `plakar pkg ls` becomes... `plakar pkg`

and adds some initial documentation for the subcommands and the file formats.