### PR TITLE
Allow 'create' to use the passphrase from the config.

### DIFF
--- a/subcommands/create/create.go
+++ b/subcommands/create/create.go
@@ -74,20 +74,15 @@ func (cmd *Create) Parse(ctx *appcontext.AppContext, args []string) error {
 	if !cmd.NoEncryption {
 		var passphrase []byte
 
-		envPassphrase, ok := os.LookupEnv("PLAKAR_PASSPHRASE")
 		if ctx.KeyFromFile == "" {
-			if ok {
-				passphrase = []byte(envPassphrase)
-			} else {
-				for attempt := 0; attempt < 3; attempt++ {
-					tmp, err := utils.GetPassphraseConfirm("repository", minEntropBits)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "%s\n", err)
-						continue
-					}
-					passphrase = tmp
-					break
+			for range 3 {
+				tmp, err := utils.GetPassphraseConfirm("repository", minEntropBits)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s\n", err)
+					continue
 				}
+				passphrase = tmp
+				break
 			}
 		} else {
 			passphrase = []byte(ctx.KeyFromFile)

--- a/subcommands/create/create_test.go
+++ b/subcommands/create/create_test.go
@@ -182,28 +182,3 @@ func TestExecuteCmdCreateDefaultWithKeyfile(t *testing.T) {
 	_, err = os.Stat(fmt.Sprintf("%s/repo/CONFIG", tmpRepoDirRoot))
 	require.NoError(t, err)
 }
-
-func TestExecuteCmdCreateDefaultWithEnvPassphrase(t *testing.T) {
-	tmpRepoDirRoot, err := os.MkdirTemp("", "tmp_repo")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		os.RemoveAll(tmpRepoDirRoot)
-	})
-	ctx := appcontext.NewAppContext()
-	defer ctx.Close()
-
-	t.Setenv("PLAKAR_PASSPHRASE", "")
-
-	args := []string{}
-
-	subcommand := &Create{}
-	err = subcommand.Parse(ctx, args)
-	require.Error(t, err, "can't encrypt the repository with an empty passphrase")
-
-	t.Setenv("PLAKAR_PASSPHRASE", "aZeRtY123456$#@!@")
-	err = subcommand.Parse(ctx, args)
-	require.NoError(t, err)
-
-	_, err = os.Stat(fmt.Sprintf("%s/repo/CONFIG", tmpRepoDirRoot))
-	require.NotNil(t, err)
-}


### PR DESCRIPTION
Get the passphrase from the env early and set it on the context.