### PR TITLE
ci: tweak timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
       contents: read
     strategy:
@@ -26,4 +25,4 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -v -timeout 1m ./...


### PR DESCRIPTION
instead of using a global timeout for the action, let's add a (strict) limit on each test.  from the `go test` doc:

> If a test binary runs longer than duration d, panic.
> If d is 0, the timeout is disabled.
> The default is 10 minutes (10m).

one minute for each binary test should be way more than enough.  the advantage is that if we go over the limit, the test binary panics and we get a stacktrace, while if the action times out we don't have any info on what was happening.