### PR TITLE
since configuration is now atomic, we no longer need to have an agent

### DIFF
--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -19,11 +19,9 @@ import (
 )
 
 func loadRepository(newCtx *appcontext.AppContext, name string) (*repository.Repository, storage.Store, error) {
-	cfg, err := utils.LoadConfig(newCtx.ConfigDir)
-	if err != nil {
+	if err := utils.ReloadConfig(newCtx); err != nil {
 		return nil, nil, fmt.Errorf("could not load configuration: %w", err)
 	}
-	newCtx.Config = cfg
 
 	storeConfig, err := newCtx.Config.GetRepository(name)
 	if err != nil {

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -19,6 +19,12 @@ import (
 )
 
 func loadRepository(newCtx *appcontext.AppContext, name string) (*repository.Repository, storage.Store, error) {
+	cfg, err := utils.LoadConfig(newCtx.ConfigDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not load configuration: %w", err)
+	}
+	newCtx.Config = cfg
+
 	storeConfig, err := newCtx.Config.GetRepository(name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to get repository configuration: %w", err)

--- a/subcommands/agent/agent.go
+++ b/subcommands/agent/agent.go
@@ -298,12 +298,10 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 			return err
 		}
 
-		cfg, err := utils.LoadConfig(ctx.ConfigDir)
-		if err != nil {
+		if err := utils.ReloadConfig(ctx); err != nil {
 			ctx.GetLogger().Warn("could not load configuration: %v", err)
 			return err
 		}
-		ctx.Config = cfg
 
 		wg.Add(1)
 		go handleClient(ctx, &wg, conn)

--- a/subcommands/agent/agent.go
+++ b/subcommands/agent/agent.go
@@ -298,6 +298,13 @@ func (cmd *Agent) ListenAndServe(ctx *appcontext.AppContext) error {
 			return err
 		}
 
+		cfg, err := utils.LoadConfig(ctx.ConfigDir)
+		if err != nil {
+			ctx.GetLogger().Warn("could not load configuration: %v", err)
+			return err
+		}
+		ctx.Config = cfg
+
 		wg.Add(1)
 		go handleClient(ctx, &wg, conn)
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/PlakarKorp/kloset/config"
+	"github.com/PlakarKorp/plakar/appcontext"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -154,6 +155,16 @@ func LoadConfig(configDir string) (*config.Config, error) {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+func ReloadConfig(ctx *appcontext.AppContext) error {
+	cl := newConfigHandler(ctx.ConfigDir)
+	cfg, err := cl.Load()
+	if err != nil {
+		return err
+	}
+	ctx.Config = cfg
+	return nil
 }
 
 func SaveConfig(configDir string, cfg *config.Config) error {


### PR DESCRIPTION
reload on config change, it can simply reopen config before reopening
repository for tasks, and reopen config when handling a new client