### PR TITLE
autospawn the agent

### DIFF
--- a/agent/flock_unix.go
+++ b/agent/flock_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func flock(fp *os.File) error {
+	return unix.Flock(int(fp.Fd()), unix.LOCK_EX)
+}

--- a/agent/flock_windows.go
+++ b/agent/flock_windows.go
@@ -1,0 +1,18 @@
+package agent
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	reserved = 0
+	allBytes = ^uint32(0)
+)
+
+func flock(fp *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(fp.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK,
+		reserved, allBytes, allBytes, ol)
+}


### PR DESCRIPTION
attempt to automatically spawn the agent if it's not running

even if there are windows bits in this, the windows path is not optimal.  on unix we rely on the fact that the agent will outlive the parent, as it will be reparented to init after the cli dies, on windows this doesn't work: it gets reparented at the cmd.exe level and killed afterwards.  on windows we still need a proper service.

still, it's nice =)