### PR TITLE
main: Lower the default concurrency.

### DIFF
--- a/main.go
+++ b/main.go
@@ -260,7 +260,7 @@ func entryPoint() int {
 	ctx.MachineID = opt_machineIdDefault
 	ctx.KeyFromFile = secretFromKeyfile
 	ctx.ProcessID = os.Getpid()
-	ctx.MaxConcurrency = opt_cpuCount*8 + 1
+	ctx.MaxConcurrency = opt_cpuCount*2 + 1
 
 	if flag.NArg() == 0 {
 		fmt.Fprintf(os.Stderr, "%s: a subcommand must be provided\n", filepath.Base(flag.CommandLine.Name()))


### PR DESCRIPTION
* Go from nproc * 8 + 1 to nproc * 2 + 1. This made sense at the time cause we were heavily i/o bound. With our new fixed-size worker pipeline it's way less true but it consummes way too much memory.

* We have had quite a lot of report of people having OOM issues on memory constrained  machines etc.

* This doesn't affect performances much, see timings at the end of the commit message.

* This will also be needed by the new packing strategy which relies on having as many packfile opened as there are backup workers.

===============================

Before:
- Korpus to fs: k[ptr@c4v3 plakar]$ ./plakar -no-agent at www backup -quiet ~/dev/Korpus/ backup: created unsigned snapshot 6b7f410f of size 36 GB in 1m49.913605141s (wrote 29 GB)

- linux to s3: [ptr@c4v3 plakar]$ ./plakar -no-agent at @scw2 backup -quiet ~/dev/linux/ backup: created unsigned snapshot 71f9f45d of size 14 GB in 2m46.393367137s (wrote 9.6 GB)

After:
- Korpus to fs: [ptr@c4v3 plakar]$ ./plakar -no-agent at www2 backup -quiet ~/dev/Korpus/ backup: created unsigned snapshot 1e520ce6 of size 36 GB in 1m54.504265366s (wrote 29 GB)

-linux to s3:
[ptr@c4v3 plakar]$ ./plakar -no-agent at @scw2 backup -quiet ~/dev/linux/ backup: created unsigned snapshot a88c5a94 of size 14 GB in 2m40.828715229s (wrote 9.6 GB)