### PR TITLE
use a counter on pending reports 

### DIFF
--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -101,7 +101,7 @@ func (reporter *Reporter) getEmitter() Emitter {
 	// Check if user is logged
 	token, err := reporter.ctx.GetCookies().GetAuthToken()
 	if err != nil {
-		reporter.ctx.GetLogger().Warn("cannot get auth token: %v", err)
+		//reporter.ctx.GetLogger().Warn("cannot get auth token: %v", err)
 		return reporter.emitter
 	}
 	if token == "" {
@@ -111,7 +111,7 @@ func (reporter *Reporter) getEmitter() Emitter {
 	sc := services.NewServiceConnector(reporter.ctx, token)
 	enabled, err := sc.GetServiceStatus("alerting")
 	if err != nil {
-		reporter.ctx.GetLogger().Warn("failed to check alerting service: %v", err)
+		//reporter.ctx.GetLogger().Warn("failed to check alerting service: %v", err)
 		return reporter.emitter
 	}
 	if !enabled {

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -99,11 +99,7 @@ func (reporter *Reporter) getEmitter() Emitter {
 	reporter.emitter_timeout = time.Now().Add(time.Minute)
 
 	// Check if user is logged
-	token, err := reporter.ctx.GetCookies().GetAuthToken()
-	if err != nil {
-		//reporter.ctx.GetLogger().Warn("cannot get auth token: %v", err)
-		return reporter.emitter
-	}
+	token, _ := reporter.ctx.GetCookies().GetAuthToken()
 	if token == "" {
 		return reporter.emitter
 	}
@@ -111,7 +107,7 @@ func (reporter *Reporter) getEmitter() Emitter {
 	sc := services.NewServiceConnector(reporter.ctx, token)
 	enabled, err := sc.GetServiceStatus("alerting")
 	if err != nil {
-		//reporter.ctx.GetLogger().Warn("failed to check alerting service: %v", err)
+		reporter.ctx.GetLogger().Warn("failed to check alerting service: %v", err)
 		return reporter.emitter
 	}
 	if !enabled {

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/PlakarKorp/kloset/objects"
@@ -21,6 +22,7 @@ type Emitter interface {
 
 type Reporter struct {
 	ctx             *appcontext.AppContext
+	reportCount     atomic.Int32
 	reports         chan *Report
 	stop            chan any
 	done            chan any
@@ -46,14 +48,17 @@ func NewReporter(ctx *appcontext.AppContext) *Reporter {
 				goto done
 			case rp = <-r.reports:
 				r.Process(rp)
+				r.reportCount.Add(-1)
 			}
 		}
 	done:
-		close(r.reports)
 		// drain remaining reports
-		for rp = range r.reports {
+		for r.reportCount.Load() != 0 {
+			rp = <-r.reports
 			r.Process(rp)
+			r.reportCount.Add(-1)
 		}
+		close(r.reports)
 		close(r.done)
 	}()
 
@@ -80,8 +85,7 @@ func (reporter *Reporter) Process(report *Report) {
 
 func (reporter *Reporter) StopAndWait() {
 	close(reporter.stop)
-	for _ = range reporter.done {
-	}
+	<-reporter.done
 }
 
 func (reporter *Reporter) getEmitter() Emitter {
@@ -128,6 +132,7 @@ func (reporter *Reporter) getEmitter() Emitter {
 }
 
 func (reporter *Reporter) NewReport() *Report {
+	reporter.reportCount.Add(1)
 	return &Report{
 		logger:   reporter.ctx.GetLogger(),
 		reporter: reporter.reports,


### PR DESCRIPTION
 to make sure the reporter doesn't stop before all reports are processed.