### PR TITLE
pass parameters to plugin

### DIFF
--- a/plugins/connect.go
+++ b/plugins/connect.go
@@ -46,12 +46,7 @@ func forkChild(pluginPath string, args []string) (int, error) {
 
 	childFile := os.NewFile(uintptr(sp[0]), "child-conn")
 
-	var cmd *exec.Cmd
-	if len(args) == 0 {
-		cmd = exec.Command(pluginPath)
-	} else {
-		cmd = exec.Command(pluginPath, args...)
-	}
+	cmd := exec.Command(pluginPath, args...)
 	cmd.Stdin = childFile
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/plugins/connect_windows.go
+++ b/plugins/connect_windows.go
@@ -6,6 +6,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-func connectPlugin(pluginPath string) (grpc.ClientConnInterface, error) {
+func connectPlugin(pluginPath string, args []string) (grpc.ClientConnInterface, error) {
 	return nil, errors.ErrUnsupported
 }

--- a/plugins/manifest.go
+++ b/plugins/manifest.go
@@ -24,6 +24,7 @@ type Manifest struct {
 		Protocols     []string `yaml:"protocols"`
 		LocationFlags []string `yaml:"location_flags"`
 		Executable    string   `yaml:"executable"`
+		Args          []string `yaml:"args"`
 		ExtraFiles    []string `yaml:"extra_files"`
 	} `yaml:"connectors"`
 }

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -67,11 +67,11 @@ func (plugin *Plugin) SetUp(ctx *kcontext.KContext, pluginFile, pluginName, cach
 		for _, proto := range conn.Protocols {
 			switch conn.Type {
 			case "importer":
-				err = plugin.registerImporter(ctx, proto, flags, exe)
+				err = plugin.registerImporter(ctx, proto, flags, exe, conn.Args)
 			case "exporter":
-				err = plugin.registerExporter(ctx, proto, flags, exe)
+				err = plugin.registerExporter(ctx, proto, flags, exe, conn.Args)
 			case "storage":
-				err = plugin.registerStorage(ctx, proto, flags, exe)
+				err = plugin.registerStorage(ctx, proto, flags, exe, conn.Args)
 			default:
 				err = fmt.Errorf("unknown plugin type: %s", conn.Type)
 			}
@@ -95,9 +95,9 @@ func (plugin *Plugin) TearDown(ctx *kcontext.KContext) {
 	plugin.teardown = nil
 }
 
-func (plugin *Plugin) registerStorage(ctx *kcontext.KContext, proto string, flags location.Flags, exe string) error {
+func (plugin *Plugin) registerStorage(ctx *kcontext.KContext, proto string, flags location.Flags, exe string, args []string) error {
 	err := storage.Register(proto, flags, func(ctx context.Context, s string, config map[string]string) (storage.Store, error) {
-		client, err := connectPlugin(exe)
+		client, err := connectPlugin(exe, args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to plugin: %w", err)
 		}
@@ -112,9 +112,9 @@ func (plugin *Plugin) registerStorage(ctx *kcontext.KContext, proto string, flag
 	return nil
 }
 
-func (plugin *Plugin) registerImporter(ctx *kcontext.KContext, proto string, flags location.Flags, exe string) error {
+func (plugin *Plugin) registerImporter(ctx *kcontext.KContext, proto string, flags location.Flags, exe string, args []string) error {
 	err := importer.Register(proto, flags, func(ctx context.Context, o *importer.Options, s string, config map[string]string) (importer.Importer, error) {
-		client, err := connectPlugin(exe)
+		client, err := connectPlugin(exe, args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to plugin: %w", err)
 		}
@@ -128,9 +128,9 @@ func (plugin *Plugin) registerImporter(ctx *kcontext.KContext, proto string, fla
 	return nil
 }
 
-func (plugin *Plugin) registerExporter(ctx *kcontext.KContext, proto string, flags location.Flags, exe string) error {
+func (plugin *Plugin) registerExporter(ctx *kcontext.KContext, proto string, flags location.Flags, exe string, args []string) error {
 	err := exporter.Register(proto, flags, func(ctx context.Context, o *exporter.Options, s string, config map[string]string) (exporter.Exporter, error) {
-		client, err := connectPlugin(exe)
+		client, err := connectPlugin(exe, args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to plugin: %w", err)
 		}


### PR DESCRIPTION
this allows providing per type args in the manifest, with this it becomes possible to build importer/exporter/storage as a single executable with an argv dispatcher