### PR TITLE
improve agent startup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -80,7 +80,7 @@ func NewClient(socketPath string, ignoreVersion bool) (*Client, error) {
 		}
 
 		attempt++
-		if attempt > 100 {
+		if attempt > 1000 {
 			return nil, fmt.Errorf("failed to run the agent")
 		}
 

--- a/agent/flock.go
+++ b/agent/flock.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"os"
+	"time"
+)
+
+type FileLock struct {
+	Path     string
+	Attempts int
+	file     *os.File
+}
+
+func LockedFile(path string) (*FileLock, error) {
+	lock := &FileLock{Path: path}
+	err := lock.Lock()
+	if err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
+func (lock *FileLock) Lock() error {
+	file, err := os.OpenFile(lock.Path, os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+	n := lock.Attempts
+	if n <= 0 {
+		n = 1000
+	}
+	for range n {
+		err = flock(file)
+		if err == nil {
+			lock.file = file
+			return nil
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return err
+}
+
+func (lock *FileLock) Unlock() {
+	os.Remove(lock.Path)
+	lock.file.Close()
+	lock.file = nil
+}


### PR DESCRIPTION
- try to connect to the socket to check if an agent is aleardy running
- remove stale socket file if any
- protect the socket bootstrap by a flock
- increase retry count for the client to connect