### PR TITLE
Fix sync

### DIFF
--- a/subcommands/sync/sync.go
+++ b/subcommands/sync/sync.go
@@ -50,7 +50,7 @@ func (cmd *Sync) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	flags.Parse(args)
 
-	if flags.NArg() > 2 {
+	if flags.NArg() > 3 {
 		return fmt.Errorf("Too many arguments")
 	}
 


### PR DESCRIPTION
In 152eb08d8 we mistakenly disallowed extra args. `plakar sync` can be given a snapshot id to synchronize.