### PR TITLE
plugins: When exec.Command pass down a context.

### DIFF
--- a/plugins/connect.go
+++ b/plugins/connect.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func connectPlugin(pluginPath string, args []string) (grpc.ClientConnInterface, error) {
-	fd, err := forkChild(pluginPath, args)
+func connectPlugin(ctx context.Context, pluginPath string, args []string) (grpc.ClientConnInterface, error) {
+	fd, err := forkChild(ctx, pluginPath, args)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func connectPlugin(pluginPath string, args []string) (grpc.ClientConnInterface, 
 	return clientConn, nil
 }
 
-func forkChild(pluginPath string, args []string) (int, error) {
+func forkChild(ctx context.Context, pluginPath string, args []string) (int, error) {
 	sp, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
 		return -1, fmt.Errorf("failed to create socketpair: %w", err)
@@ -46,7 +46,7 @@ func forkChild(pluginPath string, args []string) (int, error) {
 
 	childFile := os.NewFile(uintptr(sp[0]), "child-conn")
 
-	cmd := exec.Command(pluginPath, args...)
+	cmd := exec.CommandContext(ctx, pluginPath, args...)
 	cmd.Stdin = childFile
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/plugins/connect_windows.go
+++ b/plugins/connect_windows.go
@@ -1,11 +1,12 @@
 package plugins
 
 import (
+	"context"
 	"errors"
 
 	"google.golang.org/grpc"
 )
 
-func connectPlugin(pluginPath string, args []string) (grpc.ClientConnInterface, error) {
+func connectPlugin(ctx context.Context, pluginPath string, args []string) (grpc.ClientConnInterface, error) {
 	return nil, errors.ErrUnsupported
 }

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -97,7 +97,7 @@ func (plugin *Plugin) TearDown(ctx *kcontext.KContext) {
 
 func (plugin *Plugin) registerStorage(ctx *kcontext.KContext, proto string, flags location.Flags, exe string, args []string) error {
 	err := storage.Register(proto, flags, func(ctx context.Context, s string, config map[string]string) (storage.Store, error) {
-		client, err := connectPlugin(exe, args)
+		client, err := connectPlugin(ctx, exe, args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to plugin: %w", err)
 		}
@@ -114,7 +114,7 @@ func (plugin *Plugin) registerStorage(ctx *kcontext.KContext, proto string, flag
 
 func (plugin *Plugin) registerImporter(ctx *kcontext.KContext, proto string, flags location.Flags, exe string, args []string) error {
 	err := importer.Register(proto, flags, func(ctx context.Context, o *importer.Options, s string, config map[string]string) (importer.Importer, error) {
-		client, err := connectPlugin(exe, args)
+		client, err := connectPlugin(ctx, exe, args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to plugin: %w", err)
 		}
@@ -129,7 +129,7 @@ func (plugin *Plugin) registerImporter(ctx *kcontext.KContext, proto string, fla
 
 func (plugin *Plugin) registerExporter(ctx *kcontext.KContext, proto string, flags location.Flags, exe string, args []string) error {
 	err := exporter.Register(proto, flags, func(ctx context.Context, o *exporter.Options, s string, config map[string]string) (exporter.Exporter, error) {
-		client, err := connectPlugin(exe, args)
+		client, err := connectPlugin(ctx, exe, args)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to plugin: %w", err)
 		}


### PR DESCRIPTION
* Since the plugins are basically an infinite loop, when the parent process (plakar) dies we need to command.Kill the children, which is down through context cancellation.