### PR TITLE
fix config import

### DIFF
--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -230,17 +230,25 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			}
 		} else {
 			for _, requestedName := range flags.Args() {
-				if hasFunc(requestedName) && !opt_overwrite {
-					fmt.Fprintf(ctx.Stderr, "%s %q already exists, skipping\n", cmd, requestedName)
+				origName, targetName, found := strings.Cut(requestedName, ":")
+				if !found {
+					targetName = normalizeName(origName)
+				}
+				if origName == "" || targetName == "" {
+					fmt.Fprintf(ctx.Stderr, "%s empty section name in %q, skipping\n", cmd, requestedName)
 					continue
 				}
-				if section, ok := newConfMap[requestedName]; !ok {
-					fmt.Fprintf(ctx.Stderr, "%s %q does not exist in config", cmd, requestedName)
+
+				if hasFunc(targetName) && !opt_overwrite {
+					fmt.Fprintf(ctx.Stderr, "%s %q already exists, skipping\n", cmd, targetName)
+					continue
+				}
+				if section, ok := newConfMap[origName]; !ok {
+					fmt.Fprintf(ctx.Stderr, "%s %q does not exist in config\n", cmd, origName)
 					continue
 				} else {
-					name := normalizeName(requestedName)
-					cfgMap[name] = make(map[string]string)
-					maps.Copy(cfgMap[name], section)
+					cfgMap[targetName] = make(map[string]string)
+					maps.Copy(cfgMap[targetName], section)
 				}
 			}
 		}

--- a/subcommands/config/plakar-destination.1
+++ b/subcommands/config/plakar-destination.1
@@ -36,18 +36,23 @@ is properly configured.
 .It Cm import Oo Fl config Ar location Oc Oo Fl overwrite Oc Oo Fl rclone Oc Oo Ar sections ... Oc
 Import a configuration from either stdin (default),
 a file, or a URL.
+.Pp
 If
 .Ar location
 is specified, the input will be read from that file or URL.
+.Pp
 If
 .Fl overwrite
 is specified, existing sections will be overwritten by new ones.
+.Pp
 If
 .Fl rclone
 is specified, the input will be treated as an rclone configuration.
+.Pp
 If
 .Ar sections
 are specified, only those sections will be imported.
+A section can be renamed on import by appending a colon and the new name.
 .It Cm ping Ar name
 Try to open the destination identified by
 .Ar name

--- a/subcommands/config/plakar-source.1
+++ b/subcommands/config/plakar-source.1
@@ -36,18 +36,23 @@ is properly configured.
 .It Cm import Oo Fl config Ar location Oc Oo Fl overwrite Oc Oo Fl rclone Oc Oo Ar sections ... Oc
 Import a configuration from either stdin (default),
 a file, or a URL.
+.Pp
 If
 .Ar location
 is specified, the input will be read from that file or URL.
+.Pp
 If
 .Fl overwrite
 is specified, existing sections will be overwritten by new ones.
+.Pp
 If
 .Fl rclone
 is specified, the input will be treated as an rclone configuration.
+.Pp
 If
 .Ar sections
 are specified, only those sections will be imported.
+A section can be renamed on import by appending a colon and the new name.
 .It Cm ping Ar name
 Try to open the data source identified by
 .Ar name

--- a/subcommands/config/plakar-store.1
+++ b/subcommands/config/plakar-store.1
@@ -35,18 +35,23 @@ is properly configured.
 .It Cm import Oo Fl config Ar location Oc Oo Fl overwrite Oc Oo Fl rclone Oc Oo Ar sections ... Oc
 Import a configuration from either stdin (default),
 a file, or a URL.
+.Pp
 If
 .Ar location
 is specified, the input will be read from that file or URL.
+.Pp
 If
 .Fl overwrite
 is specified, existing sections will be overwritten by new ones.
+.Pp
 If
 .Fl rclone
 is specified, the input will be treated as an rclone configuration.
+.Pp
 If
 .Ar sections
 are specified, only those sections will be imported.
+A section can be renamed on import by appending a colon and the new name.
 .It Cm ping Ar name
 Try to connect to the store identified by
 .Ar name

--- a/subcommands/help/docs/plakar-destination.md
+++ b/subcommands/help/docs/plakar-destination.md
@@ -44,18 +44,23 @@ The subcommands are as follows:
 
 > Import a configuration from either stdin (default),
 > a file, or a URL.
+
 > If
 > *location*
 > is specified, the input will be read from that file or URL.
+
 > If
 > **-overwrite**
 > is specified, existing sections will be overwritten by new ones.
+
 > If
 > **-rclone**
 > is specified, the input will be treated as an rclone configuration.
+
 > If
 > *sections*
 > are specified, only those sections will be imported.
+> A section can be renamed on import by appending a colon and the new name.
 
 **ping** *name*
 

--- a/subcommands/help/docs/plakar-restore.md
+++ b/subcommands/help/docs/plakar-restore.md
@@ -18,7 +18,6 @@ PLAKAR-RESTORE(1) - General Commands Manual
 \[**-since**&nbsp;*date*]
 \[**-concurrency**&nbsp;*number*]
 \[**-quiet**]
-\[**-rebase**]
 \[**-to**&nbsp;*directory*]
 \[*snapshotID*:*path&nbsp;...*]
 
@@ -83,14 +82,6 @@ The options are as follows:
 > Specify the base directory to which the files will be restored.
 > If omitted, files are restored to the current working directory.
 
-**-rebase**
-
-> Strip the original path from each restored file, placing files
-> directly in the specified directory (or the current working directory
-> if
-> **-to**
-> is omitted).
-
 **-quiet**
 
 > Suppress output to standard input, only logging errors and warnings.
@@ -105,9 +96,21 @@ Restore to a specific directory:
 
 	$ plakar restore -to /mnt/ abc123
 
-Restore with rebase option, placing files directly in the target directory:
+Restore latest snapshot to a specific directory:
 
-	$ plakar restore -rebase -to /home/op abc123
+	$ plakar restore -latest -to /mnt/ abc123
+
+Restore specific path to a specific directory:
+
+	$ plakar restore -to /mnt/ abc123:/etc/apache2
+
+Restore to a specific destination:
+
+	$ plakar restore -to @s3target abc123
+
+Restore specific path to a specific destination :
+
+	$ plakar restore -to  @s3target abc123:/etc/apache2
 
 # DIAGNOSTICS
 

--- a/subcommands/help/docs/plakar-source.md
+++ b/subcommands/help/docs/plakar-source.md
@@ -44,18 +44,23 @@ The subcommands are as follows:
 
 > Import a configuration from either stdin (default),
 > a file, or a URL.
+
 > If
 > *location*
 > is specified, the input will be read from that file or URL.
+
 > If
 > **-overwrite**
 > is specified, existing sections will be overwritten by new ones.
+
 > If
 > **-rclone**
 > is specified, the input will be treated as an rclone configuration.
+
 > If
 > *sections*
 > are specified, only those sections will be imported.
+> A section can be renamed on import by appending a colon and the new name.
 
 **ping** *name*
 

--- a/subcommands/help/docs/plakar-store.md
+++ b/subcommands/help/docs/plakar-store.md
@@ -43,18 +43,23 @@ The subcommands are as follows:
 
 > Import a configuration from either stdin (default),
 > a file, or a URL.
+
 > If
 > *location*
 > is specified, the input will be read from that file or URL.
+
 > If
 > **-overwrite**
 > is specified, existing sections will be overwritten by new ones.
+
 > If
 > **-rclone**
 > is specified, the input will be treated as an rclone configuration.
+
 > If
 > *sections*
 > are specified, only those sections will be imported.
+> A section can be renamed on import by appending a colon and the new name.
 
 **ping** *name*
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/ini.v1"
 
@@ -310,9 +311,15 @@ func GetConf(rd io.Reader, thirdParty string) (map[string]map[string]string, err
 
 	if thirdParty != "" {
 		for _, section := range configMap {
+			var ignore []string
 			for key, value := range section {
+				if slices.Contains(ignore, key) {
+					continue
+				}
 				if value != "" {
-					section[thirdParty+"_"+key] = value
+					newKey := thirdParty + "_" + key
+					section[newKey] = value
+					ignore = append(ignore, newKey)
 				}
 				delete(section, key)
 			}


### PR DESCRIPTION
- when importing a therid-party conf, rememeber new keys to avoid renaming them twice
- allow to rename sections on import