### PR TITLE
fix: prevent creation of empty tag on snapshots without tags

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -66,7 +66,11 @@ func (e *tagFlags) Set(value string) error {
 }
 
 func (e *tagFlags) asList() []string {
-	return strings.Split(string(*e), ",")
+	tags := string(*e)
+	if tags == "" {
+		return []string{}
+	}
+	return strings.Split(tags, ",")
 }
 
 func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {


### PR DESCRIPTION
Previously, when no tags were provided during backup, the snapshot was assigned a tag list with a single empty entry. Now, snapshots without tags correctly store an empty list.