### PR TITLE
api: fix auto preview for empty files

### DIFF
--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -188,7 +188,7 @@ func (ui *uiserver) snapshotReader(w http.ResponseWriter, r *http.Request) error
 		buffer := make([]byte, 4096) // Fixed-size buffer for chunked reading
 		for {
 			n, err := reader.Read(buffer) // Read up to the size of the buffer
-			if n > 0 {
+			if n >= 0 {
 				chunk := string(buffer[:n])
 
 				// Tokenize the chunk and apply syntax highlighting


### PR DESCRIPTION
before, empty files have always a white background:
<img width="1534" height="937" alt="Screenshot 2025-08-20 at 15 22 07" src="https://github.com/user-attachments/assets/4dd5025c-a620-4170-a14f-9d99575facfa" />

after, correct:
<img width="1529" height="935" alt="Screenshot 2025-08-20 at 15 21 48" src="https://github.com/user-attachments/assets/2e100dfa-96bb-4593-bf76-e6fae58f1cd7" />
