### PR TITLE
agent: Stop forwarding events.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PlakarKorp/kloset/events"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/utils"
@@ -199,12 +198,6 @@ func (c *Client) SendCommand(ctx *appcontext.AppContext, name []string, cmd subc
 			fmt.Printf("%s", string(response.Data))
 		case "stderr":
 			fmt.Fprintf(os.Stderr, "%s", string(response.Data))
-		case "event":
-			evt, err := events.Deserialize(response.Data)
-			if err != nil {
-				return 1, fmt.Errorf("failed to deserialize event: %w", err)
-			}
-			ctx.Events().Send(evt)
 		case "exit":
 			var err error
 			if response.Err != "" {


### PR DESCRIPTION
* We used to forward events from the agent to the CLI, this has a non negligeable cost, due to logging every file and directory being backed up. This is pointless as of now, because the events are hooked up also inside the agent process and logged to stdout/stderr where they are also redirected to the CLI process. This was done to allow TUI mode over agent but we are never going to go that way anyway, and for now this has a non negligeable perf impact see below.

```
before:
time ./plakar at ~/bigfatdisk/repoagent backup ~/dev/korpus/ > /dev/null
real	4m3.183s
user	0m58.196s
sys	1m55.712s

time ./plakar at ~/bigfatdisk/repoagent backup -quiet ~/dev/Korpus/ 
real	3m36.369s
user	0m46.279s
sys	1m26.677s

time ./plakar -no-agent at ~/bigfatdisk/repoagentless backup -quiet ~/dev/Korpus/ 
real	2m43.293s
user	10m58.050s
sys	5m43.317s

after:
time ./plakar at ~/bigfatdisk/repoagent backup ~/dev/korpus/ > /dev/null
real	3m19.372s
user	0m15.540s
sys	0m40.803s

time ./plakar at ~/bigfatdisk/repoagent backup -quiet ~/dev/Korpus/ 
real	2m49.401s
user	0m0.021s
sys	0m0.011s

time ./plakar -no-agent at ~/bigfatdisk/repoagentless backup -quiet ~/dev/Korpus/ 
real	2m47.560s
user	11m3.193s
sys	5m55.215s
```