### PR TITLE
windows: disable the agent by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func entryPoint() int {
 	ctx.CWD = cwd
 
 	_, envAgentLess := os.LookupEnv("PLAKAR_AGENTLESS")
-	if envAgentLess {
+	if envAgentLess || runtime.GOOS == "windows" {
 		opt_agentless = true
 	}
 

--- a/subcommands/agent/agent.go
+++ b/subcommands/agent/agent.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -43,8 +44,10 @@ import (
 )
 
 func init() {
-	subcommands.Register(func() subcommands.Subcommand { return &Agent{} },
-		subcommands.BeforeRepositoryOpen, "agent")
+	if runtime.GOOS != "windows" {
+		subcommands.Register(func() subcommands.Subcommand { return &Agent{} },
+			subcommands.BeforeRepositoryOpen, "agent")
+	}
 }
 
 func (cmd *Agent) Parse(ctx *appcontext.AppContext, args []string) error {


### PR DESCRIPTION
To have the agent working on windows we need to implement a Service. For now, just implicitly disable the agent and unplug the subcommand.