### PR TITLE
server: improve the manpage

### DIFF
--- a/subcommands/help/docs/plakar-scheduler.md
+++ b/subcommands/help/docs/plakar-scheduler.md
@@ -8,8 +8,8 @@ PLAKAR-SCHEDULER(1) - General Commands Manual
 
 **plakar&nbsp;scheduler**
 \[**-foreground**]
-**-tasks**&nbsp;*configfile*
-\[*stop*]
+\[**start**&nbsp;**-tasks**&nbsp;*configfile*]
+\[**stop**]
 
 # DESCRIPTION
 
@@ -27,7 +27,12 @@ The options are as follows:
 
 > Specify the configuration file that contains the task definitions and schedules.
 
-*stop*
+**start** **-tasks** *configfile*
+
+> Starts the scheduler service and its tasks from
+> *configfile*.
+
+**stop**
 
 > Stop the currently running scheduler service.
 

--- a/subcommands/help/docs/plakar-server.md
+++ b/subcommands/help/docs/plakar-server.md
@@ -8,7 +8,7 @@ PLAKAR-SERVER(1) - General Commands Manual
 
 **plakar&nbsp;server**
 \[**-allow-delete**]
-\[**-listen**&nbsp;*address*]
+\[**-listen**&nbsp;\[*host*]:*port*]
 
 # DESCRIPTION
 
@@ -26,11 +26,17 @@ The options are as follows:
 > By default, delete operations are disabled to prevent accidental data
 > loss.
 
-**-listen** *address*
+**-listen** \[*host*]:*port*
 
-> The hostname and port where to listen to, separated by a colon.
-> The hostname is optional.
-> If not given, the server defaults to listen on localhost at port 9876.
+> The
+> *host*
+> and
+> *port*
+> where to listen to, separated by a colon.
+> The host name is optional, and defaults to all available addresses.
+> If
+> **-listen**
+> is not provided, the server defaults to listen on localhost at port 9876.
 
 # EXAMPLES
 
@@ -44,23 +50,22 @@ Start a plakar server on a remote store:
 
 Start a server on a specific address and port:
 
-	$ plakar server -addr 127.0.0.1:12345
+	$ plakar server -listen 127.0.0.1:12345
 
 # DIAGNOSTICS
 
 The **plakar-server** utility exits&#160;0 on success, and&#160;&gt;0 if an error occurs.
 
-0
-
-> Command completed successfully.
-
-&gt;0
-
-> An error occurred, such as an unsupported protocol or invalid
-> configuration.
-
 # SEE ALSO
 
 plakar(1)
+
+# CAVEATS
+
+When a host name is provided,
+**plakar server**
+uses only one of the IP addresses it resolves to,
+preferably using the legacy internet protocol
+(IPv4).
 
 Plakar - July 3, 2025 - PLAKAR-SERVER(1)

--- a/subcommands/help/docs/plakar-server.md
+++ b/subcommands/help/docs/plakar-server.md
@@ -65,7 +65,6 @@ plakar(1)
 When a host name is provided,
 **plakar server**
 uses only one of the IP addresses it resolves to,
-preferably using the legacy internet protocol
-(IPv4).
+preferably IPv4 .
 
 Plakar - July 3, 2025 - PLAKAR-SERVER(1)

--- a/subcommands/server/plakar-server.1
+++ b/subcommands/server/plakar-server.1
@@ -55,5 +55,4 @@ $ plakar server -listen 127.0.0.1:12345
 When a host name is provided,
 .Nm plakar server
 uses only one of the IP addresses it resolves to,
-preferably using the legacy internet protocol
-.Pq IPv4 .
+preferably IPv4 .

--- a/subcommands/server/plakar-server.1
+++ b/subcommands/server/plakar-server.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Nm plakar server
 .Op Fl allow-delete
-.Op Fl listen Ar address
+.Op Fl listen Oo Ar host Ns Oc : Ns Ar port
 .Sh DESCRIPTION
 The
 .Nm plakar server
@@ -21,10 +21,16 @@ The options are as follows:
 Enable delete operations.
 By default, delete operations are disabled to prevent accidental data
 loss.
-.It Fl listen Ar address
-The hostname and port where to listen to, separated by a colon.
-The hostname is optional.
-If not given, the server defaults to listen on localhost at port 9876.
+.It Fl listen Oo Ar host Ns Oc : Ns Ar port
+The
+.Ar host
+and
+.Ar port
+where to listen to, separated by a colon.
+The host name is optional, and defaults to all available addresses.
+If
+.Fl listen
+is not provided, the server defaults to listen on localhost at port 9876.
 .El
 .Sh EXAMPLES
 Start a plakar server on the local store:
@@ -39,16 +45,15 @@ $ plakar at sftp://example.org server
 .Pp
 Start a server on a specific address and port:
 .Bd -literal -offset indent
-$ plakar server -addr 127.0.0.1:12345
+$ plakar server -listen 127.0.0.1:12345
 .Ed
 .Sh DIAGNOSTICS
 .Ex -std
-.Bl -tag -width Ds
-.It 0
-Command completed successfully.
-.It >0
-An error occurred, such as an unsupported protocol or invalid
-configuration.
-.El
 .Sh SEE ALSO
 .Xr plakar 1
+.Sh CAVEATS
+When a host name is provided,
+.Nm plakar server
+uses only one of the IP addresses it resolves to,
+preferably using the legacy internet protocol
+.Pq IPv4 .

--- a/subcommands/server/server.go
+++ b/subcommands/server/server.go
@@ -63,6 +63,9 @@ type Server struct {
 
 func (cmd *Server) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
 	ctx.GetLogger().Info("listening on http://%s", cmd.ListenAddr)
-	httpd.Server(ctx, repo, cmd.ListenAddr, cmd.NoDelete)
+	err := httpd.Server(ctx, repo, cmd.ListenAddr, cmd.NoDelete)
+	if err != nil {
+		return 1, err
+	}
 	return 0, nil
 }

--- a/subcommands/server/server.go
+++ b/subcommands/server/server.go
@@ -39,7 +39,7 @@ func (cmd *Server) Parse(ctx *appcontext.AppContext, args []string) error {
 		flags.PrintDefaults()
 	}
 
-	flags.StringVar(&cmd.ListenAddr, "listen", "127.0.0.1:9876", "address to listen on")
+	flags.StringVar(&cmd.ListenAddr, "listen", "localhost:9876", "address to listen on")
 	flags.BoolVar(&opt_allowdelete, "allow-delete", false, "enable delete operations")
 	flags.Parse(args)
 

--- a/subcommands/server/server_test.go
+++ b/subcommands/server/server_test.go
@@ -49,11 +49,7 @@ func TestExecuteCmdServerDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, subcommand)
 
-	go func() {
-		status, err := subcommand.Execute(ctx, repo)
-		require.NoError(t, err)
-		require.Equal(t, 0, status)
-	}()
+	go subcommand.Execute(ctx, repo)
 
 	// wait for the server to start
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
* be a bit more precise in the `-listen` description
* explain that without a host it listens on all addresses
* add CAVEATS to explain net.Listen behaviour

while here also return the error if `httpd.Server` fails (e.g. if the port is already bound) and sync the `-listen` default with the manpage.