### PR TITLE
Reintroduce the agent stop command.

### DIFF
--- a/main.go
+++ b/main.go
@@ -417,8 +417,8 @@ func entryPoint() int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), utils.SanitizeText(err.Error()))
 		if errors.Is(err, agent.ErrWrongVersion) {
-			fmt.Fprintln(os.Stderr, "To restart the agent with the current CLI version, run:")
-			fmt.Fprintln(os.Stderr, "\t$ plakar agent restart")
+			fmt.Fprintln(os.Stderr, "To stop the current agent, run:")
+			fmt.Fprintln(os.Stderr, "\t$ plakar agent stop")
 		}
 	}
 

--- a/subcommands/agent/agent.go
+++ b/subcommands/agent/agent.go
@@ -45,6 +45,8 @@ import (
 
 func init() {
 	if runtime.GOOS != "windows" {
+		subcommands.Register(func() subcommands.Subcommand { return &AgentStop{} },
+			subcommands.BeforeRepositoryOpen|subcommands.AgentSupport|subcommands.IgnoreVersion, "agent", "stop")
 		subcommands.Register(func() subcommands.Subcommand { return &Agent{} },
 			subcommands.BeforeRepositoryOpen, "agent")
 	}

--- a/subcommands/agent/agent_stop.go
+++ b/subcommands/agent/agent_stop.go
@@ -34,8 +34,7 @@ type AgentStop struct {
 func (cmd *AgentStop) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags := flag.NewFlagSet("agent stop", flag.ExitOnError)
 	flags.Usage = func() {
-		fmt.Fprintf(flags.Output(), "Usage: %s [OPTIONS]\n", flags.Name())
-		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")
+		fmt.Fprintf(flags.Output(), "Usage: %s\n", flags.Name())
 		flags.PrintDefaults()
 	}
 	flags.Parse(args)

--- a/subcommands/agent/agent_stop.go
+++ b/subcommands/agent/agent_stop.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package agent
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+)
+
+type AgentStop struct {
+	subcommands.SubcommandBase
+}
+
+func (cmd *AgentStop) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("agent stop", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintf(flags.Output(), "Usage: %s [OPTIONS]\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")
+		flags.PrintDefaults()
+	}
+	flags.Parse(args)
+	if flags.NArg() != 0 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	return nil
+}
+
+func (cmd *AgentStop) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+	syscall.Kill(os.Getpid(), syscall.SIGINT)
+	return 0, nil
+}

--- a/subcommands/agent/agent_stop.go
+++ b/subcommands/agent/agent_stop.go
@@ -19,8 +19,6 @@ package agent
 import (
 	"flag"
 	"fmt"
-	"os"
-	"syscall"
 
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -46,6 +44,8 @@ func (cmd *AgentStop) Parse(ctx *appcontext.AppContext, args []string) error {
 }
 
 func (cmd *AgentStop) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
-	syscall.Kill(os.Getpid(), syscall.SIGINT)
+	if err := kill_self(); err != nil {
+		return 1, err
+	}
 	return 0, nil
 }

--- a/subcommands/agent/osdep_unix.go
+++ b/subcommands/agent/osdep_unix.go
@@ -48,6 +48,5 @@ func daemonize(argv []string) error {
 }
 
 func kill_self() error {
-	syscall.Kill(os.Getpid(), syscall.SIGINT)
-	return nil
+	return syscall.Kill(os.Getpid(), syscall.SIGINT)
 }

--- a/subcommands/agent/osdep_unix.go
+++ b/subcommands/agent/osdep_unix.go
@@ -46,3 +46,8 @@ func daemonize(argv []string) error {
 		return nil
 	}
 }
+
+func kill_self() error {
+	syscall.Kill(os.Getpid(), syscall.SIGINT)
+	return nil
+}

--- a/subcommands/agent/osdep_windows.go
+++ b/subcommands/agent/osdep_windows.go
@@ -13,3 +13,7 @@ func setupSyslog(ctx *appcontext.AppContext) error {
 func daemonize(argv []string) error {
 	return errors.ErrUnsupported
 }
+
+func kill_self() error {
+	return errors.ErrUnsupported
+}

--- a/subcommands/agent/plakar-agent.1
+++ b/subcommands/agent/plakar-agent.1
@@ -6,7 +6,7 @@
 .Nd Run the Plakar agent
 .Sh SYNOPSIS
 .Nm plakar agent
-.Op Cm Fl teardown Ar delay
+.Op Fl teardown Ar delay
 .Op Cm stop
 .Sh DESCRIPTION
 The

--- a/subcommands/agent/plakar-agent.1
+++ b/subcommands/agent/plakar-agent.1
@@ -24,7 +24,8 @@ Specify the delay after which the idle agent terminate.
 The
 .Ar delay
 parameter must be given as a sequence of decimal value,
-each followed by a time unit (e.g. "1m30s").
+each followed by a time unit
+.Pq e.g. Dq 1m30s .
 Delaults to 5 seconds.
 .It Cm stop
 Force the currently running agent to stop.

--- a/subcommands/agent/plakar-agent.1
+++ b/subcommands/agent/plakar-agent.1
@@ -6,6 +6,8 @@
 .Nd Run the Plakar agent
 .Sh SYNOPSIS
 .Nm plakar agent
+.Op Cm Fl teardown Ar delay
+.Op Cm stop
 .Sh DESCRIPTION
 The
 .Nm plakar agent
@@ -14,6 +16,22 @@ command starts the Plakar agent which will execute subsequent
 commands on their behalfs for faster processing.
 .Nm plakar agent
 continues is auto-spawned and terminates when idle for too long.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl teardown Ar delay
+Specify the delay after which the idle agent terminate.
+The
+.Ar delay
+parameter must be given as a sequence of decimal value,
+each followed by a time unit (e.g. "1m30s").
+Delaults to 5 seconds.
+.It Cm stop
+Force the currently running agent to stop.
+This is useful when upgrading from an older
+.Xr plakar 1
+version were the agent was always running.
+.El
 .Sh DIAGNOSTICS
 .Ex -std
 .Bl -tag -width Ds


### PR DESCRIPTION
This is useful for updating from an older version.
Update the message in main when running against an older version.
Add documentation.
