### PR TITLE
fix test: -exclude-file was renamed -ignore

### DIFF
--- a/subcommands/backup/backup_test.go
+++ b/subcommands/backup/backup_test.go
@@ -150,17 +150,6 @@ func TestExecuteCmdCreateDefaultWithIgnores(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
 
-	// output should be something like:
-	// info: 9a383818: OK ✓ /tmp/tmp_to_backup2103009254/subdir/foo.txt
-	// info: 9a383818: OK ✓ /tmp/tmp_to_backup2103009254/another_subdir/bar
-	// info: 9a383818: OK ✓ /tmp/tmp_to_backup2103009254/subdir/dummy.txt
-	// info: 9a383818: OK ✓ /tmp/tmp_to_backup2103009254/subdir
-	// info: 9a383818: OK ✓ /tmp/tmp_to_backup2103009254/another_subdir
-	// info: 9a383818: OK ✓ /tmp/tmp_to_backup2103009254
-	// info: 9a383818: OK ✓ /tmp
-	// info: 9a383818: OK ✓ /
-	// info: created unsigned snapshot 9a383818 with root PoRwWDCajeHqDG0vkZu13jOAWo3U/Wr9e/Hecg4IJoU of size 29 B in 10.961071ms
-
 	output := bufOut.String()
 	require.NotContains(t, output, "/subdir")
 }


### PR DESCRIPTION
but while here rework the test so it actually ensure we don't backup the ignored files.