### PR TITLE
skip diag in the subcommand listings

### DIFF
--- a/main.go
+++ b/main.go
@@ -584,7 +584,7 @@ func listCmds(out io.Writer, prefix string) {
 
 	all := subcommands.List()
 	for _, cmd := range all {
-		if len(cmd) == 0 {
+		if len(cmd) == 0 || cmd[0] == "diag" {
 			continue
 		}
 


### PR DESCRIPTION
`diag' is a diagnostic tool that should not be advertised for end users to actually use.  The information it provides are, usually, low level and aimed at debugging, not day-to-day operations.