### PR TITLE
github: fix mandoc lint action

### DIFF
--- a/.github/workflows/mandoc.yml
+++ b/.github/workflows/mandoc.yml
@@ -25,7 +25,8 @@ jobs:
       - name: lint
         run: |
           dir=$(mktemp -d)
-          find . -type f -iname \*.[1-9] -exec cp {} "$dir" \;
+          find subcommands -type f -iname \*.[1-9] -exec cp {} "$dir" \;
+          cp plakar.1 "$dir"
           cd "$dir"
           mandoc -Tlint -Wstyle -l *
           rm -rf "$dir"


### PR DESCRIPTION
the pattern might match other files, for e.g git references, so attempt to use something a bit more strict.