### PR TITLE
plakar agent start: readd some flags, improve the manpage

### DIFF
--- a/subcommands/agent/plakar-agent.1
+++ b/subcommands/agent/plakar-agent.1
@@ -6,19 +6,40 @@
 .Nd Run the Plakar agent
 .Sh SYNOPSIS
 .Nm plakar agent
-.Op Cm start Fl teardown Ar delay
-.Op Cm stop
+.Oo
+.Cm start
+.Op Fl foreground
+.Op Fl log Ar logfile
+.Op Fl teardown Ar delay
+.Oc
+.Nm plakar agent
+.Cm stop
 .Sh DESCRIPTION
 The
 .Nm plakar agent start
-command starts the Plakar agent which will execute subsequent
+command, which is the default, starts the Plakar agent which will
+execute subsequent
 .Xr plakar 1
 commands on their behalfs for faster processing.
-.Nm plakar agent
-continues is auto-spawned and terminates when idle for too long.
 .Pp
-The options are as follows:
+.Nm plakar agent
+is executed automatically by most
+.Xr plakar 1
+commands and terminates by itself when idle for too long, so usually
+there's no need to manually start it.
+.Pp
+The options for
+.Nm plakar agent
+.Cm start
+are as follows:
 .Bl -tag -width Ds
+.It Fl foreground
+Do not daemonize, run in the foreground and log to standard error.
+.It Fl log Ar logfile
+Write log output to the given
+.Ar logfile
+which is created if it does not exist.
+The default is to log to syslog.
 .It Fl teardown Ar delay
 Specify the delay after which the idle agent terminate.
 The
@@ -26,13 +47,15 @@ The
 parameter must be given as a sequence of decimal value,
 each followed by a time unit
 .Pq e.g. Dq 1m30s .
-Delaults to 5 seconds.
-.It Cm stop
-Force the currently running agent to stop.
+Defaults to 5 seconds.
+.El
+.Pp
+.Nm plakar agent
+.Cm stop
+forces the currently running agent to stop.
 This is useful when upgrading from an older
 .Xr plakar 1
 version were the agent was always running.
-.El
 .Sh DIAGNOSTICS
 .Ex -std
 .Bl -tag -width Ds

--- a/subcommands/agent/start.go
+++ b/subcommands/agent/start.go
@@ -63,6 +63,8 @@ func (cmd *AgentStart) Parse(ctx *appcontext.AppContext, args []string) error {
 	}
 
 	flags := flag.NewFlagSet("agent start", flag.ExitOnError)
+	flags.StringVar(&opt_logfile, "log", "", "log file")
+	flags.BoolVar(&opt_foreground, "foreground", false, "run in foreground")
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s [OPTIONS]\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "\nOPTIONS:\n")


### PR DESCRIPTION
noticed thanks to #1653, `-log` and `-foreground` were removed, but most of the logic is still there.  these changes were done in dbda028e9614e898353a619a444d472f47f0fad4, but I'm not sure about the direction: should we finish to kill the log and foreground support or readd them?

Here I'm readding them, and adjusting the documentation.  if we don't want them, given that now the agent is no longer that visible, is spawned automatically, it shuts down automatically, and we're also planning to remove it, i can amend this PR to just keep some of the manpage improvements and clean up the code.