### PR TITLE
when not in a devel branch, do not append build info, this is not

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -381,14 +381,15 @@ func GetDataDir(appName string) (string, error) {
 
 var VERSION = func() string {
 	version := "v1.0.5-devel"
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				version += "." + setting.Value
+	if strings.HasSuffix(version, "-devel") {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					version += "." + setting.Value
+				}
 			}
 		}
 	}
-
 	return version
 }()
 


### PR DESCRIPTION
only pointless on specific tags, but in cases where we don't have
a -suffix, this actually produces an invalid semver that leads to
a fatal at startup (due to the init() semver parse