### PR TITLE
goreleaser: fix homebrew package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ archives:
   - files:
       - src: plakar.1
         dst: man/plakar.1
-      - src: subcommands/**/*.1
+      - src: subcommands/**/*.[1-9]
         dst: man
         strip_parent: true
 


### PR DESCRIPTION
The manpage for plakar-query (7) was not installed.