### PR TITLE
api: embed files starting with _

### DIFF
--- a/ui/v2/ui.go
+++ b/ui/v2/ui.go
@@ -38,7 +38,7 @@ type UiOptions struct {
 	Token          string
 }
 
-//go:embed frontend/*
+//go:embed all:frontend/*
 var content embed.FS
 
 func Ui(repo *repository.Repository, ctx *appcontext.AppContext, addr string, opts *UiOptions) error {


### PR DESCRIPTION
We updated plakar-ui and the dist/ folder now contains files starting with '_'.

By default, `go:embed` frontend/* does not include files starting with '.' or '_'. To import them, you need to use the syntax `go:embed all:frontend/*`.