### PR TITLE
as measured with mathieu, since turning backup into a pipeline,

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,7 +254,7 @@ func entryPoint() int {
 	ctx.MachineID = opt_machineIdDefault
 	ctx.KeyFromFile = secretFromKeyfile
 	ctx.ProcessID = os.Getpid()
-	ctx.MaxConcurrency = opt_cpuCount*2 + 1
+	ctx.MaxConcurrency = opt_cpuCount
 
 	if flag.NArg() == 0 {
 		fmt.Fprintf(os.Stderr, "%s: a subcommand must be provided\n", filepath.Base(flag.CommandLine.Name()))


### PR DESCRIPTION
maxconcurrency = cpu*2+1 does not bring benefits anymore, we have
the same performances (slighly better actually) with reduced
memory usage by having maxconcurrency = cpu