### PR TITLE
Fix `plakar store show` to return error when store doesn't exist

### DIFF
--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -314,10 +314,12 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			names = p.Args()
 		}
 
+		var hasErrors bool
 		for _, name := range names {
 			name = normalizeName(name)
 			if !hasFunc(name) {
 				fmt.Fprintf(ctx.Stderr, "%s %q does not exist\n", cmd, name)
+				hasErrors = true
 				continue
 			}
 
@@ -358,6 +360,9 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			if err != nil {
 				return fmt.Errorf("failed to encode store %q: %w", name, err)
 			}
+		}
+		if hasErrors {
+			return fmt.Errorf("one or more %ss do not exist", cmd)
 		}
 		return nil
 


### PR DESCRIPTION
## Problem
The `plakar store show $storename` command currently returns a successful exit code (0) even when the specified store configuration does not exist. This makes it difficult for scripts and automation tools to detect missing store configurations.

## Solution
Modified the `dispatchSubcommand` function in `subcommands/config/config.go` to:

1. Show configurations for all existing stores
2. Report missing stores to stderr 
3. Return an error code if any requested stores don't exist

This maintains backward compatibility for showing multiple stores while ensuring proper error reporting.

## Changes
- **File:** `subcommands/config/config.go`
- **Function:** `dispatchSubcommand` (case "show")
- **Change:** Added error tracking to show existing stores while failing if any are missing

## Behavior Change

**Before:**
```bash
$ plakar store show existing missing
# Shows existing store config
# Prints: store "missing" does not exist
# Exit code: 0 (success)
```

**After:**
```bash
$ plakar store show existing missing  
# Shows existing store config
# Prints: store "missing" does not exist  
# Exit code: 1 (error)
```

## Testing
To test this change:
```bash
# Single missing store - should fail
plakar store show nonexistent-store

# Multiple stores with some missing - should show existing, fail for missing
plakar store show existing-store nonexistent-store

# All stores exist - should succeed
plakar store show existing1 existing2
```

## Impact
This change ensures that automation scripts can reliably detect when store configurations are missing, while preserving the ability to show multiple store configurations in a single command.