### PR TITLE
Add CLI flags for pre-hook and post-hook to backup command

### DIFF
--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -42,6 +42,8 @@ type BackupConfig struct {
 	Retention  time.Duration
 	Ignore     []string
 	IgnoreFile string `yaml:"ignoreFile"`
+	PreHook    string `yaml:"preHook"`
+	PostHook   string `yaml:"postHook"`
 }
 
 // CheckDecodeHook is a mapstructure decode hook to allow users to specify

--- a/scheduler/tasks.go
+++ b/scheduler/tasks.go
@@ -22,6 +22,8 @@ func (s *Scheduler) backupTask(taskset Task, task BackupConfig) {
 	backupSubcommand.Path = task.Path
 	backupSubcommand.Quiet = true
 	backupSubcommand.Opts = make(map[string]string)
+	backupSubcommand.PreHook = task.PreHook
+	backupSubcommand.PostHook = task.PostHook
 	if task.Check.Enabled {
 		backupSubcommand.OptCheck = true
 	}


### PR DESCRIPTION
## Feature: Pre-Backup and Post-Backup Hooks

### Summary
This PR implements pre-backup and post-backup scripting hooks for Plakar. This enables users to execute custom scripts before and after backups.

### Problem Solved
Previously, Plakar had no mechanism to run custom scripts around backup operations. This was a significant limitation for users who needed to:
- Dump databases before backup (like MySQL dumps)
- Perform cleanup operations after backup
- Run custom preparation or notification scripts
- Integrate with external systems

### Solution
Added comprehensive hook support with the following features:

#### Configuration Support
- **Scheduler YAML**: `preHook` and `postHook` fields in backup task configuration
- **CLI Flags**: `--pre-hook` and `--post-hook` flags for manual backups

####  Execution Behavior
- **Pre-hooks**: Execute before backup starts. If they fail, backup is aborted.
- **Post-hooks**: Execute after successful backup completion. If they fail, only a warning is logged (backup still succeeds).

### Usage Examples

#### Manual Backup with Hooks
```bash
plakar backup --pre-hook "mysqldump -u user -p pass db > /tmp/db.sql" \
              --post-hook "rm /tmp/db.sql" \
              /path/to/backup
```

#### Scheduled Backup Configuration
```yaml
agent:
  tasks:
    - name: mysql-backup
      repository: my-repo
      backup:
        path: /var/www
        interval: 1h
        preHook: mysqldump -u user -p pass db > /tmp/db.sql
        postHook: rm /tmp/db.sql
```

### Implementation Details

#### Files Modified
- `scheduler/config.go`: Added `PreHook` and `PostHook` fields to `BackupConfig`
- `subcommands/backup/backup.go`: 
  - Added hook execution logic in `DoBackup()`
  - Added `executeHook()` function
  - Added CLI flags for manual hook usage
- `scheduler/tasks.go`: Pass hooks from config to backup command
- `subcommands/backup/backup_test.go`: Added comprehensive hook tests

#### Key Design Decisions
1. **Pre-hook failure aborts backup**: Ensures backup integrity when preparation fails
2. **Post-hook failure doesn't abort**: Allows cleanup/notification failures without affecting backup success
3. **Shell execution**: Uses `sh -c` for maximum compatibility with shell scripts
4. **Logging**: Clear logging of hook execution and failures
5. **Backward compatibility**: All existing functionality remains unchanged

### Breaking Changes
None. This is a purely additive feature with full backward compatibility.
