### PR TITLE
restore: use a different name for the default restore directory

### DIFF
--- a/subcommands/restore/restore.go
+++ b/subcommands/restore/restore.go
@@ -87,7 +87,7 @@ func (cmd *Restore) Parse(ctx *appcontext.AppContext, args []string) error {
 	}
 
 	if pullPath == "" {
-		pullPath = fmt.Sprintf("%s/plakar-%s", ctx.CWD, time.Now().Format(time.RFC3339))
+		pullPath = fmt.Sprintf("%s/plakar-%s", ctx.CWD, time.Now().Format("20060102150405"))
 	}
 
 	cmd.RepositorySecret = ctx.GetSecret()


### PR DESCRIPTION
The default restore directory name contains a `:' which cannot be used on windows.