### PR TITLE
one more refactor for config handling

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -27,6 +27,7 @@ type AppContext struct {
 func NewAppContext() *AppContext {
 	return &AppContext{
 		KContext: kcontext.NewKContext(),
+		Config:   config.NewConfig(),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,31 +1,31 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
+)
 
-	"maps"
+var (
+	ErrNoLocation = errors.New("location is missing")
+	ErrNotFound   = errors.New("configuration not found")
 )
 
 type Config struct {
 	DefaultRepository string
-	Repositories      map[string]RepositoryConfig
-	Sources           map[string]SourceConfig
-	Destinations      map[string]DestinationConfig
+	Repositories      map[string]map[string]string
+	Sources           map[string]map[string]string
+	Destinations      map[string]map[string]string
 }
-
-type RepositoryConfig = map[string]string
-type SourceConfig = map[string]string
-type DestinationConfig = map[string]string
 
 func NewConfig() *Config {
 	return &Config{
-		Repositories: make(map[string]RepositoryConfig),
-		Sources:      make(map[string]SourceConfig),
-		Destinations: make(map[string]DestinationConfig),
+		Repositories: make(map[string]map[string]string),
+		Sources:      make(map[string]map[string]string),
+		Destinations: make(map[string]map[string]string),
 	}
 }
 
@@ -34,30 +34,27 @@ func (c *Config) HasRepository(name string) bool {
 	return ok
 }
 
-func (c *Config) GetRepository(name string) (map[string]string, error) {
+func (c *Config) get(name, kind string, configs map[string]map[string]string) (map[string]string, error) {
 	if !strings.HasPrefix(name, "@") {
 		return map[string]string{"location": name}, nil
 	}
 
-	name, rootOverride := resolveRootOverride(name)
+	name, rootOverride := resolveRootOverride(name[1:])
 
-	kv, ok := c.Repositories[name[1:]]
+	kv, ok := configs[name]
 	if !ok {
-		return nil, fmt.Errorf("could not resolve repository: %s", name)
+		return nil, fmt.Errorf("%s %w: %q", kind, ErrNotFound, name)
 	}
-	if _, ok := kv["location"]; !ok {
-		return nil, fmt.Errorf("repository %s has no location", name)
-	} else {
-		res := make(map[string]string)
-		maps.Copy(res, kv)
 
-		location, err := applyRootOverride(res["location"], rootOverride)
-		if err != nil {
-			return nil, err
-		}
-		res["location"] = location
-		return res, nil
+	if _, ok := kv["location"]; !ok {
+		return nil, fmt.Errorf("%s %w", kind, ErrNoLocation)
 	}
+
+	return resolve(kv, rootOverride)
+}
+
+func (c *Config) GetRepository(name string) (map[string]string, error) {
+	return c.get(name, "repository", c.Repositories)
 }
 
 func (c *Config) HasSource(name string) bool {
@@ -65,22 +62,14 @@ func (c *Config) HasSource(name string) bool {
 	return ok
 }
 
-func (c *Config) GetSource(name string) (map[string]string, bool) {
-	name, rootOverride := resolveRootOverride(name)
-
-	if kv, ok := c.Sources[name]; !ok {
-		return nil, false
-	} else {
-		res := make(map[string]string)
-		maps.Copy(res, kv)
-
-		location, err := applyRootOverride(res["location"], rootOverride)
-		if err != nil {
-			return nil, false
-		}
-		res["location"] = location
-		return res, ok
+func (c *Config) GetSource(name string) (map[string]string, error) {
+	if c == nil {
+		panic("c is nil")
 	}
+	if c.Sources == nil {
+		panic("sources is nil")
+	}
+	return c.get(name, "source", c.Sources)
 }
 
 func (c *Config) HasDestination(name string) bool {
@@ -88,22 +77,8 @@ func (c *Config) HasDestination(name string) bool {
 	return ok
 }
 
-func (c *Config) GetDestination(name string) (map[string]string, bool) {
-	name, rootOverride := resolveRootOverride(name)
-
-	if kv, ok := c.Destinations[name]; !ok {
-		return nil, false
-	} else {
-		res := make(map[string]string)
-		maps.Copy(res, kv)
-
-		location, err := applyRootOverride(res["location"], rootOverride)
-		if err != nil {
-			return nil, false
-		}
-		res["location"] = location
-		return res, ok
-	}
+func (c *Config) GetDestination(name string) (map[string]string, error) {
+	return c.get(name, "source", c.Destinations)
 }
 
 func resolveRootOverride(name string) (string, string) {

--- a/config/config.go
+++ b/config/config.go
@@ -107,10 +107,10 @@ func (c *Config) GetDestination(name string) (map[string]string, bool) {
 }
 
 func resolveRootOverride(name string) (string, string) {
-	if idx := strings.Index(name, ":"); idx == -1 {
+	if before, after, ok := strings.Cut(name, ":"); !ok {
 		return name, ""
 	} else {
-		return name[:idx], name[idx+1:]
+		return before, after
 	}
 }
 

--- a/config/config_extra_test.go
+++ b/config/config_extra_test.go
@@ -21,7 +21,7 @@ func TestHasDestination(t *testing.T) {
 	c := NewConfig()
 	require.False(t, c.HasDestination("missing"))
 
-	c.Destinations["dst"] = DestinationConfig{"location": "/tmp/out"}
+	c.Destinations["dst"] = map[string]string{"location": "/tmp/out"}
 	require.True(t, c.HasDestination("dst"))
 }
 
@@ -29,14 +29,15 @@ func TestGetDestination(t *testing.T) {
 	c := NewConfig()
 
 	// missing
-	got, ok := c.GetDestination("missing")
-	require.False(t, ok)
+	got, err := c.GetDestination("@missing")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotFound)
 	require.Nil(t, got)
 
 	// present
-	c.Destinations["dst"] = DestinationConfig{"location": "/tmp/out", "extra": "yes"}
-	got, ok = c.GetDestination("dst")
-	require.True(t, ok)
+	c.Destinations["dst"] = map[string]string{"location": "/tmp/out", "extra": "yes"}
+	got, err = c.GetDestination("@dst")
+	require.NoError(t, err)
 	require.Equal(t, "/tmp/out", got["location"])
 	require.Equal(t, "yes", got["extra"])
 
@@ -54,9 +55,9 @@ func TestResolveRootOverride(t *testing.T) {
 		{"plain", "plain", ""},
 		{"name:/abs/path", "name", "/abs/path"},
 		{"name:rel/path", "name", "rel/path"},
-		{"name:", "name", ""},   // trailing colon -> empty override
-		{":/abs", "", "/abs"},   // leading colon -> empty name
-		{"a:b:c", "a", "b:c"},   // only the first colon splits
+		{"name:", "name", ""}, // trailing colon -> empty override
+		{":/abs", "", "/abs"}, // leading colon -> empty name
+		{"a:b:c", "a", "b:c"}, // only the first colon splits
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
@@ -110,7 +111,7 @@ func TestApplyRootOverride_URL_BadLocationReturnsError(t *testing.T) {
 
 func TestGetRepository_RootOverrideAppliedToLocalLocation(t *testing.T) {
 	c := NewConfig()
-	c.Repositories["repo"] = RepositoryConfig{"location": "/var/backups"}
+	c.Repositories["repo"] = map[string]string{"location": "/var/backups"}
 
 	got, err := c.GetRepository("@repo:/elsewhere")
 	require.NoError(t, err)
@@ -123,7 +124,7 @@ func TestGetRepository_RootOverrideAppliedToLocalLocation(t *testing.T) {
 
 func TestGetRepository_RootOverrideAppliedToURL(t *testing.T) {
 	c := NewConfig()
-	c.Repositories["repo"] = RepositoryConfig{"location": "s3://bucket/base"}
+	c.Repositories["repo"] = map[string]string{"location": "s3://bucket/base"}
 
 	got, err := c.GetRepository("@repo:sub")
 	require.NoError(t, err)
@@ -132,7 +133,7 @@ func TestGetRepository_RootOverrideAppliedToURL(t *testing.T) {
 
 func TestGetRepository_RootOverridePropagatesURLParseError(t *testing.T) {
 	c := NewConfig()
-	c.Repositories["repo"] = RepositoryConfig{"location": "ht\x00tp://x"}
+	c.Repositories["repo"] = map[string]string{"location": "ht\x00tp://x"}
 
 	_, err := c.GetRepository("@repo:/x")
 	require.Error(t, err)
@@ -149,44 +150,44 @@ func TestGetRepository_DirectPathPassesThrough(t *testing.T) {
 
 func TestGetSource_RootOverrideAppliedToLocalLocation(t *testing.T) {
 	c := NewConfig()
-	c.Sources["src"] = SourceConfig{"location": "/data"}
+	c.Sources["src"] = map[string]string{"location": "/data"}
 
-	got, ok := c.GetSource("src:/elsewhere")
-	require.True(t, ok)
+	got, err := c.GetSource("@src:/elsewhere")
+	require.NoError(t, err)
 	require.Equal(t, "/elsewhere", got["location"])
 }
 
 func TestGetSource_RootOverrideReturnsFalseOnURLParseError(t *testing.T) {
 	c := NewConfig()
 	// GetSource swallows the applyRootOverride error and returns ok=false.
-	c.Sources["src"] = SourceConfig{"location": "ht\x00tp://x"}
+	c.Sources["src"] = map[string]string{"location": "ht\x00tp://x"}
 
-	_, ok := c.GetSource("src:/x")
-	require.False(t, ok)
+	_, err := c.GetSource("@src:/x")
+	require.Error(t, err)
 }
 
 func TestGetDestination_RootOverrideAppliedToLocalLocation(t *testing.T) {
 	c := NewConfig()
-	c.Destinations["dst"] = DestinationConfig{"location": "/out"}
+	c.Destinations["dst"] = map[string]string{"location": "/out"}
 
-	got, ok := c.GetDestination("dst:sub")
-	require.True(t, ok)
+	got, err := c.GetDestination("@dst:sub")
+	require.NoError(t, err)
 	require.Equal(t, "/out/sub", got["location"])
 }
 
 func TestGetDestination_RootOverrideReturnsFalseOnURLParseError(t *testing.T) {
 	c := NewConfig()
-	c.Destinations["dst"] = DestinationConfig{"location": "ht\x00tp://x"}
+	c.Destinations["dst"] = map[string]string{"location": "ht\x00tp://x"}
 
-	_, ok := c.GetDestination("dst:/x")
-	require.False(t, ok)
+	_, err := c.GetDestination("@dst:/x")
+	require.Error(t, err)
 }
 
 func TestGetRepository_ResolveRootOverrideStripsAtPrefix(t *testing.T) {
 	// Sanity: the "@" prefix is on the *full* token, then the colon split
 	// happens on what's left. So "@name:override" -> name lookup is "name".
 	c := NewConfig()
-	c.Repositories["repo"] = RepositoryConfig{"location": "/x"}
+	c.Repositories["repo"] = map[string]string{"location": "/x"}
 
 	got, err := c.GetRepository("@repo:sub")
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,20 +8,20 @@ import (
 
 func TestHasRepository(t *testing.T) {
 	cfg := &Config{
-		Repositories: make(map[string]RepositoryConfig),
+		Repositories: make(map[string]map[string]string),
 	}
 
 	// Test non-existent repository
 	require.False(t, cfg.HasRepository("test-repo"))
 
 	// Test existing repository
-	cfg.Repositories["test-repo"] = RepositoryConfig{"location": "/test/path"}
+	cfg.Repositories["test-repo"] = map[string]string{"location": "/test/path"}
 	require.True(t, cfg.HasRepository("test-repo"))
 }
 
 func TestGetRepository(t *testing.T) {
 	cfg := &Config{
-		Repositories: make(map[string]RepositoryConfig),
+		Repositories: make(map[string]map[string]string),
 	}
 
 	// Test direct path
@@ -34,12 +34,12 @@ func TestGetRepository(t *testing.T) {
 	require.Error(t, err)
 
 	// Test repository without location
-	cfg.Repositories["test-repo"] = RepositoryConfig{"other": "value"}
+	cfg.Repositories["test-repo"] = map[string]string{"other": "value"}
 	_, err = cfg.GetRepository("@test-repo")
 	require.Error(t, err)
 
 	// Test valid repository
-	cfg.Repositories["test-repo"] = RepositoryConfig{"location": "/test/path"}
+	cfg.Repositories["test-repo"] = map[string]string{"location": "/test/path"}
 	repo, err = cfg.GetRepository("@test-repo")
 	require.NoError(t, err)
 	require.Equal(t, "/test/path", repo["location"])
@@ -47,30 +47,49 @@ func TestGetRepository(t *testing.T) {
 
 func TestHasSource(t *testing.T) {
 	cfg := &Config{
-		Sources: make(map[string]SourceConfig),
+		Sources: make(map[string]map[string]string),
 	}
 
 	// Test non-existent source
 	require.False(t, cfg.HasSource("test-source"))
 
 	// Test existing source
-	cfg.Sources["test-source"] = SourceConfig{"url": "test://url"}
+	cfg.Sources["test-source"] = map[string]string{"url": "test://url"}
 	require.True(t, cfg.HasSource("test-source"))
 }
 
 func TestGetSource(t *testing.T) {
 	cfg := &Config{
-		Sources: make(map[string]SourceConfig),
+		Sources: make(map[string]map[string]string),
 	}
 
 	// Test non-existent source
-	source, ok := cfg.GetSource("test-source")
-	require.False(t, ok)
+	source, err := cfg.GetSource("@test-source")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotFound)
 	require.Nil(t, source)
 
 	// Test existing source
-	cfg.Sources["test-source"] = SourceConfig{"url": "test://url"}
-	source, ok = cfg.GetSource("test-source")
-	require.True(t, ok)
+	cfg.Sources["test-source"] = map[string]string{
+		"url":      "test://url",
+		"location": "xxx",
+	}
+	source, err = cfg.GetSource("@test-source")
+	require.NoError(t, err)
 	require.Equal(t, "test://url", source["url"])
+}
+
+func TestGetNoLocation(t *testing.T) {
+	cfg := Config{
+		Sources: map[string]map[string]string{
+			"foo": {
+				"option_a": "true",
+			},
+		},
+	}
+
+	opts, err := cfg.get("@foo", "source", cfg.Sources)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoLocation)
+	require.Nil(t, opts)
 }

--- a/config/old.go
+++ b/config/old.go
@@ -9,9 +9,9 @@ import (
 )
 
 type OldConfig struct {
-	DefaultRepository string                      `yaml:"default-repo"`
-	Repositories      map[string]RepositoryConfig `yaml:"repositories"`
-	Remotes           map[string]SourceConfig     `yaml:"remotes"`
+	DefaultRepository string                       `yaml:"default-repo"`
+	Repositories      map[string]map[string]string `yaml:"repositories"`
+	Remotes           map[string]map[string]string `yaml:"remotes"`
 }
 
 func LoadOldConfigIfExists(configFile string) (*Config, error) {
@@ -34,7 +34,7 @@ func LoadOldConfigIfExists(configFile string) (*Config, error) {
 	cfg.DefaultRepository = old.DefaultRepository
 	cfg.Repositories = old.Repositories
 	cfg.Sources = old.Remotes
-	cfg.Destinations = make(map[string]DestinationConfig)
+	cfg.Destinations = make(map[string]map[string]string)
 	for key, val := range cfg.Sources {
 		res := make(map[string]string)
 		maps.Copy(res, val)

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func getPassphraseFromCommand(cmd string) (string, error) {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		c = exec.Command("cmd", "/C", cmd)
+	default: // assume unix-esque
+		c = exec.Command("/bin/sh", "-c", cmd)
+	}
+
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+
+	if err := c.Start(); err != nil {
+		return "", err
+	}
+
+	var pass string
+	var lines int
+	scan := bufio.NewScanner(stdout)
+	for scan.Scan() {
+		pass = scan.Text()
+		lines++
+	}
+
+	// don't deadlock in case the scanner fails
+	io.Copy(io.Discard, stdout)
+
+	if err := c.Wait(); err != nil {
+		return "", err
+	}
+
+	if err := scan.Err(); err != nil {
+		return "", err
+	}
+
+	if lines != 1 {
+		return "", fmt.Errorf("passphrase_cmd returned too many lines")
+	}
+
+	return pass, nil
+}
+
+func resolve(conf map[string]string, rootOverride string) (map[string]string, error) {
+	ret := make(map[string]string, len(conf))
+
+	for k, v := range conf {
+		if k == "passphrase_cmd" {
+			v, err := getPassphraseFromCommand(v)
+			if err != nil {
+				return nil, err
+			}
+			ret["passphrase"] = v
+		} else {
+			ret[k], _ = strings.CutPrefix(v, "raw:")
+		}
+	}
+
+	loc, err := applyRootOverride(ret["location"], rootOverride)
+	if err != nil {
+		return nil, err
+	}
+	ret["location"] = loc
+
+	return ret, nil
+}

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -223,33 +223,12 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 			scanDir = source
 		}
 
-		// We are going to mutate this, so do a copy
-		cmdOptsCopy := make(map[string]string)
-		maps.Copy(cmdOptsCopy, cmd.Opts)
-
-		if strings.HasPrefix(scanDir, "@") {
-			remote, ok := ctx.Config.GetSource(scanDir[1:])
-			if !ok {
-				return 1, fmt.Errorf("could not resolve importer: %s", scanDir), objects.MAC{}, nil
-			}
-			if _, ok := remote["location"]; !ok {
-				return 1, fmt.Errorf("could not resolve importer location: %s", scanDir), objects.MAC{}, nil
-			} else {
-				// inherit all the options -- but the ones
-				// specified in the command line takes the
-				// precedence.
-				for k, v := range remote {
-					if _, found := cmdOptsCopy[k]; !found {
-						cmdOptsCopy[k] = v
-					}
-				}
-			}
+		options, err := ctx.Config.GetSource(scanDir)
+		if err != nil {
+			return 1, err, objects.MAC{}, nil
 		}
 
-		// Now that we have resolved the possible @ syntax let's apply the scandir.
-		if _, found := cmdOptsCopy["location"]; !found {
-			cmdOptsCopy["location"] = scanDir
-		}
+		maps.Copy(options, cmd.Opts) // inherit all the options
 
 		excludes := exclude.NewRuleSet()
 		if err := excludes.AddRulesFromArray(cmd.Excludes); err != nil {
@@ -259,7 +238,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		importerOpts := ctx.ImporterOpts()
 		importerOpts.Excludes = cmd.Excludes
 
-		imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, cmdOptsCopy)
+		imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, options)
 		if err != nil {
 			return 1, fmt.Errorf("failed to create an importer for %s: %s", scanDir, err), objects.MAC{}, nil
 		}
@@ -274,7 +253,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		sourcesPerOrig[importerKey] = append(sourcesPerOrig[importerKey], imp)
 
 		if !cmd.NoProgress && (imp.Flags()&location.FLAG_STREAM) == 0 {
-			imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, cmdOptsCopy)
+			imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, options)
 			if err != nil {
 				return 1, fmt.Errorf("failed to create an importer for %s: %s", scanDir, err), objects.MAC{}, nil
 			}

--- a/subcommands/backup/backup_cov80_test.go
+++ b/subcommands/backup/backup_cov80_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/PlakarKorp/plakar/config"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
 )
@@ -111,7 +110,6 @@ func TestCov80BackupAtSourceInheritsOptions(t *testing.T) {
 	t.Cleanup(func() { renderer.Wait() })
 	t.Cleanup(ctx.Close)
 	ctx.MaxConcurrency = 1
-	ctx.Config = config.NewConfig()
 
 	// A configured source whose location points at the backup dir, plus an
 	// extra option that must be inherited by the importer options.

--- a/subcommands/backup/backup_coverage2_test.go
+++ b/subcommands/backup/backup_coverage2_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/PlakarKorp/plakar/config"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +34,6 @@ func TestCov2BackupUnknownAtSource(t *testing.T) {
 	t.Cleanup(func() { renderer.Wait() })
 	t.Cleanup(ctx.Close)
 	ctx.MaxConcurrency = 1
-	ctx.Config = config.NewConfig()
 
 	cmd := &Backup{}
 	require.NoError(t, cmd.Parse(ctx, []string{"@nope"}))
@@ -55,7 +53,6 @@ func TestCov2BackupAtSourceResolvedSucceeds(t *testing.T) {
 	t.Cleanup(func() { renderer.Wait() })
 	t.Cleanup(ctx.Close)
 	ctx.MaxConcurrency = 1
-	ctx.Config = config.NewConfig()
 
 	// a configured source whose location points at the backup dir
 	ctx.Config.Sources["good"] = map[string]string{"location": "fs:" + tmpBackupDir}

--- a/subcommands/backup/backup_coverage2_test.go
+++ b/subcommands/backup/backup_coverage2_test.go
@@ -40,7 +40,7 @@ func TestCov2BackupUnknownAtSource(t *testing.T) {
 	status, err := cmd.Execute(ctx, repo)
 	require.Equal(t, 1, status)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not resolve importer")
+	require.Contains(t, err.Error(), "source configuration not found")
 }
 
 func TestCov2BackupAtSourceResolvedSucceeds(t *testing.T) {

--- a/subcommands/backup/backup_faults_test.go
+++ b/subcommands/backup/backup_faults_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/PlakarKorp/plakar/config"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +23,6 @@ func TestFaultBackupEmptyAtSourceUnresolved(t *testing.T) {
 	t.Cleanup(func() { renderer.Wait() })
 	t.Cleanup(ctx.Close)
 	ctx.MaxConcurrency = 1
-	ctx.Config = config.NewConfig()
 	// An unrelated configured source so the lookup map is non-empty.
 	ctx.Config.Sources["other"] = map[string]string{"location": "fs:" + tmpBackupDir}
 
@@ -59,4 +57,3 @@ func TestFaultBackupPackfilesBadDir(t *testing.T) {
 	require.Equal(t, 1, status)
 	require.Error(t, err)
 }
-

--- a/subcommands/backup/backup_faults_test.go
+++ b/subcommands/backup/backup_faults_test.go
@@ -31,7 +31,7 @@ func TestFaultBackupEmptyAtSourceUnresolved(t *testing.T) {
 	status, err := cmd.Execute(ctx, repo)
 	require.Equal(t, 1, status)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not resolve importer")
+	require.Contains(t, err.Error(), "source configuration not found")
 }
 
 // TestFaultBackupPackfilesBadDir points -packfiles at a path under a file (not a

--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -139,9 +139,9 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			store.Close(ctx)
 
 		case "source":
-			cfg, ok := ctx.Config.GetSource(name)
-			if !ok {
-				return fmt.Errorf("failed to retrieve configuration for source %q", name)
+			cfg, err := ctx.Config.GetSource(name)
+			if err != nil {
+				return err
 			}
 			imp, err := importer.NewImporter(ctx.GetInner(), ctx.ImporterOpts(), cfg)
 			if err != nil {
@@ -150,9 +150,9 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			imp.Close(ctx)
 
 		case "destination":
-			cfg, ok := ctx.Config.GetDestination(name)
-			if !ok {
-				return fmt.Errorf("failed to retrieve configuration for destination %q", name)
+			cfg, err := ctx.Config.GetDestination(name)
+			if err != nil {
+				return err
 			}
 			exp, err := exporter.NewExporter(ctx.GetInner(), ctx.ExporterOpts(), cfg)
 			if err != nil {
@@ -273,9 +273,9 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			fmt.Println("configuration OK")
 
 		case "source":
-			cfg, ok := ctx.Config.GetSource(name)
-			if !ok {
-				return fmt.Errorf("failed to retrieve configuration for source %q", name)
+			cfg, err := ctx.Config.GetSource(name)
+			if err != nil {
+				return err
 			}
 			imp, err := importer.NewImporter(ctx.GetInner(), ctx.ImporterOpts(), cfg)
 			if err != nil {
@@ -288,9 +288,9 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			fmt.Println("configuration OK")
 
 		case "destination":
-			cfg, ok := ctx.Config.GetDestination(name)
-			if !ok {
-				return fmt.Errorf("failed to retrieve configuration for destination %q", name)
+			cfg, err := ctx.Config.GetDestination(name)
+			if err != nil {
+				return err
 			}
 			exp, err := exporter.NewExporter(ctx.GetInner(), ctx.ExporterOpts(), cfg)
 			if err != nil {

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -333,18 +333,9 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (
 
 func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryWriter) error {
 	for _, loc := range cmd.BackupTargets {
-		opts := map[string]string{
-			"location": loc,
-		}
-		if strings.HasPrefix(loc, "@") {
-			remote, ok := ctx.Config.GetSource(loc[1:])
-			if !ok {
-				return fmt.Errorf("could not resolve importer: %s", loc)
-			}
-			if _, ok := remote["location"]; !ok {
-				return fmt.Errorf("could not resolve importer location: %s", loc)
-			}
-			opts = remote
+		opts, err := ctx.Config.GetSource(loc)
+		if err != nil {
+			return err
 		}
 
 		imp, err := importer.NewImporter(ctx.GetInner(), ctx.ImporterOpts(), opts)

--- a/subcommands/ptar/ptar_cov80_test.go
+++ b/subcommands/ptar/ptar_cov80_test.go
@@ -7,7 +7,6 @@ import (
 
 	_ "github.com/PlakarKorp/integrations/fs/importer"
 	_ "github.com/PlakarKorp/integrations/ptar/storage"
-	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +17,6 @@ import (
 // any backup happens.
 func TestCov80PtarParseUnknownPeerInConfig(t *testing.T) {
 	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
-	ctx.Config = config.NewConfig()
 	tmpDir := t.TempDir()
 
 	cmd := &Ptar{}
@@ -40,7 +38,6 @@ func TestCov80PtarParseEncryptedPeerConfigPassphrase(t *testing.T) {
 	srcRepo, _ := ptesting.GenerateRepository(t, nil, nil, &peerPass)
 
 	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
-	ctx.Config = config.NewConfig()
 	ctx.Config.Repositories["peer"] = map[string]string{
 		"location":   srcRepo.Root(),
 		"passphrase": string(peerPass),
@@ -65,7 +62,6 @@ func TestCov80PtarParseEncryptedPeerWrongPassphrase(t *testing.T) {
 	srcRepo, _ := ptesting.GenerateRepository(t, nil, nil, &peerPass)
 
 	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
-	ctx.Config = config.NewConfig()
 	ctx.Config.Repositories["peer"] = map[string]string{
 		"location":   srcRepo.Root(),
 		"passphrase": "wrong-passphrase",
@@ -96,7 +92,6 @@ func TestCov80PtarSyncEncryptedPeerEndToEnd(t *testing.T) {
 	defer srcSnap.Close()
 
 	dstRepo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
-	ctx.Config = config.NewConfig()
 	ctx.Config.Repositories["peer"] = map[string]string{
 		"location":   srcRepo.Root(),
 		"passphrase": string(peerPass),

--- a/subcommands/ptar/ptar_coverage2_test.go
+++ b/subcommands/ptar/ptar_coverage2_test.go
@@ -7,7 +7,6 @@ import (
 
 	_ "github.com/PlakarKorp/integrations/fs/importer"
 	_ "github.com/PlakarKorp/integrations/ptar/storage"
-	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -85,7 +84,6 @@ func TestCov2ExecuteAtSourceResolved(t *testing.T) {
 	})
 	tmpDir := t.TempDir()
 
-	ctx.Config = config.NewConfig()
 	ctx.Config.Sources["mysrc"] = map[string]string{"location": "fs:" + filepath.Join(src, "subdir")}
 
 	cmd := &Ptar{}

--- a/subcommands/ptar/ptar_coverage_test.go
+++ b/subcommands/ptar/ptar_coverage_test.go
@@ -169,5 +169,5 @@ func TestPtarExecuteUnresolvableSource(t *testing.T) {
 	status, err := cmd.Execute(ctx, repo)
 	require.Error(t, err)
 	require.Equal(t, 1, status)
-	require.Contains(t, err.Error(), "could not resolve importer")
+	require.Contains(t, err.Error(), "source configuration not found")
 }

--- a/subcommands/ptar/ptar_coverage_test.go
+++ b/subcommands/ptar/ptar_coverage_test.go
@@ -7,7 +7,6 @@ import (
 
 	_ "github.com/PlakarKorp/integrations/fs/importer"
 	_ "github.com/PlakarKorp/integrations/ptar/storage"
-	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +85,6 @@ func TestPtarParseMultipleTargets(t *testing.T) {
 
 func TestPtarParseUnknownPeer(t *testing.T) {
 	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
-	ctx.Config = config.NewConfig()
 	tmpDir := t.TempDir()
 
 	cmd := &Ptar{}
@@ -162,10 +160,6 @@ func TestPtarExecuteNoCompression(t *testing.T) {
 func TestPtarExecuteUnresolvableSource(t *testing.T) {
 	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
 	tmpDir := t.TempDir()
-
-	// GenerateRepositoryWithoutConfig leaves ctx.Config nil; the @source
-	// resolution path dereferences it, so install an empty config.
-	ctx.Config = config.NewConfig()
 
 	cmd := &Ptar{}
 	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "u.ptar")}))

--- a/subcommands/restore/restore.go
+++ b/subcommands/restore/restore.go
@@ -147,25 +147,14 @@ func (cmd *Restore) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 		return 1, fmt.Errorf("multiple snapshots found, please specify one")
 	}
 
-	exporterConfig := map[string]string{
-		"location": cmd.Target,
-	}
-	if strings.HasPrefix(cmd.Target, "@") {
-		remote, ok := ctx.Config.GetDestination(cmd.Target[1:])
-		if !ok {
-			return 1, fmt.Errorf("could not resolve exporter: %s", cmd.Target)
-		}
-		if _, ok := remote["location"]; !ok {
-			return 1, fmt.Errorf("could not resolve exporter location: %s", cmd.Target)
-		} else {
-			exporterConfig = remote
-		}
+	exporterConfig, err := ctx.Config.GetDestination(cmd.Target)
+	if err != nil {
+		return 1, err
 	}
 
 	maps.Copy(exporterConfig, cmd.Opts)
 
 	var exporterInstance exporter.Exporter
-	var err error
 	options := ctx.ExporterOpts()
 
 	exporterInstance, err = exporter.NewExporter(ctx.GetInner(), options, exporterConfig)

--- a/subcommands/sync/sync_coverage3_test.go
+++ b/subcommands/sync/sync_coverage3_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/plakar/appcontext"
-	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,6 @@ func cov3ParseCtx(t *testing.T) *appcontext.AppContext {
 	ctx.Stdout = bytes.NewBuffer(nil)
 	ctx.Stderr = bytes.NewBuffer(nil)
 	ctx.SetLogger(logging.NewLogger(ctx.Stdout, ctx.Stderr))
-	ctx.Config = config.NewConfig()
 	return ctx
 }
 

--- a/subcommands/sync/sync_test.go
+++ b/subcommands/sync/sync_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
-	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +72,6 @@ func setupSync(t *testing.T, localPassphrase, peerPassphrase []byte) *syncFixtur
 		output:    bufOut,
 	}
 
-	localCtx.Config = config.NewConfig()
 	if peerPassphrase != nil {
 		// an encrypted peer can only provide its passphrase through the
 		// configuration (or interactively), address it as @peer.


### PR DESCRIPTION
config: unify Get{Source,Store,Destination} behaviour

* let all of them to resolve internally the "at aliases" syntax
* all of them return a map or an error, not a boolean
* they verify internally that location is set

The visible changes are:
* the message for an alias not found or a location missing is
  slightly different
* passphrase_cmd gets replaced everywhere: I've checked all the
  currently packaged importers and exporters, and no-one is using it,
  I'm fine with this trade-off for now, in the near future it'll get
  replaced by a better mechanism anyway.