### PR TITLE
change clone semantics, old one is problematic on multiple levels

### DIFF
--- a/subcommands/clone/plakar-clone.1
+++ b/subcommands/clone/plakar-clone.1
@@ -11,10 +11,11 @@
 .Sh DESCRIPTION
 The
 .Nm plakar clone
-command creates a full clone of an existing Plakar repository,
-including all snapshots, packfiles, and repository states, and saves
-it at the specified
-.Ar path .
+command creates a new empty Plakar store at the specified
+.Ar path
+with a configuration identical to the origin.
+This is only useful in situations where the stores must share
+encryption and chunking parametres.
 .Sh EXAMPLES
 Clone a repository to a new location:
 .Bd -literal -offset indent


### PR DESCRIPTION
make clone create an _empty_ store with a config cloned on the origin one.

change its UUID so there's no cache ambiguity.