### PR TITLE
Remove `plakar diag errors` from doc

### DIFF
--- a/subcommands/diag/plakar-diag.1
+++ b/subcommands/diag/plakar-diag.1
@@ -6,7 +6,7 @@
 .Nd Display detailed information about Plakar internal structures
 .Sh SYNOPSIS
 .Nm plakar diag
-.Op Cm contenttype | errors | locks | object | packfile | snapshot | state | vfs | xattr
+.Op Cm contenttype | locks | object | packfile | snapshot | state | vfs | xattr
 .Sh DESCRIPTION
 The
 .Nm plakar diag
@@ -17,8 +17,6 @@ Without any arguments, display information about the repository.
 The sub-commands are as follows:
 .Bl -tag -width Ds
 .It Cm contenttype Ar snapshotID : Ns Ar path
-.It Cm errors Ar snapshotID
-Display the list of errors in the given snapshot.
 .It Cm locks
 Display the list of locks currently held on the repository.
 .It Cm object Ar objectID

--- a/subcommands/diag/repository.go
+++ b/subcommands/diag/repository.go
@@ -24,7 +24,6 @@ func (cmd *DiagRepository) Parse(ctx *appcontext.AppContext, args []string) erro
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "       %s snapshot SNAPSHOT\n", flags.Name())
-		fmt.Fprintf(flags.Output(), "       %s errors SNAPSHOT\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "       %s state [STATE]...\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "       %s search snapshot[:path] mime\n", flags.Name())
 		fmt.Fprintf(flags.Output(), "       %s packfile [PACKFILE]...\n", flags.Name())

--- a/subcommands/help/docs/plakar-diag.md
+++ b/subcommands/help/docs/plakar-diag.md
@@ -7,7 +7,7 @@ PLAKAR-DIAG(1) - General Commands Manual
 # SYNOPSIS
 
 **plakar&nbsp;diag**
-\[**contenttype**&nbsp;|&nbsp;**errors**&nbsp;|&nbsp;**locks**&nbsp;|&nbsp;**object**&nbsp;|&nbsp;**packfile**&nbsp;|&nbsp;**snapshot**&nbsp;|&nbsp;**state**&nbsp;|&nbsp;**vfs**&nbsp;|&nbsp;**xattr**]
+\[**contenttype**&nbsp;|&nbsp;**locks**&nbsp;|&nbsp;**object**&nbsp;|&nbsp;**packfile**&nbsp;|&nbsp;**snapshot**&nbsp;|&nbsp;**state**&nbsp;|&nbsp;**vfs**&nbsp;|&nbsp;**xattr**]
 
 # DESCRIPTION
 
@@ -20,10 +20,6 @@ Without any arguments, display information about the repository.
 The sub-commands are as follows:
 
 **contenttype** *snapshotID*:*path*
-
-**errors** *snapshotID*
-
-> Display the list of errors in the given snapshot.
 
 **locks**
 


### PR DESCRIPTION
The command has been moved a while ago to `plakar info` (4653c935a7a2b6).