### PR TITLE
set UI token 

### DIFF
--- a/subcommands/ui/ui.go
+++ b/subcommands/ui/ui.go
@@ -22,6 +22,7 @@ package ui
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -74,7 +75,11 @@ func (cmd *Ui) Execute(ctx *appcontext.AppContext, repo *repository.Repository) 
 	}
 
 	if !cmd.NoAuth {
-		ui_opts.Token = uuid.NewString()
+		if uiToken := os.Getenv("PLAKAR_UI_TOKEN"); uiToken != "" {
+			ui_opts.Token = uiToken
+		} else {
+			ui_opts.Token = uuid.NewString()
+		}
 	}
 
 	err := v2.Ui(repo, ctx, cmd.Addr, &ui_opts)


### PR DESCRIPTION
Retrieve UI token from environment variable or generate a new one.

read PLAKAR_UI_TOKEN if exist, else generate random uuidv4

why : when `plaker ui` is started as linux service (systemct), random auth token is not usable. 