### PR TITLE
unbreak pkg build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/PlakarKorp/integration-stdio v1.0.5-0.20260115153145-4c4e247d2c13
 	github.com/PlakarKorp/integration-tar v1.0.0-beta.7.0.20260115153106-47718979f565
 	github.com/PlakarKorp/kloset v1.0.13-0.20260126092019-3116b47cfeea
-	github.com/PlakarKorp/pkg v0.0.0-20260123134034-0e5d7163207c
+	github.com/PlakarKorp/pkg v0.0.0-20260124184248-1c75d48aecf3
 	github.com/alecthomas/chroma v0.10.0
 	github.com/anacrolix/fuse v0.3.1
 	github.com/charmbracelet/bubbles v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/PlakarKorp/integration-tar v1.0.0-beta.7.0.20260115153106-47718979f56
 github.com/PlakarKorp/integration-tar v1.0.0-beta.7.0.20260115153106-47718979f565/go.mod h1:nXTa8Kwr+62pUzMqJXX8eJlBAyOUNE/KcQrOD0Uol4E=
 github.com/PlakarKorp/kloset v1.0.13-0.20260126092019-3116b47cfeea h1:rOVMRvtBfoiYnAc2ktsGAcxy/KD45ppmwJpA38euvqs=
 github.com/PlakarKorp/kloset v1.0.13-0.20260126092019-3116b47cfeea/go.mod h1:qm4dhS+wLPBzu/r+cPuhyyyeCJNz6m0AZSK/3lkZjGY=
-github.com/PlakarKorp/pkg v0.0.0-20260123134034-0e5d7163207c h1:BiBFNSczw/8yumekc/nx92E75b7EYN9g+o1Oysp1nfM=
-github.com/PlakarKorp/pkg v0.0.0-20260123134034-0e5d7163207c/go.mod h1:xNvlGco7tRBv3u2gZySsvvxnOWPPM8CIDNu8bBPU1D0=
+github.com/PlakarKorp/pkg v0.0.0-20260124184248-1c75d48aecf3 h1:aJ8zLIbCsKw7Bx0jKrjMS7jkT2CeYpLSVpilUCOMbD8=
+github.com/PlakarKorp/pkg v0.0.0-20260124184248-1c75d48aecf3/go.mod h1:xNvlGco7tRBv3u2gZySsvvxnOWPPM8CIDNu8bBPU1D0=
 github.com/RaduBerinde/axisds v0.1.0 h1:YItk/RmU5nvlsv/awo2Fjx97Mfpt4JfgtEVAGPrLdz8=
 github.com/RaduBerinde/axisds v0.1.0/go.mod h1:UHGJonU9z4YYGKJxSaC6/TNcLOBptpmM5m2Cksbnw0Y=
 github.com/RaduBerinde/btreemap v0.0.0-20250419174037-3d62b7205d54 h1:bsU8Tzxr/PNz75ayvCnxKZWEYdLMPDkUgticP4a4Bvk=

--- a/subcommands/pkg/build.go
+++ b/subcommands/pkg/build.go
@@ -99,7 +99,7 @@ func (cmd *PkgBuild) Execute(ctx *appcontext.AppContext, repo *repository.Reposi
 	// a bit hacky, needed until we move the plugin routines from
 	// commands to a lib:
 	create := PkgCreate{}
-	if err := create.Parse(ctx, []string{manifest}); err != nil {
+	if err := create.Parse(ctx, []string{manifest, recipe.Version}); err != nil {
 		return 1, err
 	}
 	create.Out = recipe.PkgName()


### PR DESCRIPTION
with the switch to the new package manager, I got rid of a few functions.  Unfortunately, I've forgot to fix pkg build.

I've made pkg.Manager.FetchRecipe public, so we can laverage that. While here, simplify the code and inline isRemote and isBase, to make the code easier to read.

Also, remember to pass the version to pkg create, since that's now mandatory (version doesn't live in the manifest anymore.)