### PR TITLE
cached: Fix error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PlakarKorp/integration-ptar v1.0.6-0.20260124104114-70e3946c0ffc
 	github.com/PlakarKorp/integration-stdio v1.0.5-0.20260115153145-4c4e247d2c13
 	github.com/PlakarKorp/integration-tar v1.0.0-beta.7.0.20260115153106-47718979f565
-	github.com/PlakarKorp/kloset v1.0.13-0.20260126092019-3116b47cfeea
+	github.com/PlakarKorp/kloset v1.0.13-0.20260126142743-3872419d3b67
 	github.com/PlakarKorp/pkg v0.0.0-20260124184248-1c75d48aecf3
 	github.com/alecthomas/chroma v0.10.0
 	github.com/anacrolix/fuse v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/PlakarKorp/integration-stdio v1.0.5-0.20260115153145-4c4e247d2c13 h1:
 github.com/PlakarKorp/integration-stdio v1.0.5-0.20260115153145-4c4e247d2c13/go.mod h1:SPCmgU/hezJJanOZpYtBkCgoj4KCBWOwZILW6zJ7x6k=
 github.com/PlakarKorp/integration-tar v1.0.0-beta.7.0.20260115153106-47718979f565 h1:VFc4V3+Y3sHn/93ltX7DFfHME8TAGR4YjoK0CBJKnZo=
 github.com/PlakarKorp/integration-tar v1.0.0-beta.7.0.20260115153106-47718979f565/go.mod h1:nXTa8Kwr+62pUzMqJXX8eJlBAyOUNE/KcQrOD0Uol4E=
-github.com/PlakarKorp/kloset v1.0.13-0.20260126092019-3116b47cfeea h1:rOVMRvtBfoiYnAc2ktsGAcxy/KD45ppmwJpA38euvqs=
-github.com/PlakarKorp/kloset v1.0.13-0.20260126092019-3116b47cfeea/go.mod h1:qm4dhS+wLPBzu/r+cPuhyyyeCJNz6m0AZSK/3lkZjGY=
+github.com/PlakarKorp/kloset v1.0.13-0.20260126142743-3872419d3b67 h1:lt68qQZBw75u8zlpL2FWfbvzjUkNrC8+DkthtbF3LSw=
+github.com/PlakarKorp/kloset v1.0.13-0.20260126142743-3872419d3b67/go.mod h1:qm4dhS+wLPBzu/r+cPuhyyyeCJNz6m0AZSK/3lkZjGY=
 github.com/PlakarKorp/pkg v0.0.0-20260124184248-1c75d48aecf3 h1:aJ8zLIbCsKw7Bx0jKrjMS7jkT2CeYpLSVpilUCOMbD8=
 github.com/PlakarKorp/pkg v0.0.0-20260124184248-1c75d48aecf3/go.mod h1:xNvlGco7tRBv3u2gZySsvvxnOWPPM8CIDNu8bBPU1D0=
 github.com/RaduBerinde/axisds v0.1.0 h1:YItk/RmU5nvlsv/awo2Fjx97Mfpt4JfgtEVAGPrLdz8=

--- a/subcommands/cached/cached.go
+++ b/subcommands/cached/cached.go
@@ -30,10 +30,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/encryption"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
-	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/cached"
 	"github.com/PlakarKorp/plakar/subcommands"
@@ -246,10 +246,12 @@ func (cmd *Cached) handleCachedClient(ctx *appcontext.AppContext, conn net.Conn)
 	var err error
 	cmd.jobMtx.Lock()
 	if jq, ok = cmd.jobQueue[pkt.RepoID]; !ok {
-		cmd.jobQueue[pkt.RepoID] = make(chan jobReq, 1024)
-		jq = cmd.jobQueue[pkt.RepoID]
-
+		jq = make(chan jobReq, 1024)
 		err = cmd.rebuildJob(ctx, jq, pkt.RepoID, pkt.Secret, pkt.StoreConfig)
+
+		if err == nil {
+			cmd.jobQueue[pkt.RepoID] = jq
+		}
 	}
 	cmd.jobMtx.Unlock()
 


### PR DESCRIPTION
* When we fail to setup the rebuildJob goroutine early, we would enter a deadlock, because no one was listening on the channel. To fix it, install the channel only when we know that rebuildJob has started the processing goroutine.