### PR TITLE
tui: Only fire the interrupt event once.

### DIFF
--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -53,6 +53,7 @@ func (tui *tui) Run() error {
 
 		var app *commandApp
 
+		hasSeenStop := false
 		for e := range events {
 			// If app is running, forward event (non-blocking / cancel-safe)
 			if app != nil {
@@ -61,9 +62,15 @@ func (tui *tui) Run() error {
 				case <-app.done:
 					if app.err != nil {
 						if errors.Is(app.err, tea.ErrInterrupted) {
-							tui.done <- ui.ErrUserAbort
+							if !hasSeenStop {
+								hasSeenStop = true
+								tui.done <- ui.ErrUserAbort
+							}
 						} else {
-							tui.done <- app.err
+							if !hasSeenStop {
+								hasSeenStop = true
+								tui.done <- app.err
+							}
 						}
 					}
 				}


### PR DESCRIPTION
* Otherwise we neever exit the main loop and we do not reap the TUI program. We can't break of the outer loop cause we need to drain all events, so simply ignore them.