### PR TITLE
cached: Bypass it entirely on Windows

### DIFF
--- a/cached/cached.go
+++ b/cached/cached.go
@@ -45,38 +45,6 @@ var (
 	ErrWrongVersion = errors.New("cached is running with a different version of plakar")
 )
 
-func RebuildStateFromStateFile(ctx *appcontext.AppContext, stateID objects.MAC, repoID uuid.UUID, storeConfig map[string]string, fireAndForget bool) (int, error) {
-	t0 := time.Now()
-	defer func() {
-		ctx.GetLogger().Trace("cached", "rebuild from local statefile (file=%x, store=%s): %s", stateID, repoID, time.Since(t0))
-	}()
-
-	req := &RequestPkt{
-		Secret:        ctx.GetSecret(),
-		RepoID:        repoID,
-		StoreConfig:   storeConfig,
-		StateID:       stateID,
-		FireAndForget: fireAndForget,
-	}
-
-	return rebuildStateRequest(ctx, req)
-}
-
-func RebuildStateFromStore(ctx *appcontext.AppContext, repoID uuid.UUID, storeConfig map[string]string, fireAndForget bool) (int, error) {
-	t0 := time.Now()
-	defer func() {
-		ctx.GetLogger().Trace("cached", "rebuild from store (store=%s): %s", repoID, time.Since(t0))
-	}()
-	req := &RequestPkt{
-		Secret:        ctx.GetSecret(),
-		RepoID:        repoID,
-		StoreConfig:   storeConfig,
-		FireAndForget: fireAndForget,
-	}
-
-	return rebuildStateRequest(ctx, req)
-}
-
 func rebuildStateRequest(ctx *appcontext.AppContext, req *RequestPkt) (int, error) {
 	client, err := newClient(filepath.Join(ctx.CacheDir, "cached.sock"), false)
 	if err != nil {

--- a/cached/cached_unix.go
+++ b/cached/cached_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package cached
+
+import (
+	"time"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/google/uuid"
+)
+
+func RebuildStateFromStateFile(ctx *appcontext.AppContext, stateID objects.MAC, repoID uuid.UUID, storeConfig map[string]string, fireAndForget bool) (int, error) {
+	t0 := time.Now()
+	defer func() {
+		ctx.GetLogger().Trace("cached", "rebuild from local statefile (file=%x, store=%s): %s", stateID, repoID, time.Since(t0))
+	}()
+
+	req := &RequestPkt{
+		Secret:        ctx.GetSecret(),
+		RepoID:        repoID,
+		StoreConfig:   storeConfig,
+		StateID:       stateID,
+		FireAndForget: fireAndForget,
+	}
+
+	return rebuildStateRequest(ctx, req)
+}
+
+func RebuildStateFromStore(ctx *appcontext.AppContext, repoID uuid.UUID, storeConfig map[string]string, fireAndForget bool) (int, error) {
+	t0 := time.Now()
+	defer func() {
+		ctx.GetLogger().Trace("cached", "rebuild from store (store=%s): %s", repoID, time.Since(t0))
+	}()
+	req := &RequestPkt{
+		Secret:        ctx.GetSecret(),
+		RepoID:        repoID,
+		StoreConfig:   storeConfig,
+		FireAndForget: fireAndForget,
+	}
+
+	return rebuildStateRequest(ctx, req)
+}

--- a/cached/cached_windows.go
+++ b/cached/cached_windows.go
@@ -1,0 +1,98 @@
+package cached
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/encryption"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/google/uuid"
+)
+
+func RebuildStateFromStateFile(ctx *appcontext.AppContext, stateID objects.MAC, repoID uuid.UUID, storeConfig map[string]string, fireAndForget bool) (int, error) {
+	t0 := time.Now()
+	defer func() {
+		ctx.GetLogger().Trace("cached", "rebuild from local statefile (file=%x, store=%s): %s", stateID, repoID, time.Since(t0))
+	}()
+
+	var serializedConfig []byte
+	store, serializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
+	if err != nil {
+		return -1, fmt.Errorf("failed to open storage: %w", err)
+	}
+
+	key, err := getSecret(ctx, ctx.GetSecret(), serializedConfig)
+	if err != nil {
+		return -1, fmt.Errorf("failed to setup secret: %w", err)
+	}
+
+	repo, err := repository.NewNoRebuild(ctx.GetInner(), key, store, serializedConfig, false)
+	if err != nil {
+		return -1, fmt.Errorf("failed to open repository: %w", err)
+	}
+
+	if repoID != repo.Configuration().RepositoryID {
+		return -1, fmt.Errorf("invalid uuid given %q repository id is %q", repoID.String(), repo.Configuration().RepositoryID.String())
+	}
+
+	if err := repo.IngestStateFile(stateID); err != nil {
+		return -1, err
+	}
+
+	return 0, nil
+}
+
+func RebuildStateFromStore(ctx *appcontext.AppContext, repoID uuid.UUID, storeConfig map[string]string, fireAndForget bool) (int, error) {
+	t0 := time.Now()
+	defer func() {
+		ctx.GetLogger().Trace("cached", "rebuild from store (store=%s): %s", repoID, time.Since(t0))
+	}()
+
+	var serializedConfig []byte
+	store, serializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
+	if err != nil {
+		return -1, fmt.Errorf("failed to open storage: %w", err)
+	}
+
+	key, err := getSecret(ctx, ctx.GetSecret(), serializedConfig)
+	if err != nil {
+		return -1, fmt.Errorf("failed to setup secret: %w", err)
+	}
+
+	repo, err := repository.NewNoRebuild(ctx.GetInner(), key, store, serializedConfig, false)
+	if err != nil {
+		return -1, fmt.Errorf("failed to open repository: %w", err)
+	}
+
+	if repoID != repo.Configuration().RepositoryID {
+		return -1, fmt.Errorf("invalid uuid given %q repository id is %q", repoID.String(), repo.Configuration().RepositoryID.String())
+	}
+
+	if err := repo.RebuildState(); err != nil {
+		return -1, err
+	}
+
+	return 0, nil
+}
+
+// A bit of copy pasta, we'll clean this up globally.
+func getSecret(ctx *appcontext.AppContext, secret []byte, storageConfig []byte) ([]byte, error) {
+	config, err := storage.NewConfigurationFromWrappedBytes(storageConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Encryption == nil {
+		return nil, nil
+	}
+
+	key := secret
+	if !encryption.VerifyCanary(config.Encryption, key) {
+		return nil, fmt.Errorf("failed to verify key")
+	}
+
+	return key, nil
+}

--- a/main.go
+++ b/main.go
@@ -401,8 +401,8 @@ func entryPoint() int {
 			return 1
 		}
 
-		// Actual rebuild is done by cached.
-		repo, err = repository.NewNoRebuild(ctx.GetInner(), ctx.GetSecret(), store, serializedConfig, true)
+		// Actual rebuild is done by cached, unless we are on windows.
+		repo, err = repository.NewNoRebuild(ctx.GetInner(), ctx.GetSecret(), store, serializedConfig, runtime.GOOS != "windows")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", flag.CommandLine.Name(), err)
 			return 1


### PR DESCRIPTION
* Bypasses cached on Windows by issueing direct calls to RebuildState / IngestStateFile.

* As a consequence, change the way we open the repository, we need to open the cache r/w on windows.

* This fixes the windows build, and brings us back to the status-quo of previous version (no concurrent usages of plakar).