### PR TITLE
cached: Discard logs instead of exiting when local syslog is unavailable

### DIFF
--- a/subcommands/cached/cached.go
+++ b/subcommands/cached/cached.go
@@ -100,7 +100,9 @@ func (cmd *Cached) Parse(ctx *appcontext.AppContext, args []string) error {
 		ctx.GetLogger().SetOutput(f)
 	} else if !opt_foreground {
 		if err := setupSyslog(ctx); err != nil {
-			return err
+			ctx.GetLogger().Error("failed to setup syslog: %s", err)
+			ctx.GetLogger().Error("will discard all future logs")
+			ctx.GetLogger().SetOutput(io.Discard)
 		}
 	}
 


### PR DESCRIPTION
Fixes #1988.

See issue for bug analysis.

This PR is a simple fix by copying the error handling from the very similar in terms of logging behaviour `plakar scheduler` subcommand.