### PR TITLE
appcontext: introduce Quiet and Silent

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -20,6 +20,9 @@ type AppContext struct {
 	secret    []byte
 
 	StoreConfig map[string]string
+
+	Quiet  bool
+	Silent bool
 }
 
 func NewAppContext() *AppContext {


### PR DESCRIPTION
they were previously in KContext, but it's only a client-side thing, so let's move them here.