### PR TITLE
windows: enable the TUI; fix the terminal check

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/PlakarKorp/plakar/ui/tui"
 	"github.com/PlakarKorp/plakar/utils"
-	"github.com/charmbracelet/x/term"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/google/uuid"
 
@@ -166,7 +165,7 @@ func entryPoint() int {
 	defer ctx.Close()
 
 	var renderer ui.UI
-	if opt_silent || opt_stdio || opt_quiet || opt_trace != "" || !term.IsTerminal(1) {
+	if opt_silent || opt_stdio || opt_quiet || opt_trace != "" || isTerminal() {
 		renderer = stdio.New(ctx)
 	} else if opt_json {
 		renderer = jsonui.New(ctx)

--- a/term.go
+++ b/term.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "github.com/charmbracelet/x/term"
+
+func isTerminal() bool {
+	return term.IsTerminal(1)
+}

--- a/term_windows.go
+++ b/term_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+func isTerminal() bool {
+	var st uint32
+	return windows.GetConsoleMode(windows.Stdout, &st) == nil
+
+}


### PR DESCRIPTION
term.IsTerminal(1) fails on windows because the way it's implemented on windows: it casts 1 into an handler, but it's incorrect!  It should use windows.STD_OUTPUT_HANDLE (which is -11 & (1<<32 - 1) for reasons).

so, introduce a local isTerminal() with a specific windows implementation.