### PR TITLE
build: add Dockerfile for CI/CD pipeline use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.github
+.goreleaser.yml
+.gitignore
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+docs/
+unittests/
+testing/
+dist/
+plakar
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Limitations:
+#   This container runs plakar without a shared host cache.
+#   Each invocation starts with a cold cache (no VFS cache, no cached
+#   daemon persistence).  For improved incremental performance, mount a
+#   persistent volume at the plakar cache directory, e.g.:
+#       docker run -v plakar-cache:/home/plakar/.cache/plakar ...
+#
+# Stage 1: Build
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+
+# Cache dependency downloads
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy full source (ui/v2/frontend/ and subcommands/help/docs/ are embedded via go:embed)
+COPY . .
+
+# Build static binary matching goreleaser configuration
+RUN CGO_ENABLED=0 go build -trimpath -v -o /plakar .
+
+# Stage 2: Runtime
+FROM alpine:3.23
+
+# CA certificates for HTTPS connections to remote repositories and plakar.io
+RUN apk add --no-cache ca-certificates
+
+# Create non-root user (/etc/passwd required by user.Current())
+RUN addgroup -S plakar && adduser -S -G plakar -h /home/plakar plakar
+
+COPY --from=builder /plakar /usr/local/bin/plakar
+
+USER plakar
+WORKDIR /home/plakar
+
+ENTRYPOINT ["plakar"]


### PR DESCRIPTION
Adds a minimal multi-stage Dockerfile and `.dockerignore` for building a container image.

Supersedes #1232 — incorporates maintainer feedback from that PR:
- **No UI-specific configuration** (per @poolpOrg and @omar-polo's feedback on #1232)
- **No docker-compose or startup scripts** — just a clean Dockerfile skeleton
- **CLI-first design** — `ENTRYPOINT ["plakar"]`, suitable for both automation (`docker run plakar backup /data`) and interactive use (`docker run -it plakar ui`)

Closes #1533

## Changes

- Multi-stage build: `golang:1.24-alpine` builder → `alpine:3.21` runtime
- `CGO_ENABLED=0` static binary (matches goreleaser config)
- Includes `ca-certificates` for HTTPS to remote repositories
- Non-root `plakar` user (`/etc/passwd` present — required by `user.Current()`)
- Preserves embedded assets (`ui/v2/frontend/`, `subcommands/help/docs/`) required by `go:embed`
- Image size: ~80MB (70.7MB binary + Alpine base)

## Usage

```sh
docker build -t plakar .
docker run --rm plakar version

# Backup in a pipeline
docker run --rm -v /data:/data plakar backup /data

# Run the UI (the image supports all subcommands)
docker run --rm -p 8080:8080 plakar ui -addr 0.0.0.0:8080
```