### PR TITLE
tui: Debounce the iostats call.

### DIFF
--- a/ui/tui/app.go
+++ b/ui/tui/app.go
@@ -26,6 +26,9 @@ type Application struct {
 	done   chan struct{} // closed when Bubbletea program exits
 	prog   *tea.Program
 	err    error
+
+	debounceStat time.Time
+	lastStat     string
 }
 
 type State struct {

--- a/ui/tui/view.go
+++ b/ui/tui/view.go
@@ -246,17 +246,24 @@ func (m appModel) View() string {
 		if m.repo == nil {
 			return
 		}
-		ioStats := m.repo.IOStats()
-		indent := strings.Repeat(" ", len(humanDuration(time.Since(state.startTime))))
-		r := ioStats.Read.Stats()
-		w := ioStats.Write.Stats()
 
-		fmt.Fprintf(&s,
-			"%s    store: read=%s, write=%s\n",
-			indent,
-			formatBytes(r.TotalBytes),
-			formatBytes(w.TotalBytes),
-		)
+		if time.Since(m.application.debounceStat) >= 1*time.Second {
+			ioStats := m.repo.IOStats()
+			indent := strings.Repeat(" ", len(humanDuration(time.Since(state.startTime))))
+			r := ioStats.Read.Stats()
+			w := ioStats.Write.Stats()
+
+			m.application.lastStat = fmt.Sprintf(
+				"%s    store: read=%s, write=%s\n",
+				indent,
+				formatBytes(r.TotalBytes),
+				formatBytes(w.TotalBytes),
+			)
+
+			m.application.debounceStat = time.Now()
+		}
+
+		fmt.Fprint(&s, m.application.lastStat)
 	}
 
 	// --- shared line writer: prefix + item + right-aligned tail ---


### PR DESCRIPTION
* This call is heavy, and imho problematic (it's unbounded so on long back ups we will sort a huge slice, it also takes a lock etc). For now the easy route is to debounce it, View() is called any time a msg is received by the TUI which is _all the time_ for us, so debounce every once second the call to amortize the cost.

* This change the frequency of IOStat call from :
    > 1911 io stat reads
    to
    > 20 io stat reads