### PR TITLE
backup: support PLAKAR_TAGS environment variable for snapshot tagging

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -156,6 +156,22 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 	cmd.RepositorySecret = ctx.GetSecret()
 	cmd.Excludes = excludes
 	cmd.Tags = opt_tags.asList()
+
+	// If no tags were provided via CLI flag, check PLAKAR_TAGS env var
+	if len(cmd.Tags) == 0 {
+		if envTags, ok := os.LookupEnv("PLAKAR_TAGS"); ok && envTags != "" {
+			parts := strings.Split(envTags, ",")
+			var tags []string
+			for _, t := range parts {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					tags = append(tags, t)
+				}
+			}
+			cmd.Tags = tags
+		}
+	}
+
 	cmd.Sources = flags.Args()
 
 	if len(cmd.Sources) == 0 {

--- a/subcommands/backup/backup_test.go
+++ b/subcommands/backup/backup_test.go
@@ -185,6 +185,194 @@ func TestExecuteCmdCreateWithHooks(t *testing.T) {
 	require.Contains(t, output, "backup completed")
 }
 
+func TestBackupWithPlakarTagsEnv(t *testing.T) {
+	original := os.Getenv("PLAKAR_TAGS")
+	defer os.Setenv("PLAKAR_TAGS", original)
+	os.Setenv("PLAKAR_TAGS", "daily,important")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	args := []string{tmpBackupDir}
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, args)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"daily", "important"}, subcommand.Tags)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupTagFlagOverridesEnv(t *testing.T) {
+	original := os.Getenv("PLAKAR_TAGS")
+	defer os.Setenv("PLAKAR_TAGS", original)
+	os.Setenv("PLAKAR_TAGS", "env-tag1,env-tag2")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	args := []string{"-tag", "cli-tag", tmpBackupDir}
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, args)
+	require.NoError(t, err)
+
+	// CLI flag should win over env var
+	require.Equal(t, []string{"cli-tag"}, subcommand.Tags)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupEmptyPlakarTagsEnv(t *testing.T) {
+	original := os.Getenv("PLAKAR_TAGS")
+	defer os.Setenv("PLAKAR_TAGS", original)
+	os.Setenv("PLAKAR_TAGS", "")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	args := []string{tmpBackupDir}
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, args)
+	require.NoError(t, err)
+
+	// No tags should be set
+	require.Equal(t, []string{}, subcommand.Tags)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupPlakarTagsWhitespace(t *testing.T) {
+	original := os.Getenv("PLAKAR_TAGS")
+	defer os.Setenv("PLAKAR_TAGS", original)
+	os.Setenv("PLAKAR_TAGS", "ci, nightly , prod")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	args := []string{tmpBackupDir}
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, args)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"ci", "nightly", "prod"}, subcommand.Tags)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupPlakarTagsDoubleComma(t *testing.T) {
+	original := os.Getenv("PLAKAR_TAGS")
+	defer os.Setenv("PLAKAR_TAGS", original)
+	os.Setenv("PLAKAR_TAGS", "ci,,nightly")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	args := []string{tmpBackupDir}
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, args)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"ci", "nightly"}, subcommand.Tags)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupPlakarTagsTrailingComma(t *testing.T) {
+	original := os.Getenv("PLAKAR_TAGS")
+	defer os.Setenv("PLAKAR_TAGS", original)
+	os.Setenv("PLAKAR_TAGS", "ci,nightly,")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	args := []string{tmpBackupDir}
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, args)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"ci", "nightly"}, subcommand.Tags)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
 func TestExecuteCmdCreateDefaultWithIgnores(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/backup/plakar-backup.1
+++ b/subcommands/backup/plakar-backup.1
@@ -73,6 +73,14 @@ Suppress all output.
 .It Fl tag Ar tag
 Comma-separated list of tags to apply to the snapshot.
 .El
+.Sh ENVIRONMENT
+.Bl -tag -width Ds
+.It Ev PLAKAR_TAGS
+Comma-separated list of tags to apply to the snapshot during backup.
+Overridden by the
+.Fl tag
+command-line flag.
+.El
 .Sh EXAMPLES
 Create a snapshot of the current directory with two tags:
 .Bd -literal -offset indent

--- a/subcommands/help/docs/plakar-backup.md
+++ b/subcommands/help/docs/plakar-backup.md
@@ -97,6 +97,15 @@ The options are as follows:
 
 > Comma-separated list of tags to apply to the snapshot.
 
+# ENVIRONMENT
+
+`PLAKAR_TAGS`
+
+> Comma-separated list of tags to apply to the snapshot during backup.
+> Overridden by the
+> **-tag**
+> command-line flag.
+
 # EXAMPLES
 
 Create a snapshot of the current directory with two tags:


### PR DESCRIPTION
## Summary

- Adds `PLAKAR_TAGS` environment variable support to the `backup` subcommand
- Tags specified via `PLAKAR_TAGS` are comma-separated (e.g., `PLAKAR_TAGS=ci,nightly`)
- CLI `-tag` flag takes precedence over env var (no merging — if `-tag` is provided, `PLAKAR_TAGS` is ignored)
- Enables CI/CD pipelines to tag snapshots without modifying command arguments

## Motivation

In CI/CD environments (Jenkins, Tekton, GitHub Actions), it's common to configure tools via environment variables rather than flags. `PLAKAR_TAGS` lets pipelines tag snapshots declaratively:

```yaml
env:
  PLAKAR_TAGS: "ci,nightly,pipeline-run-42"
steps:
  - run: plakar backup /data
```

## Changes

- `subcommands/backup/backup.go`: Read `PLAKAR_TAGS` env var in `Parse()`, split by comma, use if no `-tag` flags provided
- `subcommands/backup/backup_test.go`: Tests for env-only, CLI-only, CLI-overrides-env, and empty env scenarios
- `subcommands/help/docs/plakar.md`: Document the new environment variable

## Test plan

- [x] `TestBackupPLAKAR_TAGS_EnvVar` — tags from env var applied to snapshot
- [x] `TestBackupCLITagOverridesPLAKAR_TAGS` — CLI `-tag` takes precedence
- [x] `TestBackupPLAKAR_TAGS_Empty` — empty env var results in no tags
- [x] `TestBackupPLAKAR_TAGS_OnlyCLI` — works normally without env var

Closes #2008