### PR TITLE
explicitly import the sync subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ import (
 	_ "github.com/PlakarKorp/plakar/subcommands/scheduler"
 	_ "github.com/PlakarKorp/plakar/subcommands/server"
 	_ "github.com/PlakarKorp/plakar/subcommands/service"
+	_ "github.com/PlakarKorp/plakar/subcommands/sync"
 	_ "github.com/PlakarKorp/plakar/subcommands/ui"
 	_ "github.com/PlakarKorp/plakar/subcommands/version"
 


### PR DESCRIPTION
as of now it works because it gets pulled in by the scheduler and the task subpackages; yet, require it explicitly like the others.