### PR TITLE
subcommands/cached: use strict perms for the crash log

### DIFF
--- a/subcommands/cached/cached.go
+++ b/subcommands/cached/cached.go
@@ -128,7 +128,7 @@ func (cmd *Cached) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 	// Since we are detaching, we loose all stack traces, with no possibility
 	// to recover them, try to log them to a known location.
 	crashLog := filepath.Join(ctx.GetInner().CacheDir, "crash-cached.log")
-	f, err := os.OpenFile(crashLog, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+	f, err := os.OpenFile(crashLog, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
 		return 1, err
 	}


### PR DESCRIPTION
no reasons for the group or the world to be able to read (or write!) the crash log.