### PR TITLE
api: restore directory summary in snapshotVFSChildren

### DIFF
--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -447,7 +447,7 @@ func (ui *uiserver) snapshotVFSChildren(w http.ResponseWriter, r *http.Request) 
 		return err
 	}
 
-	if !fsinfo.Stat().Mode().IsDir() {
+	if !fsinfo.IsDir() {
 		http.Error(w, "not a directory", http.StatusBadRequest)
 		return nil
 	}


### PR DESCRIPTION
After the switch to the summary index, we've forgotten to load them per each item in the api vfs children listing.  The introduced helper should probably be moved to kloset at some point.