### PR TITLE
cli: standardize exit codes for automation

### DIFF
--- a/exitcodes/exitcodes.go
+++ b/exitcodes/exitcodes.go
@@ -1,0 +1,35 @@
+// Package exitcodes defines standardized exit codes for plakar CLI.
+//
+// Codes follow sysexits.h(3) conventions where applicable.
+// See sysexits(3) for background on the standard exit code ranges.
+package exitcodes
+
+const (
+	// Success indicates the command completed successfully.
+	Success = 0
+
+	// Failure is a general error not covered by a more specific code.
+	Failure = 1
+
+	// Usage indicates invalid command-line arguments or flags.
+	// Corresponds to EX_USAGE from sysexits.h.
+	Usage = 64
+
+	// RepoNotFound indicates the repository could not be opened or located.
+	// Corresponds to EX_NOINPUT from sysexits.h.
+	RepoNotFound = 66
+
+	// RepoIncompatible indicates a repository version mismatch.
+	// Corresponds to EX_CONFIG from sysexits.h.
+	RepoIncompatible = 78
+
+	// AuthFailure indicates an authentication or decryption error
+	// (wrong passphrase, missing keyfile, locked repository).
+	// Corresponds to EX_NOPERM from sysexits.h.
+	AuthFailure = 77
+
+	// IntegrityFailure indicates a data integrity check failed
+	// (corrupted chunks, Merkle tree mismatch).
+	// Corresponds to EX_DATAERR from sysexits.h.
+	IntegrityFailure = 65
+)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/cached"
 	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/PlakarKorp/plakar/exitcodes"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/task"
 	"github.com/PlakarKorp/plakar/ui"
@@ -383,7 +384,7 @@ func entryPoint() int {
 		if err != nil {
 			logger.Stderr("%s: failed to open the repository at %s: %s\n", flag.CommandLine.Name(), storeConfig["location"], err)
 			logger.Stderr("To specify an alternative repository, please use \"plakar at <location> <command>\".")
-			return 1
+			return exitcodes.RepoNotFound
 		}
 
 		repoConfig, err := storage.NewConfigurationFromWrappedBytes(serializedConfig)
@@ -395,12 +396,12 @@ func entryPoint() int {
 		if repoConfig.Version != versioning.FromString(storage.VERSION) {
 			logger.Stderr("%s: incompatible repository version: %s != %s\n",
 				flag.CommandLine.Name(), repoConfig.Version, storage.VERSION)
-			return 1
+			return exitcodes.RepoIncompatible
 		}
 
 		if err := setupEncryption(ctx, repoConfig); err != nil {
 			logger.Stderr("%s: %s\n", flag.CommandLine.Name(), err)
-			return 1
+			return exitcodes.AuthFailure
 		}
 
 		// Actual rebuild is done by cached, unless we are on windows.

--- a/plakar.1
+++ b/plakar.1
@@ -188,6 +188,24 @@ Kloset stores configuration.
 .It Pa ~/.plakar
 Default Kloset store location.
 .El
+.Sh EXIT STATUS
+The following exit codes are aligned with sysexits(3) where applicable:
+.Bl -tag -width Ds
+.It 0
+Command completed successfully.
+.It 1
+A general error occurred.
+.It 64 (EX_USAGE)
+Invalid command-line arguments or flags.
+.It 65 (EX_DATAERR)
+Data integrity check failed (corrupted chunks, verification mismatch).
+.It 66 (EX_NOINPUT)
+The repository could not be opened or located.
+.It 77 (EX_NOPERM)
+Authentication or decryption failure (wrong passphrase, missing keyfile).
+.It 78 (EX_CONFIG)
+Incompatible repository version.
+.El
 .Sh EXAMPLES
 Create an encrypted Kloset store at the default location:
 .Bd -literal -offset indent

--- a/subcommands/check/check.go
+++ b/subcommands/check/check.go
@@ -25,6 +25,7 @@ import (
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/exitcodes"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/google/uuid"
 )
@@ -150,7 +151,7 @@ func (cmd *Check) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 		if failures == 1 {
 			snapshots = "snapshot"
 		}
-		return 1, fmt.Errorf("check failed for %d %s",
+		return exitcodes.IntegrityFailure, fmt.Errorf("check failed for %d %s",
 			failures, snapshots)
 	}
 


### PR DESCRIPTION
Defines distinct exit codes so automation tools and CI/CD pipelines can distinguish between failure modes without parsing stderr.

Related: #920

## Motivation

Currently plakar returns exit code 1 for every error — repo not found, wrong passphrase, integrity check failure, etc. Automation tools have no way to distinguish between these without parsing stderr output. This is especially relevant for CI/CD pipelines — for example Tekton Pipelines, where a finally task with `onError: continue` still exposes the exit code for downstream decision-making.

## Use cases

In a Tekton pipeline, plakar can run as a `finally` task to back up a workspace after all tasks complete. With distinct exit codes, the pipeline can react differently depending on what went wrong:

```bash
plakar backup /workspace
rc=$?
case $rc in
  0)  echo "backup successful" ;;
  66) echo "repository not found, skipping backup" ;;
  77) echo "wrong passphrase, check your secrets" ;;
  65) plakar check && echo "re-verified ok" ;;
  *)  echo "backup failed with exit code $rc" >&2; exit 1 ;;
esac
```

## Changes

- **`exitcodes/exitcodes.go`** — New package with named exit code constants mapped to sysexits.h(3)
- **`main.go`** — Returns specific codes for repo-open failure (66), version mismatch (78), and encryption errors (77)
- **`subcommands/check/check.go`** — Returns 65 on integrity check failure instead of generic 1
- **`plakar.1`** — Documents all exit codes in EXIT STATUS section

## Exit codes

Aligned with sysexits.h(3) where applicable:

| Code | sysexits.h | Meaning |
|------|------------|---------|
| 0 | EX_OK | Success |
| 1 | — | General error |
| 64 | EX_USAGE | Invalid command-line arguments or flags |
| 65 | EX_DATAERR | Data integrity check failed |
| 66 | EX_NOINPUT | Repository not found |
| 77 | EX_NOPERM | Authentication/decryption failure |
| 78 | EX_CONFIG | Incompatible repository version |

## Notes

This is intentionally a small first step — only the exit paths in `main.go` and `check` are updated. If the approach looks good, the remaining subcommands can adopt the constants incrementally.