### PR TITLE
build: publish multi-arch container images to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       # Evaluates to the string "true" or "false". true if tag-name doesn't
       # contain a hyphen (eg. v1.2.3-dev, 1.2.4-nightly), false otherwise.
       # GoReleaser templates consume this as a string comparison for the
-      # conditional :latest container tag and cosign signing step.
+      # conditional :latest container tag.
       MAKE_LATEST_RELEASE: ${{ contains(github.ref_name, '-') == false }}
     steps:
       - name: Checkout
@@ -62,12 +62,3 @@ jobs:
           # If using goreleaser-pro, uncomment the following line
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
-      - name: Sign container images with cosign
-        env:
-          TAG: ${{ github.ref_name }}
-          MAKE_LATEST_RELEASE: ${{ env.MAKE_LATEST_RELEASE }}
-        run: |
-          cosign sign --yes "ghcr.io/plakarkorp/plakar:${TAG}"
-          if [ "${MAKE_LATEST_RELEASE}" = "true" ]; then
-            cosign sign --yes "ghcr.io/plakarkorp/plakar:latest"
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,23 @@ name: release
 
 on:
   push:
-    # run only against tags
+    # run only against version tags
     tags:
-      - "*"
+      - "v*"
 
 permissions:
   contents: write
+  packages: write
+  id-token: write # keyless cosign signing
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     env:
-      # true if tag-name doesn't contain a hyphen (eg. v1.2.3-dev, 1.2.4-nightly), false otherwise
+      # Evaluates to the string "true" or "false". true if tag-name doesn't
+      # contain a hyphen (eg. v1.2.3-dev, 1.2.4-nightly), false otherwise.
+      # GoReleaser templates consume this as a string comparison for the
+      # conditional :latest container tag and cosign signing step.
       MAKE_LATEST_RELEASE: ${{ contains(github.ref_name, '-') == false }}
     steps:
       - name: Checkout
@@ -25,6 +30,22 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -40,3 +61,13 @@ jobs:
           MAKE_LATEST_RELEASE: ${{ env.MAKE_LATEST_RELEASE }}
           # If using goreleaser-pro, uncomment the following line
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Sign container images with cosign
+        env:
+          TAG: ${{ github.ref_name }}
+          MAKE_LATEST_RELEASE: ${{ env.MAKE_LATEST_RELEASE }}
+        run: |
+          cosign sign --yes "ghcr.io/plakarkorp/plakar:${TAG}"
+          if [ "${MAKE_LATEST_RELEASE}" = "true" ]; then
+            cosign sign --yes "ghcr.io/plakarkorp/plakar:latest"
+          fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,28 @@ builds:
     # Templates: allowed.
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+dockers_v2:
+  - id: plakar
+    ids:
+      - plakar
+    images:
+      - "ghcr.io/plakarkorp/plakar"
+    tags:
+      - "{{ .Tag }}"
+      - '{{ if eq .Env.MAKE_LATEST_RELEASE "true" }}latest{{ end }}'
+    dockerfile: Dockerfile
+    flags:
+      - "--target=goreleaser"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.source": "https://github.com/PlakarKorp/plakar"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.title": "plakar"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+
 nfpms:
   - package_name: plakar
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,6 +86,14 @@ dockers_v2:
       "org.opencontainers.image.title": "plakar"
       "org.opencontainers.image.revision": "{{ .FullCommit }}"
 
+docker_signs:
+  - cmd: cosign
+    output: true
+    args:
+      - sign
+      - "${artifact}"
+      - "--yes"
+
 nfpms:
   - package_name: plakar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,26 @@
 #   persistent volume at the plakar cache directory, e.g.:
 #       docker run -v plakar-cache:/home/plakar/.cache/plakar ...
 #
-# Stage 1: Build
+# Stage 1: Shared runtime base
+FROM alpine:3.23 AS runtime-base
+
+# CA certificates for HTTPS connections to remote repositories and plakar.io
+RUN apk add --no-cache ca-certificates
+
+# Create non-root user (/etc/passwd required by user.Current())
+RUN addgroup -S plakar && adduser -S -G plakar -h /home/plakar plakar
+
+USER plakar
+WORKDIR /home/plakar
+
+ENTRYPOINT ["plakar"]
+
+# Stage 2: GoReleaser runtime image (binary provided via GoReleaser build context)
+FROM runtime-base AS goreleaser
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/plakar /usr/local/bin/plakar
+
+# Stage 3: Build from source for manual Docker builds
 FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
@@ -20,18 +39,7 @@ COPY . .
 # Build static binary matching goreleaser configuration
 RUN CGO_ENABLED=0 go build -trimpath -v -o /plakar .
 
-# Stage 2: Runtime
-FROM alpine:3.23
-
-# CA certificates for HTTPS connections to remote repositories and plakar.io
-RUN apk add --no-cache ca-certificates
-
-# Create non-root user (/etc/passwd required by user.Current())
-RUN addgroup -S plakar && adduser -S -G plakar -h /home/plakar plakar
+# Stage 4: Runtime image for manual Docker builds
+FROM runtime-base
 
 COPY --from=builder /plakar /usr/local/bin/plakar
-
-USER plakar
-WORKDIR /home/plakar
-
-ENTRYPOINT ["plakar"]


### PR DESCRIPTION
Builds on PR #2004 (Dockerfile) to automatically publish container images to GHCR on tagged releases.

Related: #1533

## Motivation

The Dockerfile landed in #2004, but there's no CI/CD pipeline to build and publish images. Users who want to run plakar in containers (Docker, Kubernetes, Tekton) currently have to build the image themselves.

## Changes

- **`.goreleaser.yml`** — adds `dockers_v2` configuration to publish a multi-arch image to `ghcr.io/plakarkorp/plakar` using GoReleaser's pre-built `plakar` binaries.
- **`.github/workflows/release.yml`** — adds QEMU, Docker Buildx, GHCR login, and keyless cosign signing steps. Adds `packages: write` and `id-token: write` permissions.
- **`Dockerfile`** — reuses the existing Dockerfile by adding a `goreleaser` target that copies the pre-built `$TARGETPLATFORM/plakar` binary from GoReleaser's build context. The default Dockerfile behavior still performs the full source build for manual/standalone Docker builds.

## Image tags

On a tagged release like `v1.2.0`:
- `ghcr.io/plakarkorp/plakar:v1.2.0` (multi-arch manifest)
- `ghcr.io/plakarkorp/plakar:latest` (only for stable releases, not pre-releases like `v1.2.0-beta`)

Architectures: `linux/amd64`, `linux/arm64`

## Signing

Published image tags are signed with cosign using GitHub Actions OIDC keyless signing. No private signing key is stored in the repository; the workflow receives an ephemeral certificate through the GitHub OIDC token.

Example verification:

```sh
cosign verify ghcr.io/plakarkorp/plakar:v1.2.0 \
  --certificate-identity-regexp 'https://github.com/PlakarKorp/plakar/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

## Usage

```sh
docker pull ghcr.io/plakarkorp/plakar:latest
docker run ghcr.io/plakarkorp/plakar version
```

## Notes

- The `:latest` tag uses the existing `MAKE_LATEST_RELEASE` logic — only pushed and signed when the tag has no hyphen
- GoReleaser's `dockers_v2` builds the multi-arch manifest directly, so the public release tags are `:<version>` and `:latest` rather than separate architecture-suffixed tags
- The existing Dockerfile remains the source-build path for manual Docker builds; the `goreleaser` target is only for release packaging of GoReleaser's pre-built binary