### PR TITLE
subcommands/mount: update usage and documentation for mount command options

### DIFF
--- a/subcommands/help/docs/plakar-mount.md
+++ b/subcommands/help/docs/plakar-mount.md
@@ -7,7 +7,8 @@ PLAKAR-MOUNT(1) - General Commands Manual
 # SYNOPSIS
 
 **plakar&nbsp;mount**
-*mountpoint*
+\[**-to**&nbsp;*mountpoint*]
+\[*snapshotID*]
 
 # DESCRIPTION
 
@@ -21,27 +22,77 @@ the local file system, providing easy browsing and retrieval of files
 without needing to explicitly restore them.
 This command may not work on all Operating Systems.
 
+In addition to the flags described below,
+**plakar mount**
+supports the location flags documented in
+plakar-query(7)
+to precisely select snapshots.
+
+The options are as follows:
+
+**-to** *mountpoint*
+
+> Specify the mount location.
+> The
+> *mountpoint*
+> can either be:
+
+> *	A directory path for FUSE mounts
+
+> *	An HTTP address including port for remote mounting (e.g.,
+> 	'`http://hostname:8080`')
+
+> If not specified, mount will attempt a FUSE mount in the working directory with
+> a random subdirectory name.
+
+*snapshotID*
+
+	Optional.
+	Specifies which snapshot to mount.
+	If not provided, all snapshots are mounted.
+
 # EXAMPLES
 
-Mount a snapshot to the specified directory:
+Mount all snapshots to a local directory:
 
-	$ plakar mount ~/mnt
+> $ plakar mount -to ~/mnt
+
+Mount the latest snapshot to a local directory:
+
+> $ plakar mount -to ~/mnt -latest
+
+Mount a specific snapshot by ID to a directory:
+
+> $ plakar mount -to ~/mnt abc123
+
+Mount snapshots matching a filter (e.g., snapshots with tag "daily-backup"):
+
+> $ plakar mount -to ~/mnt -tag daily-backup
+
+Mount a snapshot to an HTTP endpoint:
+
+> $ plakar mount -to http://hostname:8080
+
+Mount a specific snapshot to an HTTP endpoint:
+
+> $ plakar mount -to http://hostname:8080 abc123
 
 # DIAGNOSTICS
 
-The **plakar-mount** utility exits&#160;0 on success, and&#160;&gt;0 if an error occurs.
+The **plakar-mount** utility exits0 on success, and>0 if an error occurs.
 
 0
 
-> Command completed successfully.
+	Command completed successfully.
 
-&gt;0
+>0
 
-> An error occurred, such as an invalid mountpoint or failure during the
-> mounting process.
+	An error occurred, such as an invalid mountpoint or failure during the
+	mounting process.
 
 # SEE ALSO
 
-plakar(1)
+plakar(1),
+plakar-query(7)
 
 Plakar - July 3, 2025

--- a/subcommands/mount/mount.go
+++ b/subcommands/mount/mount.go
@@ -50,7 +50,7 @@ func (cmd *Mount) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	flags := flag.NewFlagSet("mount", flag.ExitOnError)
 	flags.Usage = func() {
-		fmt.Fprintf(flags.Output(), "Usage: %s PATH\n", flags.Name())
+		fmt.Fprintf(flags.Output(), "Usage: %s [-to PATH] [snapshotID]\n", flags.Name())
 	}
 	flags.StringVar(&cmd.Mountpoint, "to", "", "mount point")
 	cmd.LocateOptions.InstallLocateFlags(flags)

--- a/subcommands/mount/plakar-mount.1
+++ b/subcommands/mount/plakar-mount.1
@@ -6,7 +6,8 @@
 .Nd Mount Plakar snapshots as read-only filesystem
 .Sh SYNOPSIS
 .Nm plakar mount
-.Ar mountpoint
+.Op Fl to Ar mountpoint
+.Op Ar snapshotID
 .Sh DESCRIPTION
 The
 .Nm plakar mount
@@ -17,10 +18,63 @@ This allows users to access snapshot contents as if they were part of
 the local file system, providing easy browsing and retrieval of files
 without needing to explicitly restore them.
 This command may not work on all Operating Systems.
+.Pp
+In addition to the flags described below,
+.Nm plakar mount
+supports the location flags documented in
+.Xr plakar-query 7
+to precisely select snapshots.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl to Ar mountpoint
+Specify the mount location.
+The
+.Ar mountpoint
+can either be:
+.Bl -bullet -offset Ds
+.It
+A directory path for FUSE mounts
+.It
+An HTTP address including port for remote mounting (e.g.,
+.Ql http://hostname:8080 )
+.El
+If not specified, mount will attempt a FUSE mount in the working directory with
+a random subdirectory name.
+.It Ar snapshotID
+Optional.
+Specifies which snapshot to mount.
+If not provided, all snapshots are mounted.
+.El
 .Sh EXAMPLES
-Mount a snapshot to the specified directory:
+Mount all snapshots to a local directory:
 .Bd -literal -offset indent
-$ plakar mount ~/mnt
+$ plakar mount -to ~/mnt
+.Ed
+.Pp
+Mount the latest snapshot to a local directory:
+.Bd -literal -offset indent
+$ plakar mount -to ~/mnt -latest
+.Ed
+.Pp
+Mount a specific snapshot by ID to a directory:
+.Bd -literal -offset indent
+$ plakar mount -to ~/mnt abc123
+.Ed
+.Pp
+Mount snapshots matching a filter (e.g., snapshots with tag "daily-backup"):
+.Bd -literal -offset indent
+$ plakar mount -to ~/mnt -tag daily-backup
+.Ed
+.Pp
+Mount a snapshot to an HTTP endpoint:
+.Bd -literal -offset indent
+$ plakar mount -to http://hostname:8080
+.Ed
+.Pp
+Mount a specific snapshot to an HTTP endpoint:
+.Bd -literal -offset indent
+$ plakar mount -to http://hostname:8080 abc123
 .Ed
 .Sh DIAGNOSTICS
 .Ex -std
@@ -32,4 +86,5 @@ An error occurred, such as an invalid mountpoint or failure during the
 mounting process.
 .El
 .Sh SEE ALSO
-.Xr plakar 1
+.Xr plakar 1 ,
+.Xr plakar-query 7


### PR DESCRIPTION
Current usage and documentation for mount subcommand is a bit vague. This PR clarifies options and adds a set of examples.