### PR TITLE
Update handling of config, cache and data directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func entryPoint() int {
 
 	// command line overrides
 	var opt_cpuCount int
+	var opt_config string // deprecated, to be removed soon
 	var opt_configdir string
 	var opt_cachedir string
 	var opt_datadir string
@@ -145,9 +146,10 @@ func entryPoint() int {
 	var opt_disableSecurityCheck bool
 	var opt_maxConcurrency int
 
-	flag.StringVar(&opt_configdir, "config", opt_configDefault, "configuration directory")
-	flag.StringVar(&opt_cachedir, "cache", opt_cacheDefault, "cache directory")
-	flag.StringVar(&opt_datadir, "data", opt_dataDefault, "data directory")
+	flag.StringVar(&opt_config, "config", opt_configDefault, "configuration directory (deprecated, use -configdir instead)")
+	flag.StringVar(&opt_configdir, "configdir", opt_configDefault, "configuration directory")
+	flag.StringVar(&opt_cachedir, "cachedir", opt_cacheDefault, "cache directory")
+	flag.StringVar(&opt_datadir, "datadir", opt_dataDefault, "data directory")
 	flag.IntVar(&opt_cpuCount, "cpu", opt_cpuDefault, "limit the number of usable cores")
 	flag.IntVar(&opt_maxConcurrency, "concurrency", -1, "limit the number of concurrent operations")
 	flag.StringVar(&opt_cpuProfile, "profile-cpu", "", "profile CPU usage")
@@ -203,7 +205,14 @@ func entryPoint() int {
 
 	ctx.Quiet = opt_quiet
 	ctx.Silent = opt_silent
-
+	// to be removed when -config is removed vvvvv
+	if opt_config != opt_configDefault {
+		fmt.Fprintln(ctx.Stderr, "Option -config is deprecated, please use -configdir instead")
+	}
+	if opt_config != opt_configDefault && opt_configdir == opt_configDefault {
+		opt_configdir = opt_config
+	}
+	// to be removed when -config is removed ^^^^^
 	ctx.ConfigDir = opt_configdir
 	err = ctx.ReloadConfig()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -113,13 +113,25 @@ func entryPoint() int {
 
 	opt_configDefault, err := utils.GetConfigDir("plakar")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: could not get config directory: %s\n", flag.CommandLine.Name(), err)
+		fmt.Fprintf(os.Stderr, "%s: could not get default config directory: %s\n", flag.CommandLine.Name(), err)
+		return 1
+	}
+	opt_cacheDefault, err := utils.GetCacheDir("plakar")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: could not get default cache directory: %s\n", flag.CommandLine.Name(), err)
+		return 1
+	}
+	opt_dataDefault, err := utils.GetDataDir("plakar")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: could not get default data directory: %s\n", flag.CommandLine.Name(), err)
 		return 1
 	}
 
 	// command line overrides
 	var opt_cpuCount int
 	var opt_configdir string
+	var opt_cachedir string
+	var opt_datadir string
 	var opt_cpuProfile string
 	var opt_memProfile string
 	var opt_time bool
@@ -134,6 +146,8 @@ func entryPoint() int {
 	var opt_maxConcurrency int
 
 	flag.StringVar(&opt_configdir, "config", opt_configDefault, "configuration directory")
+	flag.StringVar(&opt_cachedir, "cache", opt_cacheDefault, "cache directory")
+	flag.StringVar(&opt_datadir, "data", opt_dataDefault, "data directory")
 	flag.IntVar(&opt_cpuCount, "cpu", opt_cpuDefault, "limit the number of usable cores")
 	flag.IntVar(&opt_maxConcurrency, "concurrency", -1, "limit the number of concurrent operations")
 	flag.StringVar(&opt_cpuProfile, "profile-cpu", "", "profile CPU usage")
@@ -200,10 +214,8 @@ func entryPoint() int {
 	ctx.Client = "plakar/" + utils.GetVersion()
 	ctx.CWD = cwd
 
-	// default cachedir
-	cacheSubDir := "plakar"
-
-	cookiesDir, err := utils.GetCacheDir(cacheSubDir)
+	cookiesDir := opt_cachedir
+	err = os.MkdirAll(cookiesDir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: could not get cookies directory: %s\n", flag.CommandLine.Name(), err)
 		return 1
@@ -212,16 +224,16 @@ func entryPoint() int {
 	ctx.SetCookies(cookies.NewManager(cookiesDir))
 	defer ctx.GetCookies().Close()
 
-	cacheDir, err := utils.GetCacheDir(cacheSubDir)
+	err = os.MkdirAll(opt_cachedir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: could not get cache directory: %s\n", flag.CommandLine.Name(), err)
 		return 1
 	}
-	ctx.CacheDir = cacheDir
-	ctx.SetCache(caching.NewManager(pebble.Constructor(cacheDir)))
+	ctx.CacheDir = opt_cachedir
+	ctx.SetCache(caching.NewManager(pebble.Constructor(opt_cachedir)))
 	defer ctx.GetCache().Close()
 
-	dataDir, err := utils.GetDataDir("plakar")
+	err = os.MkdirAll(opt_datadir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s: could not get data directory: %s\n", flag.CommandLine.Name(), err)
 		return 1
@@ -320,7 +332,7 @@ func entryPoint() int {
 
 	ctx.SetLogger(logger)
 
-	if err := setupPkgManager(ctx, dataDir, cacheDir); err != nil {
+	if err := setupPkgManager(ctx, opt_datadir, opt_cachedir); err != nil {
 		log.Fatalln(err.Error())
 	}
 

--- a/plakar.1
+++ b/plakar.1
@@ -8,6 +8,8 @@
 .Nm
 .Op Fl concurrency Ar number
 .Op Fl config Ar dir
+.Op Fl cache Ar dir
+.Op Fl data Ar dir
 .Op Fl cpu Ar number
 .Op Fl json
 .Op Fl keyfile Ar path
@@ -40,6 +42,14 @@ Defaults to the CPU count.
 Specify an alternate configuration directory.
 Defaults to
 .Pa ~/.config/plakar .
+.It Fl cache Ar dir
+Specify an alternate cache directory.
+Defaults to
+.Pa ~/.cache/plakar .
+.It Fl data Ar dir
+Specify an alternate data directory.
+Defaults to
+.Pa ~/.local/share/plakar .
 .It Fl cpu Ar number
 Limit the number of parallel workers
 .Nm

--- a/plakar.1
+++ b/plakar.1
@@ -7,9 +7,9 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl concurrency Ar number
-.Op Fl config Ar dir
-.Op Fl cache Ar dir
-.Op Fl data Ar dir
+.Op Fl configdir Ar dir
+.Op Fl cachedir Ar dir
+.Op Fl datadir Ar dir
 .Op Fl cpu Ar number
 .Op Fl json
 .Op Fl keyfile Ar path
@@ -38,15 +38,15 @@ The following options are available:
 .It Fl concurrency Ar number
 Set the maximum number of parallel tasks for faster processing.
 Defaults to the CPU count.
-.It Fl config Ar dir
+.It Fl configdir Ar dir
 Specify an alternate configuration directory.
 Defaults to
 .Pa ~/.config/plakar .
-.It Fl cache Ar dir
+.It Fl cachedir Ar dir
 Specify an alternate cache directory.
 Defaults to
 .Pa ~/.cache/plakar .
-.It Fl data Ar dir
+.It Fl datadir Ar dir
 Specify an alternate data directory.
 Defaults to
 .Pa ~/.local/share/plakar .

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -9,6 +9,8 @@ PLAKAR(1) - General Commands Manual
 **plakar**
 \[**-concurrency**&nbsp;*number*]
 \[**-config**&nbsp;*dir*]
+\[**-cache**&nbsp;*dir*]
+\[**-data**&nbsp;*dir*]
 \[**-cpu**&nbsp;*number*]
 \[**-json**]
 \[**-keyfile**&nbsp;*path*]
@@ -46,6 +48,18 @@ The following options are available:
 > Specify an alternate configuration directory.
 > Defaults to
 > *~/.config/plakar*.
+
+**-cache** *dir*
+
+> Specify an alternate cache directory.
+> Defaults to
+> *~/.cache/plakar*.
+
+**-data** *dir*
+
+> Specify an alternate data directory.
+> Defaults to
+> *~/.local/share/plakar*.
 
 **-cpu** *number*
 

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -43,19 +43,19 @@ The following options are available:
 > Set the maximum number of parallel tasks for faster processing.
 > Defaults to the CPU count.
 
-**-config** *dir*
+**-configdir** *dir*
 
 > Specify an alternate configuration directory.
 > Defaults to
 > *~/.config/plakar*.
 
-**-cache** *dir*
+**-cachedir** *dir*
 
 > Specify an alternate cache directory.
 > Defaults to
 > *~/.cache/plakar*.
 
-**-data** *dir*
+**-datadir** *dir*
 
 > Specify an alternate data directory.
 > Defaults to

--- a/utils/config.go
+++ b/utils/config.go
@@ -102,7 +102,13 @@ func (cl *configHandler) LoadFallback() (*config.Config, error) {
 }
 
 func (cl *configHandler) Save(cfg *config.Config) error {
-	err := cl.save("sources.yml", sourcesConfig{
+	// Create the config directory if it doesn't exist
+	err := os.MkdirAll(cl.Path, 0700)
+	if err != nil {
+		return err
+	}
+
+	err = cl.save("sources.yml", sourcesConfig{
 		Version: CONFIG_VERSION,
 		Sources: cfg.Sources,
 	})

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -265,26 +265,20 @@ func GetCacheDir(appName string) (string, error) {
 
 	switch runtime.GOOS {
 	case "windows":
-		// Use %LocalAppData%
 		cacheDir = os.Getenv("LocalAppData")
-		if cacheDir == "" {
-			return "", fmt.Errorf("LocalAppData environment variable not set")
-		}
-		cacheDir = filepath.Join(cacheDir, appName)
 	default:
-		// Use XDG_CACHE_HOME or default to ~/.cache
 		cacheDir = os.Getenv("XDG_CACHE_HOME")
-		if cacheDir == "" {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			cacheDir = filepath.Join(homeDir, ".cache", appName)
-		} else {
-			cacheDir = filepath.Join(cacheDir, appName)
-		}
 	}
-
+	// Use environment or default to ~/.cache
+	if cacheDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		cacheDir = filepath.Join(homeDir, ".cache", appName)
+	} else {
+		cacheDir = filepath.Join(cacheDir, appName)
+	}
 	// Create the cache directory if it doesn't exist
 	err := os.MkdirAll(cacheDir, 0700)
 	if err != nil {
@@ -299,24 +293,19 @@ func GetConfigDir(appName string) (string, error) {
 
 	switch runtime.GOOS {
 	case "windows":
-		// Use %LocalAppData%
 		configDir = os.Getenv("LocalAppData")
-		if configDir == "" {
-			return "", fmt.Errorf("LocalAppData environment variable not set")
-		}
-		configDir = filepath.Join(configDir, appName)
 	default:
-		// Use XDG_CONFIG_HOME or default to ~/.config
 		configDir = os.Getenv("XDG_CONFIG_HOME")
-		if configDir == "" {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			configDir = filepath.Join(homeDir, ".config", appName)
-		} else {
-			configDir = filepath.Join(configDir, appName)
+	}
+	// Use the environment or default to ~/.config
+	if configDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
 		}
+		configDir = filepath.Join(homeDir, ".config", appName)
+	} else {
+		configDir = filepath.Join(configDir, appName)
 	}
 
 	// Create the cache directory if it doesn't exist
@@ -333,24 +322,19 @@ func GetDataDir(appName string) (string, error) {
 
 	switch runtime.GOOS {
 	case "windows":
-		// Use %LocalAppData%
 		dataDir = os.Getenv("LocalAppData")
-		if dataDir == "" {
-			return "", fmt.Errorf("LocalAppData environment variable not set")
-		}
-		dataDir = filepath.Join(dataDir, appName)
 	default:
-		// Use XDG_DATA_HOME or default to ~/.local/share
 		dataDir = os.Getenv("XDG_DATA_HOME")
-		if dataDir == "" {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			dataDir = filepath.Join(homeDir, ".local", "share", appName)
-		} else {
-			dataDir = filepath.Join(dataDir, appName)
+	}
+	// Use the environment or default to ~/.local/share
+	if dataDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
 		}
+		dataDir = filepath.Join(homeDir, ".local", "share", appName)
+	} else {
+		dataDir = filepath.Join(dataDir, appName)
 	}
 
 	// Create the cache directory if it doesn't exist

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -275,14 +275,13 @@ func GetCacheDir(appName string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		cacheDir = filepath.Join(homeDir, ".cache", appName)
+		if runtime.GOOS == "windows" {
+			cacheDir = filepath.Join(homeDir, "AppData", "Local", appName)
+		} else {
+			cacheDir = filepath.Join(homeDir, ".cache", appName)
+		}
 	} else {
 		cacheDir = filepath.Join(cacheDir, appName)
-	}
-	// Create the cache directory if it doesn't exist
-	err := os.MkdirAll(cacheDir, 0700)
-	if err != nil {
-		return "", err
 	}
 
 	return cacheDir, nil
@@ -308,12 +307,6 @@ func GetConfigDir(appName string) (string, error) {
 		configDir = filepath.Join(configDir, appName)
 	}
 
-	// Create the cache directory if it doesn't exist
-	err := os.MkdirAll(configDir, 0700)
-	if err != nil {
-		return "", err
-	}
-
 	return configDir, nil
 }
 
@@ -335,12 +328,6 @@ func GetDataDir(appName string) (string, error) {
 		dataDir = filepath.Join(homeDir, ".local", "share", appName)
 	} else {
 		dataDir = filepath.Join(dataDir, appName)
-	}
-
-	// Create the cache directory if it doesn't exist
-	err := os.MkdirAll(dataDir, 0700)
-	if err != nil {
-		return "", err
 	}
 
 	return dataDir, nil

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -99,6 +99,8 @@ func TestGetConfigDir(t *testing.T) {
 	appName := "testapp"
 	configDir, err := GetConfigDir(appName)
 	require.NoError(t, err)
+	err = os.MkdirAll(configDir, 0700)
+	require.NoError(t, err)
 
 	// Verify that the config directory is inside the temporary directory
 	expectedDir := filepath.Join(tempDir, appName)
@@ -126,6 +128,8 @@ func TestGetCacheDir(t *testing.T) {
 	// Call GetCacheDir with a test app name
 	appName := "testapp"
 	cacheDir, err := GetCacheDir(appName)
+	require.NoError(t, err)
+	err = os.MkdirAll(cacheDir, 0700)
 	require.NoError(t, err)
 
 	// Verify that the cache directory is inside the temporary directory


### PR DESCRIPTION
- Add -data and -cache options similar to the existing -config options, to allow user full freedom in where to store settings and similar
- Remove directory creation from Get{Cache|Config|Data}Dir() as they are called at an early stage to calculate default locations
- Add os.MkdirAll when we have processed options

Resolves #2070