### PR TITLE
plakar policy: remove -ini

### DIFF
--- a/subcommands/config/plakar-policy.1
+++ b/subcommands/config/plakar-policy.1
@@ -38,13 +38,11 @@ for the source identified by
 Multiple option/value pairs can be specified.
 .It Xo
 .Cm show
-.Op Fl ini
 .Op Fl json
 .Op Fl yaml
 .Op Ar name ...
 .Xc
 Display the current sources configuration.
-.Fl ini ,
 .Fl json
 and
 .Fl yaml

--- a/subcommands/config/policy.go
+++ b/subcommands/config/policy.go
@@ -129,7 +129,6 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 
 	case "show":
 		var opt_json bool
-		var opt_ini bool
 		var opt_yaml bool
 		p := flag.NewFlagSet("show", flag.ExitOnError)
 		p.Usage = func() {
@@ -138,7 +137,6 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		}
 
 		p.BoolVar(&opt_json, "json", false, "output in JSON format")
-		p.BoolVar(&opt_ini, "ini", false, "output in INI format")
 		p.BoolVar(&opt_yaml, "yaml", false, "output in YAML format (default)")
 		p.Parse(args)
 
@@ -150,8 +148,6 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		format := "yaml"
 		if opt_json {
 			format = "json"
-		} else if opt_ini {
-			format = "ini"
 		}
 
 		return config.Dump(ctx.Stdout, format, names)


### PR DESCRIPTION
it's not implemented in kloset, and it's not feasible to serialize a policy as ini since it's a nested structure.