### PR TITLE
plugins: Disable idle timeout on grpc client.

### DIFF
--- a/plugins/connect.go
+++ b/plugins/connect.go
@@ -19,6 +19,7 @@ func connectPlugin(ctx context.Context, pluginPath string, args []string) (grpc.
 
 	clientConn, err := grpc.NewClient("127.0.0.1:0",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithIdleTimeout(0),
 		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 			return conn, nil
 		}),


### PR DESCRIPTION
* By default grpc client uses a dialer with a 30 minutes idle timeout.

* We don't need/want this timeout to happen, for example on long lived UI instances this will break the connection for no reason. Just disable it.

* Bug found and fixed by eric@ on the enterprise side.