### PR TITLE
api: Add a NoRefresh option.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -21,6 +21,7 @@ type uiserver struct {
 	store      storage.Store
 	config     storage.Configuration
 	repository *repository.Repository
+	norefresh  bool
 
 	// XXX: Adding this for transition, it needs to go away. Some
 	// places we only have Repository and out of AppContext we
@@ -153,12 +154,13 @@ func (ui *uiserver) apiInfo(w http.ResponseWriter, r *http.Request) error {
 	return json.NewEncoder(w).Encode(res)
 }
 
-func SetupRoutes(server *http.ServeMux, repo *repository.Repository, ctx *appcontext.AppContext, token string) {
+func SetupRoutes(server *http.ServeMux, repo *repository.Repository, ctx *appcontext.AppContext, token string, norefresh bool) {
 	ui := uiserver{
 		store:      repo.Store(),
 		config:     repo.Configuration(),
 		repository: repo,
 		ctx:        ctx,
+		norefresh:  norefresh,
 	}
 
 	authToken := TokenAuthMiddleware(token)

--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -161,8 +161,10 @@ func (ui *uiserver) repositorySnapshots(w http.ResponseWriter, r *http.Request) 
 		return err
 	}
 
-	if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
-		return err
+	if !ui.norefresh {
+		if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
+			return err
+		}
 	}
 
 	totalSnapshots := int(0)
@@ -218,8 +220,10 @@ func (ui *uiserver) repositorySnapshots(w http.ResponseWriter, r *http.Request) 
 }
 
 func (ui *uiserver) repositoryImporterTypes(w http.ResponseWriter, r *http.Request) error {
-	if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
-		return err
+	if !ui.norefresh {
+		if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
+			return err
+		}
 	}
 
 	importerTypesMap := make(map[string]struct{})
@@ -298,8 +302,10 @@ func (ui *uiserver) repositoryLocatePathname(w http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
-		return err
+	if !ui.norefresh {
+		if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
+			return err
+		}
 	}
 
 	totalSnapshots := int(0)

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/caching/pebble"
+	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/hashing"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/resources"
-	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/PlakarKorp/plakar/appcontext"
 	ptesting "github.com/PlakarKorp/plakar/testing"
@@ -60,7 +60,7 @@ func _Test_RepositoryConfiguration(t *testing.T) {
 
 	var noToken string
 	mux := http.NewServeMux()
-	SetupRoutes(mux, repo, ctx, noToken)
+	SetupRoutes(mux, repo, ctx, noToken, false)
 
 	req, err := http.NewRequest("GET", "/api/repository/configuration", nil)
 	require.NoError(t, err, "creating request")
@@ -345,7 +345,7 @@ func _Test_RepositorySnapshots(t *testing.T) {
 
 			var noToken string
 			mux := http.NewServeMux()
-			SetupRoutes(mux, repo, ctx, noToken)
+			SetupRoutes(mux, repo, ctx, noToken, false)
 
 			req, err := http.NewRequest("GET", "/api/repository/snapshots", nil)
 			require.NoError(t, err, "creating request")
@@ -451,7 +451,7 @@ func _Test_RepositorySnapshotsErrors(t *testing.T) {
 
 			var noToken string
 			mux := http.NewServeMux()
-			SetupRoutes(mux, repo, ctx, noToken)
+			SetupRoutes(mux, repo, ctx, noToken, false)
 
 			req, err := http.NewRequest("GET", fmt.Sprintf("/api/repository/snapshots?%s", c.params), nil)
 			require.NoError(t, err, "creating request")

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/caching/pebble"
+	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/hashing"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/resources"
-	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/PlakarKorp/plakar/appcontext"
 	ptesting "github.com/PlakarKorp/plakar/testing"
@@ -165,7 +165,7 @@ func _TestSnapshotHeader(t *testing.T) {
 
 			var noToken string
 			mux := http.NewServeMux()
-			SetupRoutes(mux, repo, ctx, noToken)
+			SetupRoutes(mux, repo, ctx, noToken, false)
 
 			req, err := http.NewRequest("GET", fmt.Sprintf("/api/snapshot/%s", c.snapshotId), nil)
 			require.NoError(t, err, "creating request")
@@ -246,7 +246,7 @@ func TestSnapshotHeaderErrors(t *testing.T) {
 
 			var noToken string
 			mux := http.NewServeMux()
-			SetupRoutes(mux, repo, ctx, noToken)
+			SetupRoutes(mux, repo, ctx, noToken, false)
 
 			req, err := http.NewRequest("GET", fmt.Sprintf("/api/snapshot/%s", c.snapshotId), nil)
 			require.NoError(t, err, "creating request")
@@ -311,7 +311,7 @@ func _TestSnapshotSign(t *testing.T) {
 
 			token := "test-token"
 			mux := http.NewServeMux()
-			SetupRoutes(mux, repo, ctx, token)
+			SetupRoutes(mux, repo, ctx, token, false)
 
 			// retrieve a valid jwt token before calling the read
 			req, err := http.NewRequest("POST", fmt.Sprintf("/api/snapshot/reader-sign-url/%s", c.snapshotPath), nil)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/caching/pebble"
+	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/hashing"
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/resources"
-	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/cookies"
@@ -29,7 +29,7 @@ func TestNewRouter(t *testing.T) {
 	mux := http.NewServeMux()
 	// Make sure SetupRoutes doesn't panic, which happens when invalid routes
 	// are registered
-	SetupRoutes(mux, repo, ctx, token)
+	SetupRoutes(mux, repo, ctx, token, false)
 }
 
 func TestAuthMiddleware(t *testing.T) {
@@ -70,7 +70,7 @@ func TestAuthMiddleware(t *testing.T) {
 	}
 	token := "test-token"
 	mux := http.NewServeMux()
-	SetupRoutes(mux, repo, ctx, token)
+	SetupRoutes(mux, repo, ctx, token, false)
 
 	req, err := http.NewRequest("GET", "/api/info", nil)
 	if err != nil {
@@ -137,7 +137,7 @@ func Test_UnknownEndpoint(t *testing.T) {
 	}
 	token := ""
 	mux := http.NewServeMux()
-	SetupRoutes(mux, repo, ctx, token)
+	SetupRoutes(mux, repo, ctx, token, false)
 
 	req, err := http.NewRequest("GET", "/api/unknown_endpoint", nil)
 	if err != nil {

--- a/subcommands/help/docs/plakar-ui.md
+++ b/subcommands/help/docs/plakar-ui.md
@@ -10,6 +10,7 @@ PLAKAR-UI(1) - General Commands Manual
 \[**-addr**&nbsp;*address*]
 \[**-cors**]
 \[**-no-auth**]
+\[**-no-refresh**]
 \[**-no-spawn**]
 \[**-cert**&nbsp;*path*]
 \[**-key**&nbsp;*path*]
@@ -41,6 +42,11 @@ The options are as follows:
 
 > Disable the authentication token that otherwise is needed to consume
 > the exposed HTTP APIs.
+
+**-no-refresh**
+
+> Do not refresh the local state from the store on API calls.
+> Useful when you want to share a common cache between multiple UIs.
 
 **-no-spawn**
 
@@ -78,4 +84,4 @@ Create a https server with a custom certificate:
 
 plakar(1)
 
-Plakar - May 5, 2026 - PLAKAR-UI(1)
+Plakar - May 5, 2026

--- a/subcommands/ui/plakar-ui.1
+++ b/subcommands/ui/plakar-ui.1
@@ -9,6 +9,7 @@
 .Op Fl addr Ar address
 .Op Fl cors
 .Op Fl no-auth
+.Op Fl no-refresh
 .Op Fl no-spawn
 .Op Fl cert Ar path
 .Op Fl key Ar path
@@ -33,6 +34,9 @@ HTTP headers to allow the UI to be accessed from any origin.
 .It Fl no-auth
 Disable the authentication token that otherwise is needed to consume
 the exposed HTTP APIs.
+.It Fl no-refresh
+Do not refresh the local state from the store on API calls.
+Useful when you want to share a common cache between multiple UIs.
 .It Fl no-spawn
 Do not automatically open the web browser.
 .It Fl cert Ar path

--- a/subcommands/ui/ui.go
+++ b/subcommands/ui/ui.go
@@ -31,6 +31,18 @@ import (
 	"github.com/google/uuid"
 )
 
+type Ui struct {
+	subcommands.SubcommandBase
+
+	Addr      string
+	Cors      bool
+	NoAuth    bool
+	NoSpawn   bool
+	NoRefresh bool
+	Cert      string
+	Key       string
+}
+
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &Ui{} }, 0, "ui")
 }
@@ -47,6 +59,7 @@ func (cmd *Ui) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.BoolVar(&cmd.Cors, "cors", false, "enable CORS")
 	flags.BoolVar(&cmd.NoAuth, "no-auth", false, "don't use authentication")
 	flags.BoolVar(&cmd.NoSpawn, "no-spawn", false, "don't spawn browser")
+	flags.BoolVar(&cmd.NoRefresh, "no-refresh", false, "don't refresh the local state")
 	flags.StringVar(&cmd.Cert, "cert", "", "Full certificate chain")
 	flags.StringVar(&cmd.Key, "key", "", "Certificate private key")
 	flags.Parse(args)
@@ -60,24 +73,14 @@ func (cmd *Ui) Parse(ctx *appcontext.AppContext, args []string) error {
 	return nil
 }
 
-type Ui struct {
-	subcommands.SubcommandBase
-
-	Addr    string
-	Cors    bool
-	NoAuth  bool
-	NoSpawn bool
-	Cert    string
-	Key     string
-}
-
 func (cmd *Ui) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
 	ui_opts := v2.UiOptions{
-		NoSpawn: cmd.NoSpawn,
-		Cors:    cmd.Cors,
-		Token:   "",
-		Cert:    cmd.Cert,
-		Key:     cmd.Key,
+		NoSpawn:   cmd.NoSpawn,
+		NoRefresh: cmd.NoRefresh,
+		Cors:      cmd.Cors,
+		Token:     "",
+		Cert:      cmd.Cert,
+		Key:       cmd.Key,
 	}
 
 	if !cmd.NoAuth {

--- a/ui/v2/ui.go
+++ b/ui/v2/ui.go
@@ -38,6 +38,7 @@ type UiOptions struct {
 	Token          string
 	Cert           string
 	Key            string
+	NoRefresh      bool
 }
 
 //go:embed all:frontend/*
@@ -45,7 +46,7 @@ var content embed.FS
 
 func Ui(repo *repository.Repository, ctx *appcontext.AppContext, addr string, opts *UiOptions) error {
 	server := http.NewServeMux()
-	api.SetupRoutes(server, repo, ctx, opts.Token)
+	api.SetupRoutes(server, repo, ctx, opts.Token, opts.NoRefresh)
 
 	statics, err := fs.Sub(content, "frontend")
 	if err != nil {


### PR DESCRIPTION
* This option means API call won't rebuild the state. Useful one big repositories where you don't want to pay for the latency involved on each reload.