### PR TITLE
ignore unknown connector types instead of raising an error

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -69,6 +69,10 @@ func pkgpreloadhook(m *pkg.Manifest) error {
 					return fmt.Errorf("protocol %s already provided "+
 						"by another installed package", proto)
 				}
+			default:
+				fmt.Fprintf(os.Stderr,
+				    "skipping unknown connector type: %s\n",
+				    conn.Type)
 			}
 		}
 	}

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -79,8 +79,7 @@ func Load(m *pkg.Manifest, pkgdir string) error {
 			case "storage":
 				err = RegisterStorage(proto, flags, exe, conn.Args)
 			default:
-				err = fmt.Errorf("unknown connector type: %s",
-					conn.Type)
+				/* Ignore silently. */
 			}
 			if err != nil {
 				return err
@@ -103,8 +102,7 @@ func Unload(m *pkg.Manifest) error {
 			case "storage":
 				err = storage.Unregister(proto)
 			default:
-				err = fmt.Errorf("unknown connector type: %s",
-					conn.Type)
+				/* ignore silently */
 			}
 		}
 	}


### PR DESCRIPTION
Without this, integrations which contain parts that only work in the enterprise version cannot be used with the open source version, due to errors such as:

plakar: failed to load vault-integration@v1.1.5-alpha0: unknown connector type: secret_provider