### PR TITLE
don't consider "dumb" a terminal

### DIFF
--- a/term.go
+++ b/term.go
@@ -2,8 +2,16 @@
 
 package main
 
-import "github.com/charmbracelet/x/term"
+import (
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
 
 func isTerminal() bool {
+	if t, ok := os.LookupEnv("TERM"); ok && t == "dumb" {
+		return false
+	}
+
 	return term.IsTerminal(1)
 }


### PR DESCRIPTION
a lot of pseudo terminal emulator (emacs eshell and term, plan9port acme win, etc...) set TERM=dumb because while they act like a TTY, they don't support many (almost all?) escape codes.

Don't consider these to be a "terminal" so we automatically fall back to stdio.