### PR TITLE
prune: don't clobber policy filters with empty CLI overrides

### DIFF
--- a/subcommands/prune/prune.go
+++ b/subcommands/prune/prune.go
@@ -86,9 +86,11 @@ func (cmd *Prune) Parse(ctx *appcontext.AppContext, args []string) error {
 	return nil
 }
 
-// override values in "from" if it is set in "to"
+// mergePolicyOptions layers CLI overrides (from) onto policy-loaded options
+// (to): for each field, the CLI value wins iff it is set, otherwise the
+// policy value is kept.
 func mergePolicyOptions(to *locate.LocateOptions, from *locate.LocateOptions) {
-	to.Filters = from.Filters
+	mergeFilters(&to.Filters, &from.Filters)
 
 	merge := func(a, b *locate.LocatePeriod) {
 		if b.Keep != 0 {
@@ -113,6 +115,54 @@ func mergePolicyOptions(to *locate.LocateOptions, from *locate.LocateOptions) {
 	merge(&to.Periods.Saturday, &from.Periods.Saturday)
 	merge(&to.Periods.Sunday, &from.Periods.Sunday)
 
+}
+
+// mergeFilters overlays b onto a per-field: each field of a is replaced only
+// when the corresponding field in b is non-zero. Slice fields are replaced
+// wholesale when b's slice is non-empty.
+func mergeFilters(a, b *locate.LocateFilters) {
+	if !b.Before.IsZero() {
+		a.Before = b.Before
+	}
+	if !b.Since.IsZero() {
+		a.Since = b.Since
+	}
+	if b.Name != "" {
+		a.Name = b.Name
+	}
+	if b.Category != "" {
+		a.Category = b.Category
+	}
+	if b.Environment != "" {
+		a.Environment = b.Environment
+	}
+	if b.Perimeter != "" {
+		a.Perimeter = b.Perimeter
+	}
+	if b.Job != "" {
+		a.Job = b.Job
+	}
+	if len(b.Tags) > 0 {
+		a.Tags = b.Tags
+	}
+	if len(b.IgnoreTags) > 0 {
+		a.IgnoreTags = b.IgnoreTags
+	}
+	if b.Latest {
+		a.Latest = b.Latest
+	}
+	if len(b.IDs) > 0 {
+		a.IDs = b.IDs
+	}
+	if len(b.Types) > 0 {
+		a.Types = b.Types
+	}
+	if len(b.Origins) > 0 {
+		a.Origins = b.Origins
+	}
+	if len(b.Roots) > 0 {
+		a.Roots = b.Roots
+	}
 }
 
 type planEntry struct {

--- a/subcommands/prune/prune_test.go
+++ b/subcommands/prune/prune_test.go
@@ -5,9 +5,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
+	"time"
 
 	_ "github.com/PlakarKorp/integration-fs/exporter"
+	"github.com/PlakarKorp/kloset/locate"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -102,4 +105,107 @@ func TestPrune_Apply_PerMinuteCap(t *testing.T) {
 	// Sanity: ensure it didn't claim to remove the newest one (kept)
 	short2 := hex.EncodeToString(snap2.Header.GetIndexShortID())
 	require.NotContains(t, out, fmt.Sprintf("info: prune: removal of %s completed successfully", short2))
+}
+
+// TestMergePolicyOptions_PreservesPolicyFiltersWhenCLIEmpty is the regression
+// test for https://github.com/PlakarKorp/plakar/issues/1758
+//
+// Before the fix, mergePolicyOptions did `to.Filters = from.Filters`, which
+// overwrote the policy-loaded filters with the (typically empty) CLI override
+// struct. Effect: `-policy daily` (where the policy filters by tag) silently
+// matched every snapshot.
+func TestMergePolicyOptions_PreservesPolicyFiltersWhenCLIEmpty(t *testing.T) {
+	policy := locate.NewDefaultLocateOptions()
+	policy.Filters.Tags = []string{"daily"}
+	policy.Periods.Minute.Keep = 5
+
+	cli := locate.NewDefaultLocateOptions() // user passed no other flags
+
+	mergePolicyOptions(policy, cli)
+
+	require.Equal(t, []string{"daily"}, policy.Filters.Tags,
+		"policy filters must survive an empty CLI override")
+	require.Equal(t, 5, policy.Periods.Minute.Keep,
+		"policy periods must survive an empty CLI override")
+}
+
+// TestMergePolicyOptions_CLIOverridesPolicy pins that explicit CLI flags do
+// take precedence over policy values.
+func TestMergePolicyOptions_CLIOverridesPolicy(t *testing.T) {
+	policy := locate.NewDefaultLocateOptions()
+	policy.Filters.Tags = []string{"daily"}
+	policy.Filters.Name = "policy-name"
+	policy.Periods.Minute.Keep = 5
+
+	cli := locate.NewDefaultLocateOptions()
+	cli.Filters.Tags = []string{"weekly"}
+	cli.Filters.Name = "cli-name"
+	cli.Periods.Minute.Keep = 9
+
+	mergePolicyOptions(policy, cli)
+
+	require.Equal(t, []string{"weekly"}, policy.Filters.Tags)
+	require.Equal(t, "cli-name", policy.Filters.Name)
+	require.Equal(t, 9, policy.Periods.Minute.Keep)
+}
+
+// TestMergeFilters exhaustively covers each field of LocateFilters to make
+// sure mergeFilters keeps `a` when `b` is zero, and adopts `b` when it isn't.
+func TestMergeFilters(t *testing.T) {
+	now := time.Now()
+	later := now.Add(time.Hour)
+
+	t.Run("empty b keeps a", func(t *testing.T) {
+		a := locate.LocateFilters{
+			Before:      now,
+			Since:       now,
+			Name:        "n",
+			Category:    "c",
+			Environment: "e",
+			Perimeter:   "p",
+			Job:         "j",
+			Tags:        []string{"t1"},
+			IgnoreTags:  []string{"!t1"},
+			Latest:      true,
+			IDs:         []string{"id1"},
+			Types:       []string{"fs"},
+			Origins:     []string{"host"},
+			Roots:       []string{"/root"},
+		}
+		want := a
+		b := locate.LocateFilters{}
+		mergeFilters(&a, &b)
+		if !reflect.DeepEqual(a, want) {
+			t.Fatalf("a changed when b was empty:\n got  %#v\n want %#v", a, want)
+		}
+	})
+
+	t.Run("non-zero b wins", func(t *testing.T) {
+		a := locate.LocateFilters{
+			Before:      now,
+			Name:        "old",
+			Tags:        []string{"old"},
+			Latest:      false,
+		}
+		b := locate.LocateFilters{
+			Before:      later,
+			Since:       later,
+			Name:        "new",
+			Category:    "c2",
+			Environment: "e2",
+			Perimeter:   "p2",
+			Job:         "j2",
+			Tags:        []string{"new"},
+			IgnoreTags:  []string{"!new"},
+			Latest:      true,
+			IDs:         []string{"id2"},
+			Types:       []string{"s3"},
+			Origins:     []string{"host2"},
+			Roots:       []string{"/r2"},
+		}
+		mergeFilters(&a, &b)
+		if !reflect.DeepEqual(a, b) {
+			t.Fatalf("merge with all-non-zero b should equal b:\n got  %#v\n want %#v", a, b)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Fix [#1758](https://github.com/PlakarKorp/plakar/issues/1758): `plakar prune -policy <name>` silently matched every snapshot instead of only the ones the policy's filters select. Regressed since 1.0.5.
- Root cause: `mergePolicyOptions` was doing `to.Filters = from.Filters`, which wholesale replaced the policy-loaded filters with the CLI override struct. With no CLI filter flags given, that struct is zero-valued, so the policy's tag/name/origin/etc. filters got wiped out.
- Fix: replace the assignment with a per-field merge (`mergeFilters`), mirroring how period overrides already work: CLI value wins iff it is non-zero, otherwise the policy value is kept.

## Test plan

- [x] New `TestMergePolicyOptions_PreservesPolicyFiltersWhenCLIEmpty` reproduces the bug — policy sets `Filters.Tags = ["daily"]`, CLI override is empty, after merge tags must survive. Fails on `main`, passes with this commit.
- [x] New `TestMergePolicyOptions_CLIOverridesPolicy` pins the converse: explicit CLI values still take precedence over the policy.
- [x] New `TestMergeFilters` exhaustively covers each field of `LocateFilters` (Before/Since/Name/Category/Environment/Perimeter/Job/Tags/IgnoreTags/Latest/IDs/Types/Origins/Roots).
- [x] `go test ./...` clean on the whole repo.
- [x] End-to-end reproduction of the reporter's scenario (4 snapshots, 2 tagged `daily`, policy `daily: { filters: { tags: [daily] } }`): `prune -minutes 1 -policy daily` now targets only the 2 daily-tagged snapshots, leaving the untagged ones alone — matching the 1.0.4 behavior the reporter expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)