### PR TITLE
utils: add tests for TimeFlag, ValidateEmail, GetDataDir, locateField

### DIFF
--- a/utils/config_policy_test.go
+++ b/utils/config_policy_test.go
@@ -293,3 +293,98 @@ func TestPoliciesApplyConfigUnknownIsNoOp(t *testing.T) {
 		t.Fatal("ApplyConfig with unknown name should not overwrite")
 	}
 }
+
+// TestPoliciesLocateFieldAllStringKeys walks every string-valued filter
+// key supported by locateField, exercising each switch branch once.
+func TestPoliciesLocateFieldAllStringKeys(t *testing.T) {
+	stringKeys := []string{
+		"name", "category", "environment", "perimeter", "job",
+	}
+	for _, key := range stringKeys {
+		t.Run(key, func(t *testing.T) {
+			c := newTestPolicies()
+			c.Add("p")
+			if err := c.Set("p", key, "value-for-"+key); err != nil {
+				t.Fatalf("Set %s: %v", key, err)
+			}
+			if err := c.Unset("p", key); err != nil {
+				t.Fatalf("Unset %s: %v", key, err)
+			}
+		})
+	}
+}
+
+// TestPoliciesLocateFieldAllStringListKeys exercises the []string branches.
+func TestPoliciesLocateFieldAllStringListKeys(t *testing.T) {
+	listKeys := []string{"tags", "ids", "roots"}
+	for _, key := range listKeys {
+		t.Run(key, func(t *testing.T) {
+			c := newTestPolicies()
+			c.Add("p")
+			if err := c.Set("p", key, "a,b,c"); err != nil {
+				t.Fatalf("Set %s: %v", key, err)
+			}
+			if err := c.Unset("p", key); err != nil {
+				t.Fatalf("Unset %s: %v", key, err)
+			}
+		})
+	}
+}
+
+// TestPoliciesLocateFieldAllIntKeys exercises every period-related int branch
+// (Keep and Cap for each period). Each branch is hit via both Set and Unset.
+func TestPoliciesLocateFieldAllIntKeys(t *testing.T) {
+	intKeys := []string{
+		// Periods.*.Keep
+		"minutes", "hours", "days", "weeks", "months", "years",
+		"mondays", "tuesdays", "wednesdays", "thursdays",
+		"fridays", "saturdays", "sundays",
+		// Periods.*.Cap
+		"per-minute", "per-hour", "per-day", "per-week", "per-month", "per-year",
+		"per-monday", "per-tuesday", "per-wednesday", "per-thursday",
+		"per-friday", "per-saturday", "per-sunday",
+	}
+	for _, key := range intKeys {
+		t.Run(key, func(t *testing.T) {
+			c := newTestPolicies()
+			c.Add("p")
+			if err := c.Set("p", key, "5"); err != nil {
+				t.Fatalf("Set %s: %v", key, err)
+			}
+			if err := c.Unset("p", key); err != nil {
+				t.Fatalf("Unset %s: %v", key, err)
+			}
+		})
+	}
+}
+
+// TestPoliciesLocateFieldSinceAndLatest exercises the last remaining
+// non-string/non-int branches: `since` (time.Time) and `latest` (bool).
+func TestPoliciesLocateFieldSinceAndLatest(t *testing.T) {
+	c := newTestPolicies()
+	c.Add("p")
+	if err := c.Set("p", "since", "2026-01-01T00:00:00Z"); err != nil {
+		t.Fatalf("Set since: %v", err)
+	}
+	if err := c.Unset("p", "since"); err != nil {
+		t.Fatalf("Unset since: %v", err)
+	}
+	if err := c.Set("p", "latest", "true"); err != nil {
+		t.Fatalf("Set latest: %v", err)
+	}
+	if err := c.Unset("p", "latest"); err != nil {
+		t.Fatalf("Unset latest: %v", err)
+	}
+}
+
+// TestPoliciesLocateFieldInvalidKey hits the default branch.
+func TestPoliciesLocateFieldInvalidKey(t *testing.T) {
+	c := newTestPolicies()
+	c.Add("p")
+	if err := c.Set("p", "bogus-key", "x"); err == nil {
+		t.Fatal("Set with invalid key should error")
+	}
+	if err := c.Unset("p", "bogus-key"); err == nil {
+		t.Fatal("Unset with invalid key should error")
+	}
+}

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -55,3 +55,36 @@ func TestParseTimeFlag(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid time format")
 	require.True(t, t7.IsZero())
 }
+
+func TestTimeFlag_String(t *testing.T) {
+	var dest time.Time
+	tf := NewTimeFlag(&dest)
+
+	// Zero value -> empty string
+	require.Equal(t, "", tf.String())
+
+	// Nil destination -> empty string (defensive)
+	require.Equal(t, "", (&TimeFlag{}).String())
+
+	// Non-zero value -> matches time.Time.String()
+	dest = time.Date(2025, 4, 15, 10, 0, 0, 0, time.UTC)
+	require.Equal(t, dest.String(), tf.String())
+}
+
+func TestTimeFlag_Set(t *testing.T) {
+	var dest time.Time
+	tf := NewTimeFlag(&dest)
+
+	require.NoError(t, tf.Set("2025-04-15"))
+	expected, _ := time.Parse("2006-01-02", "2025-04-15")
+	require.Equal(t, expected, dest)
+
+	// Empty input is valid (clears to zero) per ParseTimeFlag.
+	require.NoError(t, tf.Set(""))
+	require.True(t, dest.IsZero())
+
+	// Invalid input propagates the parse error.
+	err := tf.Set("not-a-time")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid time format")
+}

--- a/utils/utils_extra_test.go
+++ b/utils/utils_extra_test.go
@@ -1,0 +1,141 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEmail(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		_, err := ValidateEmail("")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("valid plain", func(t *testing.T) {
+		addr, err := ValidateEmail("user@example.com")
+		require.NoError(t, err)
+		require.Equal(t, "user@example.com", addr)
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		_, err := ValidateEmail("not-an-email")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid email address")
+	})
+
+	t.Run("rejects display-name form", func(t *testing.T) {
+		// mail.ParseAddress accepts "Alice <alice@example.com>", but
+		// ValidateEmail's strict check requires the input to equal the
+		// parsed Address — so this must be rejected.
+		_, err := ValidateEmail("Alice <alice@example.com>")
+		require.Error(t, err)
+	})
+}
+
+func TestGetDataDir_FromEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	envVar := "XDG_DATA_HOME"
+	if runtime.GOOS == "windows" {
+		envVar = "LocalAppData"
+	}
+	t.Setenv(envVar, tempDir)
+
+	dataDir, err := GetDataDir("testapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(tempDir, "testapp"), dataDir)
+	require.True(t, filepath.IsAbs(dataDir))
+}
+
+func TestGetDataDir_FallbackToHome(t *testing.T) {
+	envVar := "XDG_DATA_HOME"
+	if runtime.GOOS == "windows" {
+		envVar = "LocalAppData"
+	}
+	t.Setenv(envVar, "")
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", homeDir)
+	}
+
+	dataDir, err := GetDataDir("testapp")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(dataDir, homeDir),
+		"dataDir %q should be under fallback home %q", dataDir, homeDir)
+	require.Contains(t, dataDir, "testapp")
+}
+
+func TestGetCacheDir_FallbackToHome(t *testing.T) {
+	envVar := "XDG_CACHE_HOME"
+	if runtime.GOOS == "windows" {
+		envVar = "LocalAppData"
+	}
+	t.Setenv(envVar, "")
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", homeDir)
+	}
+
+	cacheDir, err := GetCacheDir("testapp")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(cacheDir, homeDir),
+		"cacheDir %q should be under fallback home %q", cacheDir, homeDir)
+	require.Contains(t, cacheDir, "testapp")
+}
+
+func TestGetConfigDir_FallbackToHome(t *testing.T) {
+	envVar := "XDG_CONFIG_HOME"
+	if runtime.GOOS == "windows" {
+		envVar = "LocalAppData"
+	}
+	t.Setenv(envVar, "")
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", homeDir)
+	}
+
+	configDir, err := GetConfigDir("testapp")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(configDir, homeDir),
+		"configDir %q should be under fallback home %q", configDir, homeDir)
+	require.Contains(t, configDir, "testapp")
+}
+
+func TestShouldCheckUpdate(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	// `shouldCheckUpdate` short-circuits to false when VERSION contains "devel".
+	// In a non-CI dev build that's the case, so we detect that and assert the
+	// devel short-circuit; otherwise we drive the time-based path.
+	if strings.Contains(VERSION, "devel") {
+		require.False(t, shouldCheckUpdate(cacheDir))
+		return
+	}
+
+	// First call: no cookie yet -> should return true and create the cookie file.
+	require.True(t, shouldCheckUpdate(cacheDir))
+
+	cookie := filepath.Join(cacheDir, "last-update-check")
+	_, err := os.Stat(cookie)
+	require.NoError(t, err, "shouldCheckUpdate must create the cookie file")
+
+	// Second call within 24h: returns false.
+	require.False(t, shouldCheckUpdate(cacheDir))
+
+	// Backdate the cookie past 24h and confirm it flips back to true.
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(cookie, old, old))
+	require.True(t, shouldCheckUpdate(cacheDir))
+}


### PR DESCRIPTION
## Summary

Follow-up to [#2138](https://github.com/PlakarKorp/plakar/pull/2138). Brings \`utils/\` coverage from **59.4% → 71.7%**:

- **time.go** — \`TimeFlag.String\` / \`TimeFlag.Set\` (the \`flag.Value\` wrappers around \`ParseTimeFlag\`): 0% → 100%.
- **utils.go**:
  - \`ValidateEmail\`: 0% → 100% (empty, valid, malformed, and display-name-form rejection).
  - \`GetDataDir\`: 0% → 81.8% (env-var path + home fallback).
  - \`GetCacheDir\` / \`GetConfigDir\`: ~50% → ~80% (added the fallback-to-home branches).
  - \`shouldCheckUpdate\`: 0% → 18.2% (covers the devel short-circuit; the time-based path needs a non-devel \`VERSION\` constant, which can't easily be exercised from a test binary).
- **config_policy.go** — \`locateField\` is now 100%: every key in the big switch (string, list, int Keep/Cap for every period, time, bool) is exercised via \`Set\` + \`Unset\`, plus the invalid-key default branch.

All tests pass under \`-race\`. No production code changes.

### Out of scope (deliberately untestable here)

\`BrowserTrySpawn\`, \`CheckUpdate\`, \`GetPassphrase*\`, \`readpassphrase\` — open browsers, hit the network, or read from a tty. Need scaffolding (HTTP mocking, stdin injection) that would mean changing production code; saved for a separate decision.

## Test plan
- [ ] \`go test -race ./utils/...\` passes in CI.
- [ ] Codecov report shows the bump from 59.4% to ~71.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)