### PR TITLE
ui: add tests for json, stdio, tui state, and v2 corsMiddleware

### DIFF
--- a/ui/json/json_test.go
+++ b/ui/json/json_test.go
@@ -1,0 +1,203 @@
+package json
+
+import (
+	"bytes"
+	encjson "encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/plakar/appcontext"
+)
+
+func TestSanitizeDataPreservesPrimitives(t *testing.T) {
+	in := map[string]any{
+		"path":  "/var",
+		"count": 42,
+		"flag":  true,
+	}
+	got := sanitizeData(in)
+	if got["path"] != "/var" || got["count"] != 42 || got["flag"] != true {
+		t.Fatalf("primitives mutated: %+v", got)
+	}
+}
+
+func TestSanitizeDataConvertsErrorToString(t *testing.T) {
+	got := sanitizeData(map[string]any{"err": errors.New("boom")})
+	if got["err"] != "boom" {
+		t.Fatalf("err = %v, want %q", got["err"], "boom")
+	}
+}
+
+func TestSanitizeDataConvertsDurationToMillis(t *testing.T) {
+	got := sanitizeData(map[string]any{"d": 250 * time.Millisecond})
+	if got["d"] != int64(250) {
+		t.Fatalf("d = %v (%T), want int64(250)", got["d"], got["d"])
+	}
+}
+
+func TestSanitizeDataReturnsNewMap(t *testing.T) {
+	in := map[string]any{"k": "v"}
+	got := sanitizeData(in)
+	got["k"] = "changed"
+	if in["k"] != "v" {
+		t.Fatalf("sanitizeData must not mutate input map; input is now %+v", in)
+	}
+}
+
+func TestNewReturnsNonNilUI(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+	if u == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+func TestLifecycleAccessors(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+	if u.Stdout() != io.Discard {
+		t.Fatalf("Stdout = %v, want io.Discard", u.Stdout())
+	}
+	if u.Stderr() != os.Stderr {
+		t.Fatalf("Stderr = %v, want os.Stderr", u.Stderr())
+	}
+	u.SetRepository(nil) // doesn't panic
+	u.Stop()             // no-op, doesn't panic
+}
+
+func TestRunDrainsEventsAndExitsOnBusClose(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+
+	// Replace os.Stdout temporarily so the renderer's encoder writes go to a pipe
+	// we can read after the run completes. The renderer captured stdout in New(),
+	// so we have to reach into the type — keep this test scoped to ensuring the
+	// goroutine exits cleanly when the bus closes.
+	if err := u.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Closing the events bus closes the channel returned by Listen(), which
+	// terminates the renderer goroutine.
+	ctx.Events().Close()
+
+	done := make(chan error, 1)
+	go func() { done <- u.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return after bus close")
+	}
+}
+
+func TestJSONEventEncodes(t *testing.T) {
+	// Smoke test: jsonEvent struct should encode to JSON containing the fields
+	// we expect.
+	ev := jsonEvent{
+		Version:   1,
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Level:     "info",
+		Workflow:  "backup",
+		Type:      "path",
+		Data:      map[string]any{"k": "v"},
+	}
+	var buf bytes.Buffer
+	if err := encjson.NewEncoder(&buf).Encode(ev); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var back map[string]any
+	if err := encjson.Unmarshal(buf.Bytes(), &back); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back["level"] != "info" || back["workflow"] != "backup" || back["type"] != "path" {
+		t.Fatalf("unexpected encoding: %+v", back)
+	}
+}
+
+// newRendererTo returns a renderer whose encoder writes to buf, so tests can
+// inspect what handleEvent emits without racing on os.Stdout.
+func newRendererTo(ctx *appcontext.AppContext, buf *bytes.Buffer) *jsonRenderer {
+	return &jsonRenderer{
+		ctx:     ctx,
+		encoder: encjson.NewEncoder(buf),
+	}
+}
+
+func TestHandleEvent_EncodesInfo(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	var buf bytes.Buffer
+	r := newRendererTo(ctx, &buf)
+
+	r.handleEvent(&events.Event{
+		Version:   1,
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Level:     "info",
+		Workflow:  "backup",
+		Type:      "path.ok",
+		Data:      map[string]any{"path": "/etc/hosts"},
+	})
+
+	var out map[string]any
+	if err := encjson.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v (raw=%q)", err, buf.String())
+	}
+	if out["level"] != "info" || out["type"] != "path.ok" {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+	data, _ := out["data"].(map[string]any)
+	if data == nil || data["path"] != "/etc/hosts" {
+		t.Fatalf("data not encoded: %+v", out)
+	}
+}
+
+func TestHandleEvent_SilentSuppresses(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	ctx.Silent = true
+	var buf bytes.Buffer
+	r := newRendererTo(ctx, &buf)
+
+	r.handleEvent(&events.Event{Level: "info", Type: "path"})
+
+	if buf.Len() != 0 {
+		t.Fatalf("Silent should suppress output, got %q", buf.String())
+	}
+}
+
+func TestHandleEvent_QuietSuppressesInfoOnly(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	ctx.Quiet = true
+	var buf bytes.Buffer
+	r := newRendererTo(ctx, &buf)
+
+	// info level: suppressed
+	r.handleEvent(&events.Event{Level: "info", Type: "path"})
+	if buf.Len() != 0 {
+		t.Fatalf("Quiet should suppress info, got %q", buf.String())
+	}
+
+	// non-info level (e.g. error): still emitted
+	r.handleEvent(&events.Event{Level: "error", Type: "path.error"})
+	if buf.Len() == 0 {
+		t.Fatal("Quiet should not suppress non-info events")
+	}
+}
+
+func TestHandleEvent_NoDataOmitsField(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	var buf bytes.Buffer
+	r := newRendererTo(ctx, &buf)
+
+	r.handleEvent(&events.Event{Level: "info", Type: "workflow.start"})
+
+	var out map[string]any
+	if err := encjson.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := out["data"]; ok {
+		t.Fatalf("expected no data field, got %+v", out)
+	}
+}

--- a/ui/stdio/stdio_test.go
+++ b/ui/stdio/stdio_test.go
@@ -1,0 +1,243 @@
+package stdio
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/plakar/appcontext"
+)
+
+// newCtxWithBufferedLogger returns a context whose logger writes to the given
+// buffers — so tests can inspect what HandleEvent emits without touching
+// os.Stdout / os.Stderr.
+func newCtxWithBufferedLogger(t *testing.T, out, errBuf *bytes.Buffer) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetLogger(logging.NewLogger(out, errBuf))
+	return ctx
+}
+
+func TestNewReturnsNonNilUI(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+	if u == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+func TestStdoutStderrAccessors(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+	if u.Stdout() != os.Stdout {
+		t.Fatalf("Stdout = %v, want os.Stdout", u.Stdout())
+	}
+	if u.Stderr() != os.Stderr {
+		t.Fatalf("Stderr = %v, want os.Stderr", u.Stderr())
+	}
+}
+
+func TestStopAndSetRepositoryNoOps(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+	u.Stop()             // no-op
+	u.SetRepository(nil) // no-op
+}
+
+func TestRunDrainsEventsAndExitsOnBusClose(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	u := New(ctx)
+	if err := u.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	ctx.Events().Close()
+
+	done := make(chan error, 1)
+	go func() { done <- u.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return after bus close")
+	}
+}
+
+func TestHandleEvent_Silent(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+	ctx.Silent = true
+
+	HandleEvent(ctx, &Event{Level: "info", Type: "path.ok", Data: map[string]any{"path": "/x"}})
+
+	if out.Len() != 0 || errBuf.Len() != 0 {
+		t.Fatalf("Silent should suppress all output, got out=%q err=%q", out.String(), errBuf.String())
+	}
+}
+
+func TestHandleEvent_QuietSuppressesInfoOnly(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+	ctx.Quiet = true
+
+	HandleEvent(ctx, &Event{Level: "info", Type: "path.ok", Data: map[string]any{"path": "/x"}})
+	if out.Len() != 0 {
+		t.Fatalf("Quiet+info should suppress, got %q", out.String())
+	}
+
+	// error-level still emitted
+	HandleEvent(ctx, &Event{
+		Level: "error", Type: "path.error",
+		Data: map[string]any{"path": "/y", "error": errors.New("boom")},
+	})
+	if errBuf.Len() == 0 {
+		t.Fatal("Quiet should not suppress error-level events")
+	}
+}
+
+func TestHandleEvent_PathOk(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "info", Type: "path.ok",
+		Data: map[string]any{"path": "/var/log/messages"},
+	})
+	if out.Len() == 0 {
+		t.Fatal("path.ok should write to stdout")
+	}
+	if !bytes.Contains(out.Bytes(), []byte("/var/log/messages")) {
+		t.Fatalf("expected path in stdout, got %q", out.String())
+	}
+}
+
+func TestHandleEvent_PathError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "error", Type: "path.error",
+		Data: map[string]any{"path": "/oops", "error": errors.New("denied")},
+	})
+	if errBuf.Len() == 0 {
+		t.Fatal("path.error should write to stderr")
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("/oops")) ||
+		!bytes.Contains(errBuf.Bytes(), []byte("denied")) {
+		t.Fatalf("expected path+error in stderr, got %q", errBuf.String())
+	}
+}
+
+func TestHandleEvent_ObjectError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "error", Type: "object.error",
+		Data: map[string]any{"mac": objects.MAC{0xde, 0xad}, "error": errors.New("missing")},
+	})
+	if errBuf.Len() == 0 {
+		t.Fatal("object.error should write to stderr")
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("missing")) {
+		t.Fatalf("expected error message in stderr, got %q", errBuf.String())
+	}
+}
+
+func TestHandleEvent_ChunkError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "error", Type: "chunk.error",
+		Data: map[string]any{"mac": objects.MAC{0xbe, 0xef}, "error": errors.New("corrupted")},
+	})
+	if errBuf.Len() == 0 {
+		t.Fatal("chunk.error should write to stderr")
+	}
+}
+
+func TestHandleEvent_ResultNoErrors(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "info", Type: "result", Workflow: "backup",
+		Data: map[string]any{
+			"duration": 2 * time.Second,
+			"rbytes":   int64(1024),
+			"wbytes":   int64(512),
+			"errors":   uint64(0),
+		},
+	})
+	if !bytes.Contains(out.Bytes(), []byte("backup")) {
+		t.Fatalf("expected workflow name in stdout, got %q", out.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("without errors")) {
+		t.Fatalf("expected 'without errors' marker in stdout, got %q", out.String())
+	}
+}
+
+func TestHandleEvent_ResultWithErrorsSingular(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "info", Type: "result", Workflow: "backup",
+		Data: map[string]any{
+			"duration": time.Second,
+			"rbytes":   int64(100),
+			"wbytes":   int64(50),
+			"errors":   uint64(1),
+		},
+	})
+	if !bytes.Contains(out.Bytes(), []byte("1 error")) ||
+		bytes.Contains(out.Bytes(), []byte("1 errors")) {
+		t.Fatalf("expected singular 'error' wording, got %q", out.String())
+	}
+}
+
+func TestHandleEvent_ResultWithErrorsPlural(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{
+		Level: "info", Type: "result", Workflow: "backup",
+		Data: map[string]any{
+			"duration": time.Second,
+			"rbytes":   int64(100),
+			"wbytes":   int64(50),
+			"errors":   uint64(3),
+		},
+	})
+	if !bytes.Contains(out.Bytes(), []byte("3 errors")) {
+		t.Fatalf("expected '3 errors' wording, got %q", out.String())
+	}
+}
+
+func TestHandleEvent_IgnoredTypes(t *testing.T) {
+	// These types are explicitly ignored — branch is reached but produces no output.
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	for _, typ := range []string{"path", "directory", "file", "symlink", "object", "chunk", "object.ok", "chunk.ok"} {
+		HandleEvent(ctx, &Event{Level: "info", Type: typ})
+	}
+	if out.Len() != 0 || errBuf.Len() != 0 {
+		t.Fatalf("ignored types must not emit, got out=%q err=%q", out.String(), errBuf.String())
+	}
+}
+
+func TestHandleEvent_UnknownTypeIsNoOp(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
+
+	HandleEvent(ctx, &Event{Level: "info", Type: "totally.unknown.type"})
+
+	if out.Len() != 0 || errBuf.Len() != 0 {
+		t.Fatalf("unknown type must hit default and be a no-op, got out=%q err=%q", out.String(), errBuf.String())
+	}
+}
+

--- a/ui/tui/state_test.go
+++ b/ui/tui/state_test.go
@@ -1,0 +1,265 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/objects"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestStateUpdate_WorkflowStartSetsSnapshotID(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{
+		Type:     "workflow.start",
+		Snapshot: objects.MAC{0xde, 0xad, 0xbe, 0xef},
+	})
+	if s.startTime.IsZero() {
+		t.Fatal("startTime should be set")
+	}
+	if !strings.HasPrefix(s.snapshotID, "deadbeef") {
+		t.Fatalf("snapshotID = %q, want deadbeef prefix", s.snapshotID)
+	}
+}
+
+func TestStateUpdate_WorkflowEndIsNoOp(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{Type: "workflow.start"})
+	before := *s
+	s.Update(Event{Type: "workflow.end"})
+	if s.startTime != before.startTime {
+		t.Fatal("workflow.end should not alter startTime")
+	}
+}
+
+func TestStateUpdate_PathCounters(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{Type: "path", Data: map[string]any{"path": "/etc"}})
+	if s.countPath != 1 || s.lastItem != "/etc" {
+		t.Fatalf("after path: %+v", s)
+	}
+	s.Update(Event{Type: "path.ok"})
+	if s.countPathOk != 1 {
+		t.Fatalf("countPathOk = %d", s.countPathOk)
+	}
+	s.Update(Event{Type: "path.cached"})
+	if s.countPathCached != 1 {
+		t.Fatalf("countPathCached = %d", s.countPathCached)
+	}
+	s.Update(Event{
+		Type: "path.error",
+		Data: map[string]any{"path": "/no", "error": "denied"},
+	})
+	if s.countPathError != 1 || len(s.errors) != 1 {
+		t.Fatalf("expected one recorded error, got %+v", s.errors)
+	}
+}
+
+func TestStateUpdate_DirectoryCounters(t *testing.T) {
+	s := newApplicationState()
+	for _, typ := range []string{"directory", "directory.ok", "directory.error", "directory.cached"} {
+		s.Update(Event{Type: typ})
+	}
+	if s.countDir != 1 || s.countDirOk != 1 || s.countDirError != 1 || s.countDirCached != 1 {
+		t.Fatalf("directory counters wrong: %+v", s)
+	}
+}
+
+func TestStateUpdate_FileCountersAndSizes(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{Type: "file"})
+
+	fi := objects.FileInfo{Lsize: 1024}
+	s.Update(Event{Type: "file.ok", Data: map[string]any{"fileinfo": fi}})
+	if s.countFileOk != 1 || s.countFileSize != 1024 {
+		t.Fatalf("file.ok: countFileOk=%d countFileSize=%d", s.countFileOk, s.countFileSize)
+	}
+
+	s.Update(Event{Type: "file.error"})
+	if s.countFileError != 1 {
+		t.Fatalf("file.error: countFileError=%d", s.countFileError)
+	}
+
+	s.Update(Event{Type: "file.cached", Data: map[string]any{"fileinfo": objects.FileInfo{Lsize: 2048}}})
+	if s.countFileCached != 1 || s.countCachedSize != 2048 {
+		t.Fatalf("file.cached: countFileCached=%d countCachedSize=%d", s.countFileCached, s.countCachedSize)
+	}
+}
+
+func TestStateUpdate_XattrCounters(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{Type: "xattr"})
+	s.Update(Event{Type: "xattr.ok", Data: map[string]any{"size": int64(64)}})
+	s.Update(Event{Type: "xattr.error"})
+	s.Update(Event{Type: "xattr.cached", Data: map[string]any{"size": int64(128)}})
+
+	if s.countXattr != 1 || s.countXattrOk != 1 || s.countXattrError != 1 || s.countXattrCached != 1 {
+		t.Fatalf("xattr counters: %+v", s)
+	}
+	if s.countXattrSize != 64 {
+		t.Fatalf("countXattrSize = %d, want 64", s.countXattrSize)
+	}
+	if s.countCachedSize != 128 {
+		t.Fatalf("countCachedSize = %d, want 128", s.countCachedSize)
+	}
+}
+
+func TestStateUpdate_SymlinkCounters(t *testing.T) {
+	s := newApplicationState()
+	for _, typ := range []string{"symlink", "symlink.ok", "symlink.error", "symlink.cached"} {
+		s.Update(Event{Type: typ})
+	}
+	if s.countSymlink != 1 || s.countSymlinkOk != 1 ||
+		s.countSymlinkError != 1 || s.countSymlinkCached != 1 {
+		t.Fatalf("symlink counters: %+v", s)
+	}
+}
+
+func TestStateUpdate_FsSummary(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{
+		Type: "fs.summary",
+		Data: map[string]any{
+			"files":       uint64(10),
+			"directories": uint64(2),
+			"symlinks":    uint64(1),
+			"xattrs":      uint64(3),
+			"size":        uint64(99999),
+		},
+	})
+	if !s.gotSummary {
+		t.Fatal("gotSummary should be true")
+	}
+	if s.summaryFile != 10 || s.summaryDirectory != 2 || s.summarySymlink != 1 || s.summaryXattr != 3 {
+		t.Fatalf("summary fields wrong: %+v", s)
+	}
+	if s.summarySize != 99999 {
+		t.Fatalf("summarySize = %d", s.summarySize)
+	}
+	if s.summaryPath != 10+2+1+3 {
+		t.Fatalf("summaryPath = %d, want %d", s.summaryPath, 10+2+1+3)
+	}
+}
+
+func TestStateUpdate_SnapshotPhases(t *testing.T) {
+	s := newApplicationState()
+
+	s.Update(Event{Type: "snapshot.import.start"})
+	if s.phase != "processing" {
+		t.Fatalf("phase after import.start = %q", s.phase)
+	}
+	if s.timerBegin.IsZero() {
+		t.Fatal("timerBegin should be set on import.start")
+	}
+
+	s.Update(Event{Type: "snapshot.import.done"})
+	if !s.timerDone {
+		t.Fatal("timerDone should be true after import.done")
+	}
+
+	s.Update(Event{Type: "snapshot.vfs.start"})
+	if s.phase != "building VFS" {
+		t.Fatalf("phase after vfs.start = %q", s.phase)
+	}
+
+	s.Update(Event{Type: "snapshot.vfs.end"})
+	if s.phase != "" {
+		t.Fatalf("phase after vfs.end = %q", s.phase)
+	}
+
+	s.Update(Event{Type: "snapshot.index.start"})
+	if s.phase != "indexing" {
+		t.Fatalf("phase after index.start = %q", s.phase)
+	}
+
+	s.Update(Event{Type: "snapshot.index.end"})
+	if s.phase != "" {
+		t.Fatalf("phase after index.end = %q", s.phase)
+	}
+
+	s.Update(Event{Type: "snapshot.commit.start"})
+	if s.phase != "committing" {
+		t.Fatalf("phase after commit.start = %q", s.phase)
+	}
+}
+
+func TestStateUpdate_Result(t *testing.T) {
+	s := newApplicationState()
+	s.Update(Event{
+		Type: "result",
+		Data: map[string]any{
+			"size":     uint64(1024 * 1024),
+			"errors":   uint64(2),
+			"duration": 5 * time.Second,
+		},
+	})
+	if s.phase != "completed" {
+		t.Fatalf("phase = %q, want completed", s.phase)
+	}
+	if !strings.Contains(s.detail, "errors=2") {
+		t.Fatalf("detail should include error count: %q", s.detail)
+	}
+	if !strings.Contains(s.detail, "5s") {
+		t.Fatalf("detail should include duration: %q", s.detail)
+	}
+}
+
+func TestStateUpdate_UnknownTypeIsNoOp(t *testing.T) {
+	s := newApplicationState()
+	before := *s
+	s.Update(Event{Type: "totally.unknown.event"})
+	// Anything beyond no-op would change one of these fields:
+	if s.countPath != before.countPath || s.countFile != before.countFile ||
+		s.phase != before.phase || s.lastItem != before.lastItem {
+		t.Fatalf("unknown type altered state: %+v", s)
+	}
+}
+
+// newAppModelForTest returns an appModel with just enough plumbing for
+// the message-dispatch tests below. We don't construct a real Application
+// (that spawns a bubbletea program) — we set application to nil and only
+// invoke branches that don't dereference it.
+func newAppModelForTest() appModel {
+	return appModel{progress: progressBar()}
+}
+
+func TestAppModelUpdate_WindowSizeStoresGeometry(t *testing.T) {
+	m := newAppModelForTest()
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	got := next.(appModel)
+	if got.width != 120 || got.height != 40 {
+		t.Fatalf("dimensions = %dx%d, want 120x40", got.width, got.height)
+	}
+}
+
+func TestAppModelUpdate_CancelledSetsForceQuit(t *testing.T) {
+	m := newAppModelForTest()
+	next, cmd := m.Update(cancelledMsg{})
+	if !next.(appModel).forceQuit {
+		t.Fatal("cancelledMsg should set forceQuit")
+	}
+	if cmd == nil {
+		t.Fatal("cancelledMsg should return a quit command")
+	}
+}
+
+func TestAppModelUpdate_EventsClosedReturnsQuit(t *testing.T) {
+	m := newAppModelForTest()
+	_, cmd := m.Update(eventsClosedMsg{})
+	if cmd == nil {
+		t.Fatal("eventsClosedMsg should return tea.Quit")
+	}
+}
+
+func TestAppModelUpdate_UnhandledMsgIsNoOp(t *testing.T) {
+	m := newAppModelForTest()
+	type bogus struct{}
+	next, cmd := m.Update(bogus{})
+	if next.(appModel).forceQuit {
+		t.Fatal("unhandled message should not set forceQuit")
+	}
+	if cmd != nil {
+		t.Fatal("unhandled message should return nil cmd")
+	}
+}

--- a/ui/v2/ui_test.go
+++ b/ui/v2/ui_test.go
@@ -1,0 +1,61 @@
+package v2
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCorsMiddleware_SetsHeadersOnGET(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	handler := corsMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("next handler should have been called for GET")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("Allow-Origin = %q, want *", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Fatal("Allow-Methods should be set")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got == "" {
+		t.Fatal("Allow-Headers should be set")
+	}
+	if rec.Body.String() != "ok" {
+		t.Fatalf("body = %q, want ok", rec.Body.String())
+	}
+}
+
+func TestCorsMiddleware_OptionsShortCircuits(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	handler := corsMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodOptions, "/anything", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("next handler must NOT be called for preflight OPTIONS")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("Allow-Origin = %q, want *", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds Go-side tests for the four \`ui/*\` subpackages. No production code changes; tests pass under \`-race\`.

| Subpackage | Coverage delta | Notes |
|---|---|---|
| \`ui/json\` | 0% → **92.9%** | \`sanitizeData\`, lifecycle, \`handleEvent\` (Silent/Quiet/normal). |
| \`ui/stdio\` | 0% → **97.6%** | Every event-type branch of \`HandleEvent\` (path.ok, path.error, object/chunk.error, result with singular/plural error wording, ignored types, default), plus \`New\`/\`Run\`/\`Wait\` lifecycle. |
| \`ui/tui\` | 0% → **18.8%** | Every event-type branch of \`State.Update\` (path, dir, file, xattr, symlink × {plain, .ok, .error, .cached}, fs.summary, snapshot.* phases, result). Also covers the bubbletea \`appModel.Update\` dispatcher's pure branches. |
| \`ui/v2\` | 0% → **15.7%** | \`corsMiddleware\` at 100% (preflight short-circuit + normal-path headers). |

### Deliberately out of scope

- \`ui/tui\` rendering / lifecycle that drives the bubbletea program needs a tty.
- \`ui/v2/Ui()\` launcher spawns a browser, listens forever, and embeds the frontend — not testable in this layer.

## Test plan
- [ ] \`go test -race ./ui/...\` passes in CI.
- [ ] Codecov report shows the four bumps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)