### PR TITLE
codecov: exclude testing/ and testing/fileinfo/ from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+# Codecov configuration for plakar.
+#
+# https://docs.codecov.com/docs/codecov-yaml
+
+# Paths that are excluded from the coverage report. These are test-support
+# packages — they have no `_test.go` files of their own and exist purely
+# to be imported by tests elsewhere in the tree. Counting them against
+# project coverage punishes us for having well-factored test helpers.
+ignore:
+  - "testing/"          # GenerateRepository, GenerateSnapshot, MockFile, FakeCachedServer, ...
+  - "testing/fileinfo/" # FileInfo mocks used by snapshot tests


### PR DESCRIPTION
## Summary

Adds \`.codecov.yml\` excluding two test-support packages from coverage reports:

- \`testing/\` — \`GenerateRepository\`, \`GenerateSnapshot\`, \`MockFile\`, \`FakeCachedServer\`, etc.
- \`testing/fileinfo/\` — FileInfo mocks used by snapshot tests

Both have no \`_test.go\` files of their own and exist purely to be imported by tests elsewhere in the tree. Counting them against project coverage punishes the codebase for having well-factored test helpers and obscures the true coverage of production code.

## What this changes

- Project coverage % on the next Codecov report will reflect production code only.
- No \`go test\` invocation changes — \`go tool cover\` still emits data for these packages locally if you want it.
- No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)