### PR TITLE
mount: add -allow-others flag for FUSE mounts

### DIFF
--- a/subcommands/mount/fuse/fuse.go
+++ b/subcommands/mount/fuse/fuse.go
@@ -36,7 +36,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS) (int, error) {
+func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS, allowOthers bool) (int, error) {
 	if mountpoint == "" {
 		mountpoint = filepath.Join(ctx.CWD, uuid.New().String())
 		if err := os.MkdirAll(mountpoint, 0700); err != nil {
@@ -53,12 +53,15 @@ func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountp
 		}
 	}
 
-	c, err := fuse.Mount(
-		mountpoint,
+	mountOptions := []fuse.MountOption{
 		fuse.FSName("plakar"),
 		fuse.Subtype("plakarfs"),
 		fuse.LocalVolume(),
-	)
+	}
+	if allowOthers {
+		mountOptions = append(mountOptions, fuse.AllowOther())
+	}
+	c, err := fuse.Mount(mountpoint, mountOptions...)
 	if err != nil {
 		return 1, fmt.Errorf("mount: %v", err)
 	}

--- a/subcommands/mount/fuse/fuse_dragonfly.go
+++ b/subcommands/mount/fuse/fuse_dragonfly.go
@@ -25,6 +25,6 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 )
 
-func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS) (int, error) {
+func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS, allowOthers bool) (int, error) {
 	return 1, fmt.Errorf("mount not supported on %s", ctx.OperatingSystem)
 }

--- a/subcommands/mount/fuse/fuse_freebsd.go
+++ b/subcommands/mount/fuse/fuse_freebsd.go
@@ -25,6 +25,6 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 )
 
-func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS) (int, error) {
+func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS, allowOthers bool) (int, error) {
 	return 1, fmt.Errorf("mount not supported on %s", ctx.OperatingSystem)
 }

--- a/subcommands/mount/fuse/fuse_netbsd.go
+++ b/subcommands/mount/fuse/fuse_netbsd.go
@@ -25,6 +25,6 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 )
 
-func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS) (int, error) {
+func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS, allowOthers bool) (int, error) {
 	return 1, fmt.Errorf("mount not supported on %s", ctx.OperatingSystem)
 }

--- a/subcommands/mount/fuse/fuse_openbsd.go
+++ b/subcommands/mount/fuse/fuse_openbsd.go
@@ -25,6 +25,6 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 )
 
-func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS) (int, error) {
+func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS, allowOthers bool) (int, error) {
 	return 1, fmt.Errorf("mount not supported on %s", ctx.OperatingSystem)
 }

--- a/subcommands/mount/fuse/fuse_windows.go
+++ b/subcommands/mount/fuse/fuse_windows.go
@@ -25,6 +25,6 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 )
 
-func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS) (int, error) {
+func ExecuteFUSE(ctx *appcontext.AppContext, repo *repository.Repository, mountpoint string, locateOptions *locate.LocateOptions, chrootfs fs.FS, allowOthers bool) (int, error) {
 	return 1, fmt.Errorf("mount not supported on %s", ctx.OperatingSystem)
 }

--- a/subcommands/mount/mount.go
+++ b/subcommands/mount/mount.go
@@ -35,6 +35,7 @@ type Mount struct {
 
 	Mountpoint    string
 	LocateOptions *locate.LocateOptions
+	AllowOthers   bool
 
 	SnapshotPath string
 
@@ -53,6 +54,7 @@ func (cmd *Mount) Parse(ctx *appcontext.AppContext, args []string) error {
 		fmt.Fprintf(flags.Output(), "Usage: %s [-to PATH] [snapshotID]\n", flags.Name())
 	}
 	flags.StringVar(&cmd.Mountpoint, "to", "", "mount point")
+	flags.BoolVar(&cmd.AllowOthers, "allow-others", false, "allow other users to access the mount")
 	cmd.LocateOptions.InstallLocateFlags(flags)
 	flags.Parse(args)
 
@@ -91,5 +93,5 @@ func (cmd *Mount) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 	if strings.HasPrefix(cmd.Mountpoint, "http://") {
 		return http.ExecuteHTTP(ctx, repo, cmd.Mountpoint, cmd.LocateOptions, chrootFS)
 	}
-	return fuse.ExecuteFUSE(ctx, repo, cmd.Mountpoint, cmd.LocateOptions, chrootFS)
+	return fuse.ExecuteFUSE(ctx, repo, cmd.Mountpoint, cmd.LocateOptions, chrootFS, cmd.AllowOthers)
 }

--- a/subcommands/mount/plakar-mount.1
+++ b/subcommands/mount/plakar-mount.1
@@ -1,4 +1,4 @@
-.Dd May 5, 2026
+.Dd May 29, 2026
 .Dt PLAKAR-MOUNT 1
 .Os
 .Sh NAME
@@ -6,6 +6,7 @@
 .Nd Mount Plakar snapshots as read-only filesystem
 .Sh SYNOPSIS
 .Nm plakar mount
+.Op Fl allow-others
 .Op Fl to Ar mountpoint
 .Op Ar snapshotID
 .Sh DESCRIPTION
@@ -27,6 +28,8 @@ to precisely select snapshots.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl allow-others
+Allow other users to access the mounted filesystem.
 .It Fl to Ar mountpoint
 Specify the mount location.
 The
@@ -62,6 +65,11 @@ $ plakar mount -to ~/mnt -latest
 Mount a specific snapshot by ID to a directory:
 .Bd -literal -offset indent
 $ plakar mount -to ~/mnt abc123
+.Ed
+.Pp
+Mount all snapshots allowing access by other users:
+.Bd -literal -offset indent
+$ plakar mount -allow-others -to ~/mnt
 .Ed
 .Pp
 Mount snapshots matching a filter (e.g., snapshots with tag "daily-backup"):


### PR DESCRIPTION
## Changes

  - `subcommands/mount/mount.go`: adds `AllowOthers bool` field and `-allow-others` CLI flag
  - `subcommands/mount/fuse/fuse.go`: accepts the parameter and conditionally appends `fuse.AllowOther()` to the mount options slice
  - All platform stub files (`windows`, `freebsd`, `openbsd`, `netbsd`, `dragonfly`) updated to match the new `ExecuteFUSE` signature

  ## Usage

  `plakar mount -allow-others -to /mnt/plakar`

> Note: On Linux, user_allow_other must be enabled in /etc/fuse.conf for this option to take effect.

Resolves #2165