### PR TITLE
backup: allow multiple ignore files

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -107,7 +107,7 @@ func (e *tagFlags) asList() []string {
 }
 
 func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
-	var opt_ignore_file string
+	var opt_ignore_files ignoreFlags
 	var opt_ignore ignoreFlags
 	var opt_tags tagFlags
 
@@ -129,7 +129,7 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.StringVar(&cmd.Environment, "environment", "", "backup environment")
 	flags.StringVar(&cmd.Perimeter, "perimeter", "", "backup perimeter")
 	flags.StringVar(&cmd.Job, "job", "", "backup job")
-	flags.StringVar(&opt_ignore_file, "ignore-file", "", "path to a file containing newline-separated gitignore patterns, treated as -ignore")
+	flags.Var(&opt_ignore_files, "ignore-file", "path to a file containing newline-separated gitignore patterns, treated as -ignore; can be specified multiple times")
 	flags.Var(&opt_ignore, "ignore", "gitignore pattern to exclude files, can be specified multiple times to add several exclusion patterns")
 	flags.StringVar(&cmd.PackfileTempStorage, "packfiles", "", "memory or a path to a directory to store temporary packfiles")
 	flags.BoolVar(&cmd.OptCheck, "check", false, "check the snapshot after creating it")
@@ -148,8 +148,8 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 		}
 	}
 
-	if opt_ignore_file != "" {
-		lines, err := LoadIgnoreFile(opt_ignore_file)
+	for _, ignoreFile := range opt_ignore_files {
+		lines, err := LoadIgnoreFile(ignoreFile)
 		if err != nil {
 			return err
 		}

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -156,6 +156,39 @@ func TestBackupIgnoreFileFlag(t *testing.T) {
 	require.NotContains(t, bufOut.String(), "/subdir/")
 }
 
+func TestBackupMultipleIgnoreFileFlags(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	ignoreDir := t.TempDir()
+	macOSIgnoreFile := filepath.Join(ignoreDir, "macos-ignore")
+	sourceIgnoreFile := filepath.Join(ignoreDir, "source-ignore")
+	require.NoError(t, os.WriteFile(macOSIgnoreFile, []byte(".DS_Store\n"), 0o600))
+	require.NoError(t, os.WriteFile(sourceIgnoreFile, []byte("**/subdir\n"), 0o600))
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-ignore-file", macOSIgnoreFile,
+		"-ignore-file", sourceIgnoreFile,
+		"-ignore", "**/another_subdir",
+		tmpBackupDir,
+	}))
+	require.Equal(t, []string{".DS_Store", "**/subdir", "**/another_subdir"}, cmd.Excludes)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotContains(t, bufOut.String(), "/subdir/")
+	require.NotContains(t, bufOut.String(), "/another_subdir/")
+}
+
 func TestBackupIgnoreFileMissing(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/backup/plakar-backup.1
+++ b/subcommands/backup/plakar-backup.1
@@ -70,6 +70,7 @@ This option can be repeated.
 .It Fl ignore-file Ar file
 Specify a file containing gitignore exclusion patterns, one per line, to
 ignore files or directories in the backup.
+This option can be repeated.
 .It Fl job Ar job
 Name the snapshot job.
 .It Fl name Ar name
@@ -117,9 +118,9 @@ Create a snapshot of the current directory with two tags:
 $ plakar backup -tag daily-backup,production
 .Ed
 .Pp
-Ignore files using patterns in a given file:
+Ignore files using patterns in one or more files:
 .Bd -literal -offset indent
-$ plakar backup -ignore-file ~/my-ignore-file /var/www
+$ plakar backup -ignore-file ~/common-ignore -ignore-file ~/project-ignore /var/www
 .Ed
 .Pp
 or by using patterns specified inline:

--- a/subcommands/help/docs/plakar-backup.md
+++ b/subcommands/help/docs/plakar-backup.md
@@ -88,6 +88,7 @@ The options are as follows:
 
 > Specify a file containing gitignore exclusion patterns, one per line, to
 > ignore files or directories in the backup.
+> This option can be repeated.
 
 **-job** *job*
 
@@ -154,9 +155,9 @@ Create a snapshot of the current directory with two tags:
 
 	$ plakar backup -tag daily-backup,production
 
-Ignore files using patterns in a given file:
+Ignore files using patterns in one or more files:
 
-	$ plakar backup -ignore-file ~/my-ignore-file /var/www
+	$ plakar backup -ignore-file ~/common-ignore -ignore-file ~/project-ignore /var/www
 
 or by using patterns specified inline:
 


### PR DESCRIPTION
Make `plakar backup -ignore-file` repeatable so users can combine common ignore files with source-specific ones.

Patterns are loaded from each `-ignore-file` in flag order, then inline `-ignore` patterns are appended as before.

Fixes #1617

Tests:
* `go test ./subcommands/backup`
* `go test ./subcommands/...`