### PR TITLE
introduce a helper for yaml.NewEncoder() to always close it

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/PlakarKorp/plakar/utils"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -160,7 +161,7 @@ func save(file string, src any) error {
 		return err
 	}
 
-	err = yaml.NewEncoder(tmpFile).Encode(src)
+	err = utils.YAMLEncode(tmpFile, src)
 	tmpFile.Close()
 
 	if err == nil {

--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -32,7 +32,7 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/config"
 	"github.com/PlakarKorp/plakar/subcommands"
-	"go.yaml.in/yaml/v3"
+	"github.com/PlakarKorp/plakar/utils"
 	"gopkg.in/ini.v1"
 )
 
@@ -419,7 +419,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 			} else if opt_ini {
 				err = MarshalINISections(name, cfgMap[name], ctx.Stdout)
 			} else {
-				err = yaml.NewEncoder(ctx.Stdout).Encode(map[string]map[string]string{name: cfgMap[name]})
+				err = utils.YAMLEncode(ctx.Stdout, map[string]map[string]string{name: cfgMap[name]})
 			}
 			if err != nil {
 				return fmt.Errorf("failed to encode store %q: %w", name, err)

--- a/subcommands/service/show.go
+++ b/subcommands/service/show.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/subcommands"
-	"go.yaml.in/yaml/v3"
+	"github.com/PlakarKorp/plakar/utils"
 )
 
 type ServiceShow struct {
@@ -56,7 +56,7 @@ func (cmd *ServiceShow) Execute(ctx *appcontext.AppContext, repo *repository.Rep
 	if cmd.AsJson {
 		err = json.NewEncoder(ctx.Stdout).Encode(map[string]any{cmd.Service: config})
 	} else {
-		err = yaml.NewEncoder(ctx.Stdout).Encode(map[string]any{cmd.Service: config})
+		err = utils.YAMLEncode(ctx.Stdout, map[string]any{cmd.Service: config})
 	}
 	if err != nil {
 		return 1, fmt.Errorf("failed to encode config: %w", err)

--- a/utils/config_policy.go
+++ b/utils/config_policy.go
@@ -204,7 +204,7 @@ func (c *policiesConfig) SaveToFile(filename string) error {
 	if err != nil {
 		return err
 	}
-	err = yaml.NewEncoder(tmpFile).Encode(c)
+	err = YAMLEncode(tmpFile, c)
 	tmpFile.Close()
 	if err == nil {
 		err = os.Rename(tmpFile.Name(), filename)
@@ -234,7 +234,7 @@ func (c *policiesConfig) Dump(w io.Writer, format string, names []string) error 
 		case "json":
 			err = json.NewEncoder(w).Encode(map[string]*locate.LocateOptions{name: c.Policies[name]})
 		case "yaml":
-			err = yaml.NewEncoder(w).Encode(map[string]*locate.LocateOptions{name: c.Policies[name]})
+			err = YAMLEncode(w, map[string]*locate.LocateOptions{name: c.Policies[name]})
 		default:
 			return fmt.Errorf("unknown format %q", format)
 		}

--- a/utils/marshal.go
+++ b/utils/marshal.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"io"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func YAMLEncode(w io.Writer, x any) error {
+	enc := yaml.NewEncoder(w)
+	if err := enc.Encode(x); err != nil {
+		enc.Close()
+		return err
+	}
+	return enc.Close()
+}


### PR DESCRIPTION
unlike json.NewEncoder(), yaml Encoder needs to be Close()d to properly flush.  Introduce an helper and use it across the codebase to avoid forgetting to do so.