### PR TITLE
ci: use codecov-action@v5 for test results (drop deprecated action)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,10 +50,12 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./junit.xml
+        report_type: test_results
+        fail_ci_if_error: false
 
     - name: Fail if tests failed
       if: ${{ steps.gotest.outputs.test_exit != '0' }}


### PR DESCRIPTION
`codecov/test-results-action@v1` is deprecated in favor of `codecov-action@v5` with `report_type: test_results`. Switch the test-results upload to the recommended pattern (the coverage step already uses v5). Uploads were already succeeding in CI; this just removes the deprecation warning and future-proofs the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)