### PR TITLE
Fix sync.

### DIFF
--- a/subcommands/sync/sync.go
+++ b/subcommands/sync/sync.go
@@ -190,8 +190,7 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, fmt.Errorf("could not open peer repository %s: %w", cmd.PeerRepositoryLocation, err)
 	}
 
-	_, err = cached.RebuildStateFromStore(ctx, peerRepository.Configuration().RepositoryID, storeConfig, false)
-	if err != nil {
+	if _, err = cached.RebuildStateFromStore(peerCtx, peerRepository.Configuration().RepositoryID, storeConfig, false); err != nil {
 		return 1, fmt.Errorf("failed to rebuild peer repository's state %s: %w", cmd.PeerRepositoryLocation, err)
 	}
 

--- a/subcommands/sync/sync_test.go
+++ b/subcommands/sync/sync_test.go
@@ -3,18 +3,14 @@ package sync
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
-	_ "github.com/PlakarKorp/integrations/fs/exporter"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
-	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
-	"github.com/PlakarKorp/plakar/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,114 +18,176 @@ func init() {
 	os.Setenv("TZ", "UTC")
 }
 
-func generateSnapshot(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) (*repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
-	stateRefresher = func(*appcontext.AppContext, *repository.Repository) func(objects.MAC, bool) error {
-		return nil
+var mockFiles = []ptesting.MockFile{
+	ptesting.NewMockDir("subdir"),
+	ptesting.NewMockDir("another_subdir"),
+	ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	ptesting.NewMockFile("subdir/foo.txt", 0644, "hello foo"),
+	ptesting.NewMockFile("subdir/to_exclude", 0644, "*/subdir/to_exclude\n"),
+	ptesting.NewMockFile("another_subdir/bar.txt", 0644, "hello bar"),
+}
+
+// syncFixture is the equivalent of what main.go sets up before dispatching to
+// the sync subcommand: a local repository (the one the command operates on), a
+// peer repository, an in-process cached and a configuration through which the
+// peer can be resolved.
+type syncFixture struct {
+	localRepo *repository.Repository
+	localCtx  *appcontext.AppContext
+	peerRepo  *repository.Repository
+
+	// what to pass as the REPOSITORY argument of the sync command
+	peerArg string
+
+	output *bytes.Buffer
+}
+
+func setupSync(t *testing.T, localPassphrase, peerPassphrase []byte) *syncFixture {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	var localPass, peerPass *[]byte
+	if localPassphrase != nil {
+		localPass = &localPassphrase
+	}
+	if peerPassphrase != nil {
+		peerPass = &peerPassphrase
 	}
 
-	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
-	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
-		ptesting.NewMockDir("subdir"),
-		ptesting.NewMockDir("another_subdir"),
-		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
-		ptesting.NewMockFile("subdir/foo.txt", 0644, "hello foo"),
-		ptesting.NewMockFile("subdir/to_exclude", 0644, "*/subdir/to_exclude\n"),
-		ptesting.NewMockFile("another_subdir/bar.txt", 0644, "hello bar"),
-	})
-	return repo, snap, ctx
+	localRepo, localCtx := ptesting.GenerateRepository(t, bufOut, bufErr, localPass)
+	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, peerPass)
+
+	// sync taps into cached to rebuild states, run one in-process on the
+	// local context's cache directory.
+	ptesting.StartCached(t, localCtx)
+
+	// main.go sets the resolved store config of the repository being
+	// operated on; the state refresher relies on it.
+	localCtx.StoreConfig = map[string]string{"location": localRepo.Root()}
+
+	fixture := &syncFixture{
+		localRepo: localRepo,
+		localCtx:  localCtx,
+		peerRepo:  peerRepo,
+		peerArg:   peerRepo.Root(),
+		output:    bufOut,
+	}
+
+	localCtx.Config = config.NewConfig()
+	if peerPassphrase != nil {
+		// an encrypted peer can only provide its passphrase through the
+		// configuration (or interactively), address it as @peer.
+		localCtx.Config.Repositories["peer"] = map[string]string{
+			"location":   peerRepo.Root(),
+			"passphrase": string(peerPassphrase),
+		}
+		fixture.peerArg = "@peer"
+	}
+
+	return fixture
 }
 
-func _TestExecuteCmdSyncTo(t *testing.T) {
-	bufOut := bytes.NewBuffer(nil)
-	bufErr := bytes.NewBuffer(nil)
+func snapshotIDs(t *testing.T, repo *repository.Repository) map[objects.MAC]struct{} {
+	require.NoError(t, repo.RebuildState())
 
-	localRepo, snap, lctx := generateSnapshot(t, bufOut, bufErr)
-	defer snap.Close()
-
-	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
-
-	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:])), "to", peerRepo.Root()}
-
-	subcommand := &Sync{}
-	fmt.Println(args)
-	err := subcommand.Parse(lctx, args)
-	require.NoError(t, err)
-	require.NotNil(t, subcommand)
-
-	status, err := subcommand.Execute(lctx, localRepo)
-	require.NoError(t, err)
-	require.Equal(t, 0, status)
-
-	// output should look like this
-	// 2025-03-26T21:17:28Z info: sync: synchronization from /tmp/tmp_repo1957539148/repo to /tmp/tmp_repo2470692775/repo completed: 1 snapshots synchronized
-	output := bufOut.String()
-	require.Contains(t, strings.Trim(output, "\n"), fmt.Sprintf("info: sync: synchronization from %s to %s completed: 1 snapshots synchronized", localRepo.Origin(), peerRepo.Origin()))
+	ids := make(map[objects.MAC]struct{})
+	for id, err := range repo.ListSnapshots() {
+		require.NoError(t, err)
+		ids[id] = struct{}{}
+	}
+	return ids
 }
 
-func _TestExecuteCmdSyncWith(t *testing.T) {
-	bufOut := bytes.NewBuffer(nil)
-	bufErr := bytes.NewBuffer(nil)
-
-	localRepo, snap, lctx := generateSnapshot(t, bufOut, bufErr)
-	defer snap.Close()
-
-	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
-
-	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:])), "with", peerRepo.Root()}
-
+func runSync(t *testing.T, fixture *syncFixture, args []string) {
 	subcommand := &Sync{}
-	err := subcommand.Parse(lctx, args)
+	err := subcommand.Parse(fixture.localCtx, args)
 	require.NoError(t, err)
-	require.NotNil(t, subcommand)
 
-	status, err := subcommand.Execute(lctx, localRepo)
+	status, err := subcommand.Execute(fixture.localCtx, fixture.localRepo)
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
-
-	// output should look like this
-	// 2025-03-26T21:28:23Z info: sync: synchronization between /tmp/tmp_repo3863826583/repo and /tmp/tmp_repo327669581/repo completed: 1 snapshots synchronized
-	output := bufOut.String()
-	require.Contains(t, strings.Trim(output, "\n"), fmt.Sprintf("info: sync: synchronization between %s and %s completed: 1 snapshots synchronized", localRepo.Origin(), peerRepo.Origin()))
 }
 
-func _TestExecuteCmdSyncWithEncryption(t *testing.T) {
-	bufOut := bytes.NewBuffer(nil)
-	bufErr := bytes.NewBuffer(nil)
+func testSyncDirection(t *testing.T, direction string, localPassphrase, peerPassphrase []byte) {
+	fixture := setupSync(t, localPassphrase, peerPassphrase)
 
-	localRepo, snap, lctx := generateSnapshot(t, bufOut, bufErr)
+	wantSynchronized := 1
+	var localSnap, peerSnap *objects.MAC
+	switch direction {
+	case "to":
+		snap := ptesting.GenerateSnapshot(t, fixture.localRepo, mockFiles)
+		defer snap.Close()
+		localSnap = &snap.Header.Identifier
+	case "from":
+		snap := ptesting.GenerateSnapshot(t, fixture.peerRepo, mockFiles)
+		defer snap.Close()
+		peerSnap = &snap.Header.Identifier
+	case "with":
+		lsnap := ptesting.GenerateSnapshot(t, fixture.localRepo, mockFiles)
+		defer lsnap.Close()
+		localSnap = &lsnap.Header.Identifier
+		psnap := ptesting.GenerateSnapshot(t, fixture.peerRepo, mockFiles)
+		defer psnap.Close()
+		peerSnap = &psnap.Header.Identifier
+		wantSynchronized = 2
+	}
+
+	runSync(t, fixture, []string{direction, fixture.peerArg})
+
+	// whatever the direction, both ends must now hold every snapshot
+	localIDs := snapshotIDs(t, fixture.localRepo)
+	peerIDs := snapshotIDs(t, fixture.peerRepo)
+	require.Len(t, localIDs, wantSynchronized)
+	require.Len(t, peerIDs, wantSynchronized)
+	if localSnap != nil {
+		require.Contains(t, localIDs, *localSnap)
+		require.Contains(t, peerIDs, *localSnap)
+	}
+	if peerSnap != nil {
+		require.Contains(t, localIDs, *peerSnap)
+		require.Contains(t, peerIDs, *peerSnap)
+	}
+
+	require.Regexp(t,
+		`info: sync: synchronization .*completed: `+string(rune('0'+wantSynchronized))+` snapshots synchronized`,
+		fixture.output.String())
+}
+
+func TestExecuteCmdSync(t *testing.T) {
+	localPassphrase := []byte("aZeRtY123456$#@!@")
+	// different from the local one on purpose: rebuilding the peer's state
+	// with the local crypto material must not work.
+	peerPassphrase := []byte("QsDfG654321&^%*%!")
+
+	combinations := []struct {
+		name      string
+		localPass []byte
+		peerPass  []byte
+	}{
+		{"plain_plain", nil, nil},
+		{"plain_encrypted", nil, peerPassphrase},
+		{"encrypted_plain", localPassphrase, nil},
+		{"encrypted_encrypted", localPassphrase, peerPassphrase},
+	}
+
+	for _, direction := range []string{"to", "from", "with"} {
+		for _, combo := range combinations {
+			t.Run(direction+"_"+combo.name, func(t *testing.T) {
+				testSyncDirection(t, direction, combo.localPass, combo.peerPass)
+			})
+		}
+	}
+}
+
+func TestExecuteCmdSyncSnapshotID(t *testing.T) {
+	fixture := setupSync(t, nil, nil)
+
+	snap := ptesting.GenerateSnapshot(t, fixture.localRepo, mockFiles)
 	defer snap.Close()
 
-	passphrase := []byte("aZeRtY123456$#@!@")
-	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
-
-	// need to recreate configuration to store passphrase on peer repo
-	opt_configfile := strings.TrimPrefix(peerRepo.Root(), "fs://")
-
-	cfg, err := utils.LoadConfig(opt_configfile)
-	require.NoError(t, err)
-	lctx.Config = cfg
-	lctx.Config.Repositories["peerRepo"] = make(map[string]string)
-	lctx.Config.Repositories["peerRepo"]["passphrase"] = string(passphrase)
-	lctx.Config.Repositories["peerRepo"]["location"] = peerRepo.Root()
-	err = utils.SaveConfig(opt_configfile, lctx.Config)
-	require.NoError(t, err)
-
 	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:])), "with", "@peerRepo"}
+	runSync(t, fixture, []string{hex.EncodeToString(indexId[:]), "to", fixture.peerArg})
 
-	subcommand := &Sync{}
-	err = subcommand.Parse(lctx, args)
-	require.NoError(t, err)
-	require.NotNil(t, subcommand)
-
-	status, err := subcommand.Execute(lctx, localRepo)
-	require.NoError(t, err)
-	require.Equal(t, 0, status)
-
-	// output should look like this
-	// 2025-03-26T21:28:23Z info: sync: synchronization between /tmp/tmp_repo3863826583/repo and /tmp/tmp_repo327669581/repo completed: 1 snapshots synchronized
-	output := bufOut.String()
-	require.Contains(t, strings.Trim(output, "\n"), fmt.Sprintf("info: sync: synchronization between %s and %s completed: 1 snapshots synchronized", localRepo.Origin(), peerRepo.Origin()))
+	peerIDs := snapshotIDs(t, fixture.peerRepo)
+	require.Contains(t, peerIDs, snap.Header.Identifier)
 }

--- a/testing/cached.go
+++ b/testing/cached.go
@@ -1,0 +1,47 @@
+package testing
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	cachedcmd "github.com/PlakarKorp/plakar/subcommands/cached"
+	"github.com/stretchr/testify/require"
+)
+
+// StartCached runs the cached daemon in-process, listening on the cached.sock
+// of the given context's CacheDir. The cached client connects to that socket
+// before trying to spawn an external process, so commands relying on cached
+// (sync, backup -check, ...) can be exercised from tests as long as the
+// server is started before they execute.
+func StartCached(t *testing.T, ctx *appcontext.AppContext) {
+	srvCtx := appcontext.NewAppContextFrom(ctx)
+
+	srv := &cachedcmd.Cached{}
+	err := srv.Parse(srvCtx, []string{"-foreground", "-teardown", "5m"})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.Execute(srvCtx, nil)
+	}()
+
+	socketPath := filepath.Join(ctx.CacheDir, "cached.sock")
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("unix", socketPath)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 10*time.Second, 5*time.Millisecond, "cached did not come up on %s", socketPath)
+
+	t.Cleanup(func() {
+		srvCtx.Close()
+		<-done
+		srv.Close()
+	})
+}


### PR DESCRIPTION
Fix sync failure on encrypted peer repositories. We always need to use the peerCtx when dealing with the peer repository. 

While we are let's re-enable sync tests by providing a fixture for cached, and add a full matrix of tests for to/from/with and encryption so that those never happen again. (tests mainly generated by our friend.)

Reported by @karreg on discord, many thx!

