### PR TITLE
test: raise stdio/json/cookies/services/httpd coverage to ~100%

### DIFF
--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -114,6 +114,129 @@ func TestFirstRunOperations(t *testing.T) {
 	require.False(t, isFirstRun)
 }
 
+func TestNewManagerMkdirPanics(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Point the base dir at a path whose parent is a regular file, so MkdirAll
+	// fails with ENOTDIR and NewManager panics.
+	blocker := filepath.Join(tmpDir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte{}, 0600))
+
+	require.Panics(t, func() {
+		NewManager(filepath.Join(blocker, "sub"))
+	})
+}
+
+func TestCloseAndGetDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	require.NoError(t, manager.Close())
+	require.Equal(t, filepath.Join(tmpDir, "cookies", COOKIES_VERSION), manager.GetDir())
+}
+
+func TestGetAuthTokenFromEnv(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	t.Setenv("PLAKAR_TOKEN", "env-token")
+	token, err := manager.GetAuthToken()
+	require.NoError(t, err)
+	require.Equal(t, "env-token", token)
+}
+
+func TestGetAuthTokenEmptyFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	// An empty token file is treated as "no token".
+	require.NoError(t, manager.PutAuthToken(""))
+	_, err = manager.GetAuthToken()
+	require.Error(t, err)
+}
+
+func TestGetAuthTokenReadError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	// Make .auth-token a directory so ReadFile fails with a non-NotExist error.
+	require.NoError(t, os.Mkdir(filepath.Join(manager.cookiesDir, ".auth-token"), 0700))
+	_, err = manager.GetAuthToken()
+	require.Error(t, err)
+	require.False(t, os.IsNotExist(err))
+}
+
+func TestDeleteAuthTokenFromEnv(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	t.Setenv("PLAKAR_TOKEN", "env-token")
+	err = manager.DeleteAuthToken()
+	require.ErrorIs(t, err, ErrDeleteEnvToken)
+}
+
+func TestDeleteAuthTokenNotLoggedIn(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	// No token file present: deleting reports ErrNotLoggedIn.
+	err = manager.DeleteAuthToken()
+	require.ErrorIs(t, err, ErrNotLoggedIn)
+}
+
+func TestPutRepositoryCookieMkdirError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+	repoID := uuid.New()
+
+	// Create a regular file where the per-repository directory is expected, so
+	// MkdirAll fails.
+	require.NoError(t, os.WriteFile(filepath.Join(manager.cookiesDir, repoID.String()), []byte{}, 0600))
+	err = manager.PutRepositoryCookie(repoID, "cookie")
+	require.Error(t, err)
+}
+
+func TestIsFirstRunStatError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cookies_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	manager := NewManager(tmpDir)
+
+	// Make .first-run unstattable by placing it under a non-directory path
+	// component: create a file "blocker" and point cookiesDir's child through it.
+	// Simpler: replace cookiesDir with a path whose parent is a file, forcing a
+	// non-NotExist stat error (ENOTDIR).
+	blocker := filepath.Join(tmpDir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte{}, 0600))
+	manager.cookiesDir = filepath.Join(blocker, "sub")
+
+	require.False(t, manager.IsFirstRun())
+}
+
 func TestSecurityCheckOperations(t *testing.T) {
 	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp("", "cookies_test")

--- a/server/httpd/httpd_test.go
+++ b/server/httpd/httpd_test.go
@@ -6,15 +6,19 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
+	ptesting "github.com/PlakarKorp/plakar/testing"
 )
 
 // fakeStore is a minimal storage.Store that records the calls the httpd
@@ -28,8 +32,9 @@ type fakeStore struct {
 	listResources map[storage.StorageResource][]objects.MAC
 	listErr       error
 
-	getData map[storage.StorageResource]map[objects.MAC][]byte
-	getErr  error
+	getData   map[storage.StorageResource]map[objects.MAC][]byte
+	getErr    error
+	getReader io.ReadCloser // if set, returned by Get instead of getData
 
 	deleteErr error
 	putErr    error
@@ -60,6 +65,9 @@ func (f *fakeStore) Get(ctx context.Context, typ storage.StorageResource, mac ob
 	f.lastGetType, f.lastGetMAC, f.lastGetRng = typ, mac, rg
 	if f.getErr != nil {
 		return nil, f.getErr
+	}
+	if f.getReader != nil {
+		return f.getReader, nil
 	}
 	data := f.getData[typ][mac]
 	return io.NopCloser(bytes.NewReader(data)), nil
@@ -242,6 +250,15 @@ func TestGetRange_EndEqualStart(t *testing.T) {
 	req.Header.Set("Range", "bytes=50-50")
 	if _, err := getRange(req); !errors.Is(err, ErrInvalidRange) {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestGetRange_LengthOverflowsUint32(t *testing.T) {
+	// A range whose length exceeds math.MaxUint32 is rejected.
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Range", "bytes=0-4294967296") // length = 2^32 > MaxUint32
+	if _, err := getRange(req); !errors.Is(err, ErrInvalidRange) {
+		t.Fatalf("err = %v, want ErrInvalidRange", err)
 	}
 }
 
@@ -435,6 +452,26 @@ func TestGetResourceHandler_StoreError(t *testing.T) {
 	}
 }
 
+// errReadCloser fails on Read so io.ReadAll in getResource returns an error.
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReadCloser) Close() error             { return nil }
+
+func TestGetResourceHandler_ReadError(t *testing.T) {
+	mac := makeMAC(0x42)
+	store := &fakeStore{getReader: errReadCloser{}}
+	mux := newTestMux(store, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
 func TestPutResource_Ok(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
@@ -563,5 +600,72 @@ func TestDeleteResource_StoreError(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+// freePort asks the kernel for an unused TCP port and returns it as a string.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().(*net.TCPAddr)
+	_ = l.Close()
+	return fmt.Sprintf("127.0.0.1:%d", addr.Port)
+}
+
+func TestServer_StartServeAndShutdown(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	addr := freePort(t)
+	errCh := make(chan error, 1)
+	go func() {
+		// noDelete=false, no TLS — exercises the plain ListenAndServe path.
+		errCh <- Server(ctx, repo, addr, false, "", "")
+	}()
+
+	// Wait until the server accepts connections, then make one request so the
+	// wired routes are exercised through a real listener.
+	base := "http://" + addr
+	var resp *http.Response
+	deadline := 2 * time.Second
+	for waited := time.Duration(0); waited < deadline; waited += 20 * time.Millisecond {
+		r, err := http.Get(base + "/")
+		if err == nil {
+			resp = r
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if resp == nil {
+		t.Fatal("server never became reachable")
+	}
+	_ = resp.Body.Close()
+
+	// Cancelling the context triggers the goroutine inside Server() to call
+	// Shutdown, which makes ListenAndServe return.
+	ctx.GetInner().Cancel(nil)
+
+	select {
+	case err := <-errCh:
+		// http.ErrServerClosed is the expected return after a graceful Shutdown.
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("Server returned %v, want ErrServerClosed or nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Server did not return after context cancellation")
+	}
+}
+
+func TestServer_TLSConfigErrors(t *testing.T) {
+	// With cert/key set but pointing at nonexistent files, ListenAndServeTLS
+	// returns an error immediately — this covers the TLS branch of Server().
+	repo, ctx := ptesting.GenerateRepository(t, nil, nil, nil)
+
+	addr := freePort(t)
+	err := Server(ctx, repo, addr, false, "/nonexistent/cert.pem", "/nonexistent/key.pem")
+	if err == nil {
+		t.Fatal("expected error from ListenAndServeTLS with missing cert/key")
 	}
 }

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -318,6 +318,115 @@ func TestValidateServiceConfigurationKnownService(t *testing.T) {
 	}
 }
 
+// badRequestConnector returns a connector whose endpoint contains a control
+// character, so http.NewRequest fails before any network call is made.
+func badRequestConnector(t *testing.T) *ServiceConnector {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	sc := NewServiceConnector(ctx, "tok")
+	sc.endpoint = "http://\x7f" // ASCII DEL makes the URL invalid for NewRequest
+	return sc
+}
+
+func TestNewRequestErrorPropagates(t *testing.T) {
+	if _, err := badRequestConnector(t).GetServiceList(); err == nil {
+		t.Fatal("GetServiceList: expected NewRequest error, got nil")
+	}
+	if _, err := badRequestConnector(t).GetServiceStatus("x"); err == nil {
+		t.Fatal("GetServiceStatus: expected NewRequest error, got nil")
+	}
+	if err := badRequestConnector(t).SetServiceStatus("x", true); err == nil {
+		t.Fatal("SetServiceStatus: expected NewRequest error, got nil")
+	}
+	if _, err := badRequestConnector(t).GetServiceConfiguration("x"); err == nil {
+		t.Fatal("GetServiceConfiguration: expected NewRequest error, got nil")
+	}
+}
+
+func TestSetServiceConfigurationNewRequestError(t *testing.T) {
+	// getServicesList must succeed (so validation passes) before the bad URL is
+	// hit on the configuration PUT. Point the services-list lookup at a working
+	// server but the configuration write at an invalid URL.
+	sc, _ := newTestConnector(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+	}), "tok")
+	// Prime the cached services list, then break the endpoint.
+	if _, err := sc.GetServiceList(); err != nil {
+		t.Fatalf("priming services list: %v", err)
+	}
+	sc.endpoint = "http://\x7f"
+	if err := sc.SetServiceConfiguration("alerting", map[string]string{"k": "v"}); err == nil {
+		t.Fatal("expected NewRequest error, got nil")
+	}
+}
+
+func TestSetServiceConfigurationNetworkError(t *testing.T) {
+	sc, _ := newTestConnector(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+	}), "tok")
+	if _, err := sc.GetServiceList(); err != nil {
+		t.Fatalf("priming services list: %v", err)
+	}
+	sc.endpoint = "http://127.0.0.1:0" // unreachable
+	if err := sc.SetServiceConfiguration("alerting", map[string]string{"k": "v"}); err == nil {
+		t.Fatal("expected network error, got nil")
+	}
+}
+
+// shortBodyHandler claims a large Content-Length but writes fewer bytes and
+// closes the connection, so io.ReadAll on the client fails with an unexpected
+// EOF.
+func shortBodyHandler(w http.ResponseWriter, r *http.Request) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		return
+	}
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort")
+	_ = bufrw.Flush()
+	// connection closes here with body shorter than Content-Length
+}
+
+func TestReadBodyErrorPropagates(t *testing.T) {
+	sc, _ := newTestConnector(t, http.HandlerFunc(shortBodyHandler), "tok")
+
+	if _, err := sc.GetServiceList(); err == nil {
+		t.Fatal("GetServiceList: expected read-body error, got nil")
+	}
+	if _, err := sc.GetServiceStatus("x"); err == nil {
+		t.Fatal("GetServiceStatus: expected read-body error, got nil")
+	}
+	if _, err := sc.GetServiceConfiguration("x"); err == nil {
+		t.Fatal("GetServiceConfiguration: expected read-body error, got nil")
+	}
+}
+
+func TestValidateServiceConfigurationListError(t *testing.T) {
+	// getServicesList fails (server returns non-200), so the error must surface.
+	sc, _ := newTestConnector(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}), "tok")
+	if err := sc.ValidateServiceConfiguration("alerting", nil); err == nil {
+		t.Fatal("expected getServicesList error to propagate, got nil")
+	}
+}
+
+func TestSetServiceConfigurationValidationError(t *testing.T) {
+	// SetServiceConfiguration first validates, which calls getServicesList; a
+	// failing list lookup must abort with the wrapped "invalid configuration"
+	// error before any write request is made.
+	sc, _ := newTestConnector(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}), "tok")
+	if err := sc.SetServiceConfiguration("alerting", map[string]string{"k": "v"}); err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
 func TestRequestNetworkErrorPropagates(t *testing.T) {
 	ctx := appcontext.NewAppContext()
 	sc := NewServiceConnector(ctx, "tok")

--- a/ui/json/json_test.go
+++ b/ui/json/json_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/PlakarKorp/kloset/events"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/google/uuid"
 )
 
 func TestSanitizeDataPreservesPrimitives(t *testing.T) {
@@ -73,13 +74,14 @@ func TestRunDrainsEventsAndExitsOnBusClose(t *testing.T) {
 	ctx := appcontext.NewAppContext()
 	u := New(ctx)
 
-	// Replace os.Stdout temporarily so the renderer's encoder writes go to a pipe
-	// we can read after the run completes. The renderer captured stdout in New(),
-	// so we have to reach into the type — keep this test scoped to ensuring the
-	// goroutine exits cleanly when the bus closes.
 	if err := u.Run(); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+
+	// Publish an event so the goroutine's loop body runs and dispatches through
+	// handleEvent before the bus is closed.
+	emitter := ctx.Events().NewRepositoryEmitter(uuid.Nil, "test")
+	emitter.PathOk("/x")
 
 	// Closing the events bus closes the channel returned by Listen(), which
 	// terminates the renderer goroutine.
@@ -92,6 +94,22 @@ func TestRunDrainsEventsAndExitsOnBusClose(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Wait did not return after bus close")
 	}
+}
+
+// failWriter always fails, so the encoder's Encode returns an error.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+func TestHandleEvent_EncodeErrorIsSwallowed(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	r := &jsonRenderer{
+		ctx:     ctx,
+		encoder: encjson.NewEncoder(failWriter{}),
+	}
+
+	// handleEvent must return cleanly even when the underlying writer errors.
+	r.handleEvent(&events.Event{Level: "info", Type: "path.ok", Data: map[string]any{"path": "/x"}})
 }
 
 func TestJSONEventEncodes(t *testing.T) {

--- a/ui/stdio/stdio_test.go
+++ b/ui/stdio/stdio_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/PlakarKorp/kloset/logging"
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/google/uuid"
 )
 
 // newCtxWithBufferedLogger returns a context whose logger writes to the given
@@ -49,11 +50,18 @@ func TestStopAndSetRepositoryNoOps(t *testing.T) {
 }
 
 func TestRunDrainsEventsAndExitsOnBusClose(t *testing.T) {
-	ctx := appcontext.NewAppContext()
+	var out, errBuf bytes.Buffer
+	ctx := newCtxWithBufferedLogger(t, &out, &errBuf)
 	u := New(ctx)
 	if err := u.Run(); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+
+	// Publish at least one event so the goroutine loop body runs and dispatches
+	// through HandleEvent before the bus is closed.
+	emitter := ctx.Events().NewRepositoryEmitter(uuid.Nil, "test")
+	emitter.PathOk("/x")
+
 	ctx.Events().Close()
 
 	done := make(chan error, 1)


### PR DESCRIPTION
## Summary

Closes the remaining **reachable** coverage gaps in five already-well-covered packages by adding error-path and lifecycle test cases. Tests only — no production code changed.

| Package | Before | After |
|---|---|---|
| `ui/stdio` | 97.6% | **100%** |
| `ui/json` | 92.9% | **100%** |
| `cookies` | 77.1% | **97.9%** |
| `services` | 90.6% | **98.6%** |
| `server/httpd` | 84.5% | **100%** |

## What was added

- **ui/stdio** — exercise the `Run` goroutine's dispatch loop by emitting an event before closing the bus.
- **ui/json** — cover the `Run` loop body and the encoder write-error branch (via a failing writer).
- **cookies** — env-token paths, empty/unreadable token file, `ErrNotLoggedIn`, the `MkdirAll` panic in `NewManager`, and `Close`/`GetDir`.
- **services** — `http.NewRequest` / `Do` / `io.ReadAll` error paths across all four API calls, plus validation-error propagation.
- **server/httpd** — the full `Server()` lifecycle (start → request over a real listener → graceful shutdown on context cancel), the TLS-error branch, the `io.ReadAll` error path, and the range-length overflow check.

## Intentionally left uncovered

A handful of lines are unreachable in practice and are deliberately not tested:
- `cookies`: the `os.Chmod` error panic in `NewManager` (only a TOCTOU race could trigger it after `MkdirAll` succeeds).
- `services`: the two `json.Marshal` error branches — marshaling a `struct{Enabled bool}` / `map[string]string` cannot fail.

## Test plan

All five packages pass against the published kloset module (no `replace` directive, no `-mod=mod`), and `server/httpd` passes under `-race` (the `Server()` test runs the listener in a goroutine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)