### PR TITLE
test: raise Tier-2 subcommand coverage with error/edge-path cases

### DIFF
--- a/subcommands/archive/archive_test.go
+++ b/subcommands/archive/archive_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	_ "github.com/PlakarKorp/integrations/fs/exporter"
@@ -14,6 +15,70 @@ import (
 
 func init() {
 	os.Setenv("TZ", "UTC")
+}
+
+func TestArchiveParseNoSnapshot(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Archive{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one snapshot")
+}
+
+func TestArchiveParseUnsupportedFormat(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Archive{}
+	err := cmd.Parse(ctx, []string{"-format", "rar", "abc"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported format")
+}
+
+func TestArchiveParseDefaultOutputName(t *testing.T) {
+	// With no -output, Parse derives a plakar-<ts>.<ext> filename from the
+	// format.
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Archive{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-format", "zip", "abc"}))
+	require.Contains(t, cmd.Output, "plakar-")
+	require.Contains(t, cmd.Output, ".zip")
+}
+
+func TestArchiveExecuteBadSnapshot(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "a"),
+	})
+	defer snap.Close()
+
+	cmd := &Archive{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-output", filepath.Join(t.TempDir(), "x.tar.gz"), "deadbeefdeadbeef"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "could not open snapshot")
+}
+
+func TestArchiveExecuteOutputCreateError(t *testing.T) {
+	// An output path under a nonexistent directory makes os.Create fail.
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "a"),
+	})
+	defer snap.Close()
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Archive{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-output", "/nonexistent-dir-xyz/sub/archive.tar.gz",
+		hex.EncodeToString(indexId[:]),
+	}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "failed to create")
 }
 
 func TestExecuteCmdArchiveDefault(t *testing.T) {

--- a/subcommands/cat/cat_test.go
+++ b/subcommands/cat/cat_test.go
@@ -2,6 +2,7 @@ package cat
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -149,6 +150,39 @@ func TestExecuteCmdCatErrorUnknownFile(t *testing.T) {
 
 	outputErr := bufErr.String()
 	require.Contains(t, outputErr, "cat: /unknown: no such file")
+}
+
+func TestCatParseNoArgs(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Cat{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one parameter")
+}
+
+func TestExecuteCmdCatDecompressGzip(t *testing.T) {
+	// A gzip-compressed file with -decompress is transparently inflated.
+	var gzBuf bytes.Buffer
+	gz := gzip.NewWriter(&gzBuf)
+	_, err := gz.Write([]byte("hello compressed"))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("data.gz", 0644, gzBuf.String()),
+	})
+	snap.Close()
+
+	cmd := &Cat{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-decompress", ":data.gz"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "hello compressed")
 }
 
 func TestExecuteCmdCatHighlight(t *testing.T) {

--- a/subcommands/check/check_test.go
+++ b/subcommands/check/check_test.go
@@ -76,6 +76,59 @@ func TestExecuteCmdCheckDefault(t *testing.T) {
 	require.Contains(t, lastline, "check completed without errors")
 }
 
+func TestCheckParseSnapshotWithFiltersWarns(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-name", "x", "abc"}))
+	require.Contains(t, bufErr.String(), "filters will be ignored")
+}
+
+func TestCheckExecuteInvalidPrefix(t *testing.T) {
+	// A non-hex snapshot prefix is rejected before any locate.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"nothex!:/"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "invalid snapshot prefix")
+}
+
+func TestExecuteCmdCheckFast(t *testing.T) {
+	// -fast exercises the FastCheck option path.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-fast", hex.EncodeToString(indexId[:])}))
+	require.True(t, cmd.FastCheck)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
 func TestExecuteCmdCheckSpecificSnapshot(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/create/create_test.go
+++ b/subcommands/create/create_test.go
@@ -94,6 +94,54 @@ func TestExecuteCmdCreateDefaultWithoutEncryption(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCreateParseWeakPassphraseWithKeyfile(t *testing.T) {
+	// -weak-passphrase lowers the entropy requirement; combined with a keyfile
+	// it parses without prompting.
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+	ctx.KeyFromFile = "weak"
+
+	cmd := &Create{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-weak-passphrase"}))
+	require.Equal(t, []byte("weak"), cmd.RepositorySecret)
+}
+
+func TestCreateParseTooManyParameters(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+	cmd := &Create{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "extra-arg"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many parameters")
+}
+
+func TestCreateParseUnknownHashing(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+	cmd := &Create{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "-hashing", "NOTAHASH"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown hashing algorithm")
+}
+
+func TestExecuteCmdCreateUnknownHashingConfig(t *testing.T) {
+	// Execute looks up the hashing default configuration; an unknown algorithm
+	// that slips past Parse (set directly on the struct) makes it fail.
+	tmpRepoDirRoot, err := os.MkdirTemp("", "tmp_repo")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpRepoDirRoot) })
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+
+	repo, err := repository.Inexistent(ctx.GetInner(), map[string]string{"location": tmpRepoDirRoot + "/repo"})
+	require.NoError(t, err)
+
+	cmd := &Create{NoEncryption: true, Hashing: "NOTAHASH"}
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
 func TestExecuteCmdCreateDefaultWithKeyfile(t *testing.T) {
 	tmpRepoDirRoot, err := os.MkdirTemp("", "tmp_repo")
 	require.NoError(t, err)

--- a/subcommands/digest/digest_test.go
+++ b/subcommands/digest/digest_test.go
@@ -66,6 +66,61 @@ func TestExecuteCmdDigestDefault(t *testing.T) {
 	}
 }
 
+func TestExecuteCmdDigestBadSnapshotPath(t *testing.T) {
+	// An unresolvable snapshot path is logged as an error and skipped; Execute
+	// still returns 0.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Digest{}
+	require.NoError(t, cmd.Parse(ctx, []string{"deadbeefdeadbeef:/nope"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufErr.String(), "digest:")
+}
+
+func TestExecuteCmdDigestSingleFile(t *testing.T) {
+	// Targeting one regular file exercises the GetEntry + non-dir path that
+	// produces a single digest line.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexId := snap.Header.GetIndexID()
+	id := hex.EncodeToString(indexId[:])
+	cmd := &Digest{}
+	require.NoError(t, cmd.Parse(ctx, []string{id + ":/subdir/dummy.txt"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "dummy.txt")
+	require.Equal(t, 1, len(strings.Split(strings.Trim(bufOut.String(), "\n"), "\n")))
+}
+
+func TestExecuteCmdDigestCancelledContext(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexId := snap.Header.GetIndexID()
+	id := hex.EncodeToString(indexId[:])
+	cmd := &Digest{}
+	require.NoError(t, cmd.Parse(ctx, []string{id}))
+
+	ctx.GetInner().Cancel(nil)
+	// displayDigests bails on ctx.Err(); Execute swallows it and still returns 0,
+	// but produces no digest output.
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Empty(t, strings.TrimSpace(bufOut.String()))
+}
+
 func TestExecuteCmdDigestNoParam(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/help/help_test.go
+++ b/subcommands/help/help_test.go
@@ -117,6 +117,35 @@ func _TestParseCmdHelpDefault(t *testing.T) {
 	require.Contains(t, output, "# FILES")
 }
 
+func TestHelpExecuteUnknownCommand(t *testing.T) {
+	// An unknown command has no embedded doc, so ReadFile fails and Execute
+	// returns 1.
+	ctx := appcontext.NewAppContext()
+	cmd := &Help{}
+	require.NoError(t, cmd.Parse(ctx, []string{"no-such-command"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestHelpExecuteNoColor(t *testing.T) {
+	// NO_COLOR forces the ascii (disableColors) rendering branch.
+	t.Setenv("NO_COLOR", "1")
+
+	old := os.Stdout
+	_, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = old; w.Close() }()
+
+	ctx := appcontext.NewAppContext()
+	cmd := &Help{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
 func TestParseCmdHelpCommand(t *testing.T) {
 	// Create a pipe to capture stdout
 	old := os.Stdout

--- a/subcommands/info/info_test.go
+++ b/subcommands/info/info_test.go
@@ -86,6 +86,33 @@ func TestExecuteCmdInfoDefault(t *testing.T) {
 	require.Contains(t, output, "Snapshots: 1")
 }
 
+func TestInfoParseTooManyArguments(t *testing.T) {
+	_, snap, ctx := generateSnapshot(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+	defer snap.Close()
+
+	cmd := &Info{}
+	err := cmd.Parse(ctx, []string{"a", "b"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+func TestExecuteCmdInfoSnapshotErrors(t *testing.T) {
+	// "-errors <snapshot>" dispatches to executeErrors.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Info{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-errors", hex.EncodeToString(indexId[:])}))
+	require.True(t, cmd.Errors)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
 func TestExecuteCmdInfoSnapshot(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/locate/locate_test.go
+++ b/subcommands/locate/locate_test.go
@@ -59,6 +59,61 @@ func TestExecuteCmdLocateDefault(t *testing.T) {
 	require.Equal(t, 1, len(lines))
 }
 
+func TestLocateParseSnapshotWithFiltersWarns(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+	_ = repo
+
+	cmd := &Locate{}
+	// Both -snapshot and a filter (-name) set: Parse warns that filters are
+	// ignored.
+	require.NoError(t, cmd.Parse(ctx, []string{"-snapshot", "abc", "-name", "x", "dummy.txt"}))
+	require.Contains(t, bufErr.String(), "filters will be ignored")
+}
+
+func TestLocateGlobMatch(t *testing.T) {
+	// A glob pattern goes through path.Match rather than the exact-base branch.
+	bufOut := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bytes.NewBuffer(nil))
+	defer snap.Close()
+
+	cmd := &Locate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"*.txt"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// dummy.txt, foo.txt and bar.txt all match *.txt
+	require.Contains(t, bufOut.String(), "dummy.txt")
+	require.Contains(t, bufOut.String(), "bar.txt")
+}
+
+func TestLocateBadGlobPattern(t *testing.T) {
+	// A malformed glob pattern surfaces a path.Match error.
+	repo, snap, ctx := generateSnapshot(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+	defer snap.Close()
+
+	cmd := &Locate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"[invalid"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "match pattern")
+}
+
+func TestLocateCancelledContext(t *testing.T) {
+	repo, snap, ctx := generateSnapshot(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+	defer snap.Close()
+
+	cmd := &Locate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"dummy.txt"}))
+	ctx.GetInner().Cancel(nil)
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
 func TestExecuteCmdLocateWithSnapshotId(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/ls/ls_test.go
+++ b/subcommands/ls/ls_test.go
@@ -107,6 +107,70 @@ func TestExecuteCmdLsFilterByIDAndRecursive(t *testing.T) {
 	require.Equal(t, "/subdir/dummy.txt", fields[len(fields)-1])
 }
 
+func TestLsParseTooManyArguments(t *testing.T) {
+	_, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	cmd := &Ls{}
+	err := cmd.Parse(ctx, []string{"a", "b"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+func TestLsListSnapshotBadPath(t *testing.T) {
+	// Listing a snapshot:path that resolves to no snapshot surfaces an error
+	// (and a status of 1) from Execute.
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	cmd := &Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{"deadbeefdeadbeef:/subdir"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestLsListSnapshotNonRecursive(t *testing.T) {
+	// Non-recursive listing of a snapshot path exercises the entryname=Name()
+	// branch and the SkipDir return for nested directories.
+	bufOut := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockDir("subdir/nested"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("subdir/nested/deep.txt", 0644, "deep"),
+	})
+	defer snap.Close()
+
+	cmd := &Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{hex.EncodeToString(snap.Header.GetIndexShortID()) + ":/subdir"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	// dummy.txt is listed by base name; the nested directory's contents are not
+	// descended into (SkipDir), so deep.txt must be absent.
+	require.Contains(t, out, "dummy.txt")
+	require.NotContains(t, out, "deep.txt")
+}
+
+func TestLsListSnapshotCancelledContext(t *testing.T) {
+	// A cancelled context makes the WalkDir callback bail out with the context
+	// error.
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	cmd := &Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{hex.EncodeToString(snap.Header.GetIndexShortID()) + ":/"}))
+
+	ctx.GetInner().Cancel(nil)
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
 func TestExecuteCmdLsFilterUuid(t *testing.T) {
 	// Create a pipe to capture stdout
 	old := os.Stdout

--- a/subcommands/prune/prune_test.go
+++ b/subcommands/prune/prune_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -105,6 +106,93 @@ func TestPrune_Apply_PerMinuteCap(t *testing.T) {
 	// Sanity: ensure it didn't claim to remove the newest one (kept)
 	short2 := hex.EncodeToString(snap2.Header.GetIndexShortID())
 	require.NotContains(t, out, fmt.Sprintf("info: prune: removal of %s completed successfully", short2))
+}
+
+func TestPrune_NoFilterRejected(t *testing.T) {
+	// With no positional args and no filters, Parse must refuse rather than
+	// prune everything.
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, nil, nil)
+	defer snap1.Close()
+	defer snap2.Close()
+	_ = repo
+
+	cmd := &Prune{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not going to prune everything")
+}
+
+func TestPrune_PolicyNotFound(t *testing.T) {
+	// A -policy referencing an unknown policy (no policies.yml present) reports
+	// "policy not found".
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, nil, nil)
+	defer snap1.Close()
+	defer snap2.Close()
+	_ = repo
+
+	ctx.ConfigDir = t.TempDir()
+
+	cmd := &Prune{}
+	err := cmd.Parse(ctx, []string{"-policy", "nope"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestPrune_PolicyLoadError(t *testing.T) {
+	// A malformed policies.yml surfaces as a load error.
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, nil, nil)
+	defer snap1.Close()
+	defer snap2.Close()
+	_ = repo
+
+	dir := t.TempDir()
+	ctx.ConfigDir = dir
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policies.yml"),
+		[]byte("this: : : not valid yaml\n  - broken"), 0644))
+
+	cmd := &Prune{}
+	err := cmd.Parse(ctx, []string{"-policy", "any"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to load policies config")
+}
+
+func TestPrune_PolicyApplied(t *testing.T) {
+	// A valid policy is loaded and applied: -per-minute cap from the policy
+	// drives the dry-run plan.
+	bufOut := bytes.NewBuffer(nil)
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, bufOut, bytes.NewBuffer(nil))
+	defer snap1.Close()
+	defer snap2.Close()
+
+	dir := t.TempDir()
+	ctx.ConfigDir = dir
+	policyYAML := "version: v1.0.0\npolicies:\n  keepone:\n    periods:\n      minute:\n        cap: 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policies.yml"), []byte(policyYAML), 0644))
+
+	cmd := &Prune{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-policy", "keepone"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "prune: would keep 1 and delete 1 snapshot(s)")
+}
+
+func TestPrune_ApplyNothingToDelete(t *testing.T) {
+	// -apply with a filter that keeps everything deletes nothing and returns 0.
+	bufOut := bytes.NewBuffer(nil)
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, bufOut, bytes.NewBuffer(nil))
+	defer snap1.Close()
+	defer snap2.Close()
+
+	// A high per-minute cap keeps both snapshots, so toDelete is empty.
+	cmd := &Prune{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-apply", "--per-minute=100"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotContains(t, bufOut.String(), "prune: removal of")
 }
 
 // TestMergePolicyOptions_PreservesPolicyFiltersWhenCLIEmpty is the regression

--- a/subcommands/restore/restore_extra_test.go
+++ b/subcommands/restore/restore_extra_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,6 +160,116 @@ func TestRestoreInvalidSnapshotID(t *testing.T) {
 
 	cmd := &Restore{}
 	require.NoError(t, cmd.Parse(ctx, []string{"-to", mkRestoreDir(t), "deadbeefdeadbeef"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestRestoreMultipleSnapshotsFound(t *testing.T) {
+	// Two snapshots match the (default, latest-less) locate filter, so Execute
+	// must refuse with "multiple snapshots found".
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+	snap2 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap2.Close()
+
+	id1 := snap.Header.GetIndexID()
+	id2 := snap2.Header.GetIndexID()
+
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-to", mkRestoreDir(t),
+		hex.EncodeToString(id1[:]) + ":",
+		hex.EncodeToString(id2[:]) + ":",
+	}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "multiple snapshots found")
+}
+
+func TestRestoreToAliasWithLocation(t *testing.T) {
+	// A destination alias that resolves to a usable fs:// location restores
+	// successfully — exercises the alias success branch in Execute.
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	dir := mkRestoreDir(t)
+	ctx.ConfigDir = t.TempDir()
+	require.NoError(t, ctx.ReloadConfig())
+	ctx.Config.Destinations["mydest"] = map[string]string{"location": "fs://" + dir}
+
+	id := snap.Header.GetIndexID()
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-to", "@mydest", hex.EncodeToString(id[:]) + ":"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	checkRestored(t, dir)
+}
+
+func TestRestoreSkipPermissionsExecutes(t *testing.T) {
+	// Drive a real restore with -skip-permissions so the SkipPermissions branch
+	// in Execute is taken.
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	dir := mkRestoreDir(t)
+	id := snap.Header.GetIndexID()
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-skip-permissions", "-to", dir, hex.EncodeToString(id[:]) + ":"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	checkRestored(t, dir)
+}
+
+func TestRestoreSubtreeWithTrailingSlashStrip(t *testing.T) {
+	// "<id>:/subdir/" (with a trailing slash) takes the Strip == pathname branch
+	// rather than path.Dir(pathname).
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	dir := mkRestoreDir(t)
+	id := snap.Header.GetIndexID()
+	target := fmt.Sprintf("%s:/subdir/", hex.EncodeToString(id[:]))
+
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-to", dir, target}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// The subdir contents land directly under the restore dir when the whole
+	// subdir path is stripped.
+	sawDummy := false
+	require.NoError(t, filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(data), "hello dummy") {
+			sawDummy = true
+		}
+		return nil
+	}))
+	require.True(t, sawDummy, "expected dummy.txt content under %s", dir)
+}
+
+func TestRestoreInvalidExporterLocation(t *testing.T) {
+	// An unknown exporter scheme makes NewExporter fail inside Execute.
+	repo, snap, ctx := generateSnapshot(t)
+	defer snap.Close()
+
+	id := snap.Header.GetIndexID()
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-to", "bogusscheme://nowhere", hex.EncodeToString(id[:]) + ":"}))
 	status, err := cmd.Execute(ctx, repo)
 	require.Error(t, err)
 	require.Equal(t, 1, status)

--- a/subcommands/rm/rm_test.go
+++ b/subcommands/rm/rm_test.go
@@ -80,6 +80,60 @@ func TestExecuteCmdRmWithSnapshot(t *testing.T) {
 	require.NotContains(t, output, "rm: would remove these")
 }
 
+func TestRmParseNoFilterRejected(t *testing.T) {
+	_, snap, ctx := generateSnapshot(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+	defer snap.Close()
+
+	cmd := &Rm{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not going to remove everything")
+}
+
+func TestRmExecuteNoMatches(t *testing.T) {
+	// A filter that matches nothing logs an informational line and returns 0.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Rm{}
+	require.NoError(t, cmd.Parse(ctx, []string{"deadbeefdeadbeef"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String()+bufErr.String(), "no snapshots matched")
+}
+
+func TestRm_DryRun_MultipleSnapshotsSorted(t *testing.T) {
+	// With two matching snapshots the dry-run plan exercises the sort comparator
+	// across distinct timestamps.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap1 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "a"),
+	})
+	defer snap1.Close()
+	snap2 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("b.txt", 0644, "b"),
+	})
+	defer snap2.Close()
+
+	id1 := snap1.Header.GetIndexID()
+	id2 := snap2.Header.GetIndexID()
+	cmd := &Rm{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		hex.EncodeToString(id1[:]),
+		hex.EncodeToString(id2[:]),
+	}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "rm: would remove these 2 snapshot(s)")
+}
+
 func TestRm_DryRun_ShowsPlan(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/server/server_test.go
+++ b/subcommands/server/server_test.go
@@ -22,6 +22,48 @@ func init() {
 	os.Setenv("TZ", "UTC")
 }
 
+func TestServerParseAllowDelete(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	defer ctx.Close()
+	_ = repo
+
+	cmd := &Server{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-allow-delete"}))
+	require.False(t, cmd.NoDelete, "-allow-delete should clear NoDelete")
+}
+
+func TestServerParseDefaultsToNoDelete(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	defer ctx.Close()
+	_ = repo
+
+	cmd := &Server{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.True(t, cmd.NoDelete, "delete must be disabled by default")
+}
+
+func TestServerExecuteTLSErrorReturns1(t *testing.T) {
+	// cert+key set (https protocol branch) but pointing at missing files, so
+	// httpd.Server returns immediately with an error and Execute reports 1.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	defer ctx.Close()
+
+	cmd := &Server{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-listen", "127.0.0.1:0",
+		"-cert", "/nonexistent/cert.pem",
+		"-key", "/nonexistent/key.pem",
+	}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	// The https protocol branch was taken when logging the listen line.
+	require.Contains(t, bufOut.String()+bufErr.String(), "https://")
+}
+
 func TestExecuteCmdServerDefault(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/version/version_test.go
+++ b/subcommands/version/version_test.go
@@ -24,6 +24,14 @@ func TestParseCmdVersion(t *testing.T) {
 	require.NotNil(t, subcommand)
 }
 
+func TestParseCmdVersionTooManyArgs(t *testing.T) {
+	ctx := &appcontext.AppContext{}
+	subcommand := &Version{}
+	err := subcommand.Parse(ctx, []string{"extra"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Too many arguments")
+}
+
 func TestExecuteCmdVersion(t *testing.T) {
 	// Create a pipe to capture stdout
 	old := os.Stdout


### PR DESCRIPTION
## Summary

Follow-up to [#2208](https://github.com/PlakarKorp/plakar/pull/2208) (Tier 1). Adds error-path, guard, and edge-case tests across **14 subcommand packages**, exercising branches the existing happy-path tests missed. Tests only — no production code changed.

| Package | Before | After |
|---|---|---|
| `archive` | 69.7% | **84.8%** |
| `restore` | 83.5% | **88.7%** |
| `prune` | 79.9% | **86.3%** |
| `ls` | 76.2% | **83.3%** |
| `server` | 75.0% | **82.1%** |
| `locate` | 73.1% | **80.8%** |
| `digest` | 72.9% | **79.7%** |
| `rm` | 67.1% | **78.6%** |
| `info` | 69.8% | **75.8%** |
| `version` | 66.7% | **75.0%** |
| `create` | 67.7% | **73.8%** |
| `help` | 65.8% | **73.7%** |
| `cat` | 60.4% | **64.4%** |
| `check` | 69.1% | 69.1% (+invalid-prefix & filter-warning branches) |

## What was added

Representative new cases: bad/unresolvable snapshot paths, cancelled-context bail-outs, flag-validation guards (too-many-args, no-filter, unsupported format/hashing), destination-alias resolution, glob matching + malformed globs, gzip `-decompress`, multi-snapshot dry-run plans (sort comparator), `os.Create` failures, and TLS/listen errors.

## Intentionally left

- **`maintenance`** stays at its existing 75.4% — its uncovered lines are `if err != nil` guards inside concurrent errgroup workers and cache operations, which need storage/cache fault injection the current harness doesn't provide.
- Across the touched packages, the remaining uncovered lines are mostly unreachable in-process: `init()` / `flags.Usage` hooks under `flag.ExitOnError`, dead `else if` branches, signature-verification paths needing signed snapshots, and deep error wrappers requiring storage failures.

## Test plan

All 14 packages pass with a clean working tree (no stray restore output), and `go vet` is clean against the published kloset module — no `replace` directive and no `-mod=mod` needed for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)