### PR TITLE
diag: add chunks subcommand to inspect per-file chunk layout

### DIFF
--- a/subcommands/diag/chunks.go
+++ b/subcommands/diag/chunks.go
@@ -1,0 +1,62 @@
+package diag
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/PlakarKorp/kloset/locate"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+)
+
+type DiagChunks struct {
+	subcommands.SubcommandBase
+
+	SnapshotPath string
+}
+
+func (cmd *DiagChunks) Parse(ctx *appcontext.AppContext, args []string) error {
+	flags := flag.NewFlagSet("diag chunks", flag.ExitOnError)
+	flags.Parse(args)
+
+	if len(flags.Args()) != 1 {
+		return fmt.Errorf("usage: %s chunks SNAPSHOT:PATH", flags.Name())
+	}
+
+	cmd.RepositorySecret = ctx.GetSecret()
+	cmd.SnapshotPath = flags.Args()[0]
+
+	return nil
+}
+
+func (cmd *DiagChunks) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+	snap, pathname, err := locate.OpenSnapshotByPath(repo, cmd.SnapshotPath)
+	if err != nil {
+		return 1, err
+	}
+	defer snap.Close()
+
+	fs, err := snap.Filesystem()
+	if err != nil {
+		return 1, err
+	}
+
+	entry, err := fs.GetEntry(pathname)
+	if err != nil {
+		return 1, err
+	}
+
+	if entry.ResolvedObject == nil {
+		return 1, fmt.Errorf("no object for path: %s", pathname)
+	}
+
+	var offset int64
+	for i, chunk := range entry.ResolvedObject.Chunks {
+		fmt.Fprintf(ctx.Stdout, "Chunk[%d]: offset=%d length=%d mac=%x entropy=%f\n",
+			i, offset, chunk.Length, chunk.ContentMAC, chunk.Entropy)
+		offset += int64(chunk.Length)
+	}
+
+	return 0, nil
+}

--- a/subcommands/diag/diag.go
+++ b/subcommands/diag/diag.go
@@ -33,5 +33,6 @@ func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &DiagSearch{} }, 0, "diag", "search")
 	subcommands.Register(func() subcommands.Subcommand { return &DiagDirPack{} }, 0, "diag", "dirpack")
 	subcommands.Register(func() subcommands.Subcommand { return &DiagBlob{} }, 0, "diag", "blob")
+	subcommands.Register(func() subcommands.Subcommand { return &DiagChunks{} }, 0, "diag", "chunks")
 	subcommands.Register(func() subcommands.Subcommand { return &DiagRepository{} }, 0, "diag")
 }

--- a/subcommands/diag/plakar-diag.1
+++ b/subcommands/diag/plakar-diag.1
@@ -6,7 +6,7 @@
 .Nd Display detailed information about Plakar internal structures
 .Sh SYNOPSIS
 .Nm plakar diag
-.Op Cm contenttype | locks | object | packfile | snapshot | state | vfs | xattr
+.Op Cm chunks | contenttype | locks | object | packfile | snapshot | state | vfs | xattr
 .Sh DESCRIPTION
 The
 .Nm plakar diag
@@ -16,6 +16,9 @@ Without any arguments, display information about the repository.
 .Pp
 The sub-commands are as follows:
 .Bl -tag -width Ds
+.It Cm chunks Ar snapshotID : Ns Ar path
+Display the list of chunks for a file within a snapshot, including
+the index, byte offset, length, MAC, and entropy of each chunk.
 .It Cm contenttype Ar snapshotID : Ns Ar path
 .It Cm locks
 Display the list of locks currently held on the repository.


### PR DESCRIPTION
Add `plakar diag chunks SNAPSHOT:PATH` to display the chunk breakdown of a file stored in a snapshot.

The chunks list is available from the UI, but there was no way to get them from the CLI.

Placed under `diag` since it is low-level inspection that most users won't need.