### PR TITLE
test: cover subcommand init() factory closures via registry lookup

### DIFF
--- a/subcommands/archive/factory_test.go
+++ b/subcommands/archive/factory_test.go
@@ -1,0 +1,16 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"archive"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Archive{}, cmd)
+}

--- a/subcommands/cat/factory_test.go
+++ b/subcommands/cat/factory_test.go
@@ -1,0 +1,16 @@
+package cat
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"cat"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Cat{}, cmd)
+}

--- a/subcommands/check/factory_test.go
+++ b/subcommands/check/factory_test.go
@@ -1,0 +1,16 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"check"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Check{}, cmd)
+}

--- a/subcommands/create/factory_test.go
+++ b/subcommands/create/factory_test.go
@@ -1,0 +1,16 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"create"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Create{}, cmd)
+}

--- a/subcommands/diff/factory_test.go
+++ b/subcommands/diff/factory_test.go
@@ -1,0 +1,16 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"diff"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Diff{}, cmd)
+}

--- a/subcommands/digest/factory_test.go
+++ b/subcommands/digest/factory_test.go
@@ -1,0 +1,16 @@
+package digest
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"digest"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Digest{}, cmd)
+}

--- a/subcommands/help/factory_test.go
+++ b/subcommands/help/factory_test.go
@@ -1,0 +1,16 @@
+package help
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"help"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Help{}, cmd)
+}

--- a/subcommands/locate/factory_test.go
+++ b/subcommands/locate/factory_test.go
@@ -1,0 +1,16 @@
+package locate
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"locate"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Locate{}, cmd)
+}

--- a/subcommands/ls/factory_test.go
+++ b/subcommands/ls/factory_test.go
@@ -1,0 +1,16 @@
+package ls
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"ls"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Ls{}, cmd)
+}

--- a/subcommands/maintenance/factory_test.go
+++ b/subcommands/maintenance/factory_test.go
@@ -1,0 +1,16 @@
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"maintenance"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Maintenance{}, cmd)
+}

--- a/subcommands/prune/factory_test.go
+++ b/subcommands/prune/factory_test.go
@@ -1,0 +1,16 @@
+package prune
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"prune"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Prune{}, cmd)
+}

--- a/subcommands/ptar/factory_test.go
+++ b/subcommands/ptar/factory_test.go
@@ -1,0 +1,16 @@
+package ptar
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"ptar"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Ptar{}, cmd)
+}

--- a/subcommands/restore/factory_test.go
+++ b/subcommands/restore/factory_test.go
@@ -1,0 +1,16 @@
+package restore
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"restore"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Restore{}, cmd)
+}

--- a/subcommands/rm/factory_test.go
+++ b/subcommands/rm/factory_test.go
@@ -1,0 +1,16 @@
+package rm
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"rm"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Rm{}, cmd)
+}

--- a/subcommands/server/factory_test.go
+++ b/subcommands/server/factory_test.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"server"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Server{}, cmd)
+}

--- a/subcommands/sync/factory_test.go
+++ b/subcommands/sync/factory_test.go
@@ -1,0 +1,16 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFactory looks the command up through the registry, which
+// invokes the factory closure registered in init().
+func TestRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"sync"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Sync{}, cmd)
+}

--- a/subcommands/version/version_test.go
+++ b/subcommands/version/version_test.go
@@ -10,9 +10,18 @@ import (
 
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/utils"
 	"github.com/stretchr/testify/require"
 )
+
+func TestVersionRegisteredFactory(t *testing.T) {
+	// Looking the command up through the registry invokes the factory closure
+	// registered in init().
+	cmd, _, _ := subcommands.Lookup([]string{"version"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Version{}, cmd)
+}
 
 func TestParseCmdVersion(t *testing.T) {
 	ctx := &appcontext.AppContext{}


### PR DESCRIPTION
## Summary

Answers a "why is version.go only 75%?" investigation. Every subcommand's `init()` registers a factory closure:

```go
subcommands.Register(func() subcommands.Subcommand { return &Version{} }, ...)
```

`init()` runs on import (so `Register` is called), but the **factory closure itself** is never invoked — the tests build the command struct directly (`&Version{}`) instead of going through the registry. That left `init()` at 50% in every subcommand package.

This adds a tiny `TestRegisteredFactory` to 16 packages (plus `version`) that looks the command up via `subcommands.Lookup`, which calls the registered factory — lifting each `init()` to **100%**. (`diag` and `info` already had such a test.)

Packages touched: archive, cat, check, create, diff, digest, help, locate, ls, maintenance, prune, ptar, restore, rm, server, sync, version.

## What's still uncovered in these Parse paths

Only the `flags.Usage` closure, which is gated behind `flag.ExitOnError` — triggering it calls `os.Exit`, so it can't be exercised in-process without changing the production code to `flag.ContinueOnError`. That's a behavior change, out of scope for a coverage pass.

## Test plan

All 16 packages pass `go test -run TestRegisteredFactory`, and `go vet` is clean against the published kloset module (no `replace`, no `-mod=mod`). Tests only — no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)