### PR TITLE
test: cover task.RunCommand dispatch and report paths

### DIFF
--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,126 @@
+package task
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	_ "github.com/PlakarKorp/integrations/fs/importer"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/PlakarKorp/plakar/ui/stdio"
+	"github.com/stretchr/testify/require"
+
+	"github.com/PlakarKorp/plakar/subcommands/check"
+	"github.com/PlakarKorp/plakar/subcommands/ls"
+	"github.com/PlakarKorp/plakar/subcommands/maintenance"
+	"github.com/PlakarKorp/plakar/subcommands/restore"
+	"github.com/PlakarKorp/plakar/subcommands/rm"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+// newRepoWithSnapshot returns a repository preloaded with a single snapshot and
+// a context whose stdio renderer is draining the event bus, so commands that
+// emit events (and the reporter) don't deadlock.
+func newRepoWithSnapshot(t *testing.T) (*appcontext.AppContext, *repository.Repository) {
+	t.Helper()
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	snap.Close()
+
+	startRenderer(t, ctx)
+	return ctx, repo
+}
+
+func startRenderer(t *testing.T, ctx *appcontext.AppContext) {
+	t.Helper()
+	renderer := stdio.New(ctx)
+	require.NoError(t, renderer.Run())
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+}
+
+func TestRunCommandCheck(t *testing.T) {
+	ctx, repo := newRepoWithSnapshot(t)
+
+	cmd := &check.Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := RunCommand(ctx, cmd, repo, "task-check")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestRunCommandRm(t *testing.T) {
+	ctx, repo := newRepoWithSnapshot(t)
+
+	cmd := &rm.Rm{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-latest", "-apply"}))
+
+	status, err := RunCommand(ctx, cmd, repo, "task-rm")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// NOTE: the *backup.Backup branch of RunCommand (DoBackup + WithSnapshotID) is
+// intentionally not tested here. backup wires a package-level stateRefresher
+// that connects to the `cached` daemon; the backup package's own tests override
+// that unexported hook with a stub, but it isn't reachable from this package, so
+// a real backup deadlocks waiting on the daemon. Covering that branch would
+// require the same override mechanism to be exported.
+
+func TestRunCommandRestore(t *testing.T) {
+	ctx, repo := newRepoWithSnapshot(t)
+
+	cmd := &restore.Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-to", t.TempDir()}))
+
+	status, err := RunCommand(ctx, cmd, repo, "task-restore")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestRunCommandMaintenance(t *testing.T) {
+	ctx, repo := newRepoWithSnapshot(t)
+
+	cmd := &maintenance.Maintenance{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := RunCommand(ctx, cmd, repo, "task-maintenance")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestRunCommandDefaultKindIsIgnored(t *testing.T) {
+	// ls is not one of the recognized task kinds, so the report is ignored.
+	ctx, repo := newRepoWithSnapshot(t)
+
+	cmd := &ls.Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := RunCommand(ctx, cmd, repo, "task-ls")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestRunCommandFailureReportsTaskFailed(t *testing.T) {
+	// A recognized task kind (check) that fails drives the TaskFailed branch
+	// (status != 0). Pointing check at a non-hex snapshot prefix makes Execute
+	// return status 1.
+	ctx, repo := newRepoWithSnapshot(t)
+
+	cmd := &check.Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"nothex!:/"}))
+
+	status, err := RunCommand(ctx, cmd, repo, "task-check-fail")
+	require.Error(t, err)
+	require.NotEqual(t, 0, status)
+}


### PR DESCRIPTION
## Summary

The `task` package (a single `RunCommand` dispatcher that runs a subcommand and emits a report) was at **0%**. This brings it to **80.6%**. Tests only — no production code changed.

New tests drive `RunCommand` for several command kinds:

- **check / rm / restore / maintenance** — recognized task kinds taking the `Execute` path; covers those switch arms plus the `WithRepository` wiring and the `TaskDone` success branch.
- **ls** — an unrecognized kind; covers the `default: report.SetIgnore()` branch.
- **a failing check** (non-hex snapshot prefix → status 1) — covers the `TaskFailed` branch.

## Intentionally left uncovered

The `*backup.Backup` branch (`DoBackup` + `WithSnapshotID`). `backup` wires a package-level `stateRefresher` that connects to the `cached` daemon, so a real backup run through `RunCommand` **deadlocks** waiting on it (confirmed: the first attempt hit the 600s test timeout). The backup package's own tests override that unexported hook with a nil stub, but it isn't reachable from `task`. A comment in the test file records this; covering it would need the override mechanism exported.

## Test plan

`go test ./task/` passes in ~1.6s; `go vet` is clean against the published kloset module (no `replace`, no `-mod=mod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)