### PR TITLE
test: cover dup, ui/v2 server, and main encryption helpers

### DIFF
--- a/main_extra_test.go
+++ b/main_extra_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/encryption"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPassphraseFromEnv_PassphraseCmd(t *testing.T) {
+	ctx := newTestCtx(t)
+	// passphrase_cmd runs a shell command whose stdout is the passphrase.
+	params := map[string]string{"passphrase_cmd": "echo hunter2"}
+	pass, err := getPassphraseFromEnv(ctx, params)
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", pass)
+	// the key is consumed from the params map
+	_, ok := params["passphrase_cmd"]
+	require.False(t, ok)
+}
+
+func TestSetupEncryption_KeyFromFileCorrect(t *testing.T) {
+	ctx := newTestCtx(t)
+	cfg := storage.NewConfiguration()
+	require.NotNil(t, cfg.Encryption)
+
+	passphrase := "correct horse battery staple"
+	key, err := encryption.DeriveKey(cfg.Encryption.KDFParams, []byte(passphrase))
+	require.NoError(t, err)
+	canary, err := encryption.DeriveCanary(cfg.Encryption, key)
+	require.NoError(t, err)
+	cfg.Encryption.Canary = canary
+
+	ctx.KeyFromFile = passphrase
+	require.NoError(t, setupEncryption(ctx, cfg))
+}
+
+func TestSetupEncryption_KeyFromFileWrong(t *testing.T) {
+	ctx := newTestCtx(t)
+	cfg := storage.NewConfiguration()
+
+	// Set a canary derived from the right passphrase...
+	key, err := encryption.DeriveKey(cfg.Encryption.KDFParams, []byte("right"))
+	require.NoError(t, err)
+	canary, err := encryption.DeriveCanary(cfg.Encryption, key)
+	require.NoError(t, err)
+	cfg.Encryption.Canary = canary
+
+	// ...but unlock with the wrong one: setupEncryption fails with ErrCantUnlock.
+	ctx.KeyFromFile = "wrong"
+	err = setupEncryption(ctx, cfg)
+	require.ErrorIs(t, err, ErrCantUnlock)
+}
+

--- a/subcommands/dup/dup_test.go
+++ b/subcommands/dup/dup_test.go
@@ -1,0 +1,75 @@
+package dup
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func TestDupRegisteredFactory(t *testing.T) {
+	cmd, _, _ := subcommands.Lookup([]string{"dup"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Dup{}, cmd)
+}
+
+func TestDupParseNoArgs(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Dup{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one parameter")
+}
+
+func TestDupParseArgs(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Dup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"a", "b"}))
+	require.Equal(t, []string{"a", "b"}, cmd.SnapshotIDS)
+}
+
+func TestDupExecute(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/a.txt", 0644, "hello"),
+	})
+	defer snap.Close()
+
+	id := snap.Header.GetIndexID()
+	cmd := &Dup{}
+	require.NoError(t, cmd.Parse(ctx, []string{hex.EncodeToString(id[:])}))
+	// Execute duplicates the snapshot in-memory (snap.Dup) and closes the copy;
+	// it completes successfully with no errors logged.
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestDupExecuteBadSnapshot(t *testing.T) {
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "x"),
+	})
+	defer snap.Close()
+
+	cmd := &Dup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"deadbeefdeadbeef"}))
+	// An unresolvable snapshot is logged and counted, but Execute still returns 0.
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufErr.String(), "digest:")
+}

--- a/ui/v2/ui_server_test.go
+++ b/ui/v2/ui_server_test.go
@@ -1,0 +1,88 @@
+package v2
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().(*net.TCPAddr)
+	_ = l.Close()
+	return fmt.Sprintf("127.0.0.1:%d", addr.Port)
+}
+
+func TestUiStartServeShutdown(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	addr := freePort(t)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Ui(repo, ctx, addr, &UiOptions{NoSpawn: true, NoRefresh: true})
+	}()
+
+	// Wait until the server is reachable, then make a request: an API route and
+	// a static path that falls back to index.html.
+	base := "http://" + addr
+	var reached bool
+	for waited := time.Duration(0); waited < 3*time.Second; waited += 25 * time.Millisecond {
+		if resp, err := http.Get(base + "/api/info"); err == nil {
+			_ = resp.Body.Close()
+			reached = true
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	require.True(t, reached, "server never became reachable")
+
+	// Unknown static asset falls back to index.html (served from the embedded FS).
+	resp, err := http.Get(base + "/some/spa/route")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	// Cancelling the context triggers graceful shutdown.
+	ctx.GetInner().Cancel(nil)
+
+	select {
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			t.Fatalf("Ui returned %v, want ErrServerClosed or nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ui did not return after context cancellation")
+	}
+}
+
+func TestUiCorsAndRandomPort(t *testing.T) {
+	// addr == "" exercises the random-port path; Cors=true wraps the handler.
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Ui(repo, ctx, "", &UiOptions{NoSpawn: true, NoRefresh: true, Cors: true, Token: "tok"})
+	}()
+
+	// Give the server a moment to bind, then shut it down. We don't know the
+	// random port, so just confirm the goroutine exits cleanly on cancel.
+	time.Sleep(200 * time.Millisecond)
+	ctx.GetInner().Cancel(nil)
+
+	select {
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			t.Fatalf("Ui returned %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ui did not return after cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

Easy coverage wins across three spots. Tests only — no production code changed.

| Target | Before | After |
|---|---|---|
| `subcommands/dup` | 0% | **77.8%** |
| `ui/v2` | 15.7% | **86.3%** |
| `main` helpers | — | `setupEncryption` 9.1%→45.5%, `getPassphraseFromEnv` 72.7%→90.9% |

- **dup**: registry factory lookup, `Parse` (no-args error / args), `Execute` on a real snapshot, and the bad-snapshot error path.
- **ui/v2**: the `Ui()` server lifecycle — start, request an API route + an SPA-fallback static path, then graceful shutdown on context cancel — plus the random-port + CORS variant. `NoSpawn` keeps it from launching a browser. (`corsMiddleware` was already covered.)
- **main**: `setupEncryption` with a correct vs wrong `KeyFromFile` (derives a real canary), and `getPassphraseFromEnv`'s `passphrase_cmd` branch.

## Intentionally left

The interactive passphrase prompt loop, the `entryPoint`/`main` CLI driver, and `setupPkgManager` (network) — none unit-testable in-process.

## Test plan

`go test ./subcommands/dup/ ./ui/v2/ .` passes; `go vet` clean against the published kloset (no `replace`, no `-mod=mod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)