### PR TITLE
prune: carry -group-by through the policy/CLI merge

### DIFF
--- a/subcommands/prune/prune.go
+++ b/subcommands/prune/prune.go
@@ -92,6 +92,10 @@ func (cmd *Prune) Parse(ctx *appcontext.AppContext, args []string) error {
 func mergePolicyOptions(to *locate.LocateOptions, from *locate.LocateOptions) {
 	mergeFilters(&to.Filters, &from.Filters)
 
+	if from.GroupBy != locate.GroupByNone {
+		to.GroupBy = from.GroupBy
+	}
+
 	merge := func(a, b *locate.LocatePeriod) {
 		if b.Keep != 0 {
 			a.Keep = b.Keep

--- a/subcommands/prune/prune_test.go
+++ b/subcommands/prune/prune_test.go
@@ -237,6 +237,39 @@ func TestMergePolicyOptions_CLIOverridesPolicy(t *testing.T) {
 	require.Equal(t, 9, policy.Periods.Minute.Keep)
 }
 
+// TestMergePolicyOptions_CarriesGroupBy is the regression test for the bug
+// where `prune -group-by perimeter` silently applied retention globally.
+//
+// prune parses its locate flags into a temporary override struct and merges
+// them onto the active options via mergePolicyOptions. Before the fix, that
+// merge copied Filters and every Period but never copied GroupBy, so GroupBy
+// stayed GroupByNone and `-per-day`/`-per-minute` caps were applied across all
+// snapshots instead of independently within each group.
+func TestMergePolicyOptions_CarriesGroupBy(t *testing.T) {
+	// CLI sets group-by; policy has none.
+	policy := locate.NewDefaultLocateOptions()
+	cli := locate.NewDefaultLocateOptions()
+	cli.GroupBy = locate.GroupByPerimeter
+
+	mergePolicyOptions(policy, cli)
+
+	require.Equal(t, locate.GroupByPerimeter, policy.GroupBy,
+		"CLI -group-by must be carried into the active options")
+}
+
+// TestMergePolicyOptions_GroupByEmptyCLIKeepsPolicy pins that a group-by set in
+// a policy survives an empty CLI override (mirrors the filters/periods rule).
+func TestMergePolicyOptions_GroupByEmptyCLIKeepsPolicy(t *testing.T) {
+	policy := locate.NewDefaultLocateOptions()
+	policy.GroupBy = locate.GroupByPerimeter
+	cli := locate.NewDefaultLocateOptions() // user passed no -group-by
+
+	mergePolicyOptions(policy, cli)
+
+	require.Equal(t, locate.GroupByPerimeter, policy.GroupBy,
+		"policy group-by must survive an empty CLI override")
+}
+
 // TestMergeFilters exhaustively covers each field of LocateFilters to make
 // sure mergeFilters keeps `a` when `b` is zero, and adopts `b` when it isn't.
 func TestMergeFilters(t *testing.T) {


### PR DESCRIPTION
## Problem

`plakar prune -group-by perimeter -per-day 1` (or any `-group-by` with a retention cap) applies the cap **globally** instead of independently within each group. Reported by Karreg on v1.1.3: "I only get one backup per day, no matter the perimeter."

Reproduced end-to-end with the real binary (3 backups in perimeter `alpha`, 2 in `beta`, all in one minute bucket):

```
# BEFORE — prune -group-by perimeter -per-minute 1
prune: would keep 1 and delete 4 snapshot(s)   # ❌ 1 globally

# AFTER
prune: would keep 2 and delete 3 snapshot(s)   # ✅ 1 per perimeter
keep   ... f1a43e31  match=minute:...-15:41 rank=1 cap=1   # alpha
keep   ... eb3e95ba  match=minute:...-15:41 rank=1 cap=1   # beta — rank resets
```

## Root cause

`prune` is the only command that parses its locate flags into a temporary override struct and then merges them onto the active `LocateOptions` via `mergePolicyOptions`. That merge copied `Filters` and every retention `Period` but **never copied `GroupBy`**, so `GroupBy` stayed `GroupByNone` and retention ran over the merged set.

The `locate` core itself groups correctly (its per-group unit tests pass) — only the prune-layer merge dropped the field. This also affects a `group-by` specified in a `-policy` file, since it routes through the same merge.

## Fix

Carry `GroupBy` through `mergePolicyOptions`, mirroring the existing rule for filters and periods (CLI wins when set, otherwise the policy value is kept).

## Tests

- `TestMergePolicyOptions_CarriesGroupBy` — CLI `-group-by` flows into the active options (fails without the fix).
- `TestMergePolicyOptions_GroupByEmptyCLIKeepsPolicy` — a policy-supplied group-by survives an empty CLI override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)