### PR TITLE
build: exclude testing/ from coverage locally and tidy codecov ignore

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,5 +10,4 @@ coverage:
 comment: false
 
 ignore:
-  - "testing/**/*"
-  - "testing/*"
+  - "testing"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /plakar
 **/vendor
 /dist
+/coverage.out

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,15 @@ check: test
 test:
 	${GO} test ./...
 
-.PHONY: all plakar install check test
+# coverage runs the test suite and reports total statement coverage with the
+# testing/ support packages (mocks, fixtures) excluded, matching the Codecov
+# `ignore` config. Go has no package-level coverage exclude, so we filter the
+# profile after the fact: the `mode:` header line is kept, and every block
+# belonging to a testing/ package is dropped before `go tool cover` totals it.
+COVERPROFILE = coverage.out
+coverage:
+	${GO} test -covermode=atomic -coverprofile=${COVERPROFILE} ./...
+	@grep -v '/plakar/testing/' ${COVERPROFILE} > ${COVERPROFILE}.tmp && mv ${COVERPROFILE}.tmp ${COVERPROFILE}
+	@${GO} tool cover -func=${COVERPROFILE} | tail -1
+
+.PHONY: all plakar install check test coverage


### PR DESCRIPTION
## Summary

The `testing/` packages are test-support code (mocks, fixtures, fake backends/servers), not production code, so they shouldn't count toward coverage. Codecov already ignored them via `.codecov.yml`; this aligns the **local** numbers too.

- **`.codecov.yml`**: collapse the two globs (`testing/**/*` + `testing/*`) into a single `testing` directory ignore.
- **`Makefile`**: add a `make coverage` target that runs the suite and prints the total statement coverage with `testing/` packages filtered out of the profile. Go has no package-level coverage exclude, so the profile is filtered after the run — the `mode:` header line is preserved and every block under a `…/plakar/testing/` path is dropped before `go tool cover` totals it.
- **`.gitignore`**: ignore the generated `/coverage.out`.

No production or test code changed.

## Test plan

Ran the equivalent of `make coverage` across the whole repo: 0 `testing/` blocks remain in the filtered profile, the `mode: atomic` header is intact, and `go tool cover` reports a clean total (**55.8%** with testing/ excluded). The filter pattern `/plakar/testing/` only matches the two support packages — no production import path contains `testing/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)