### PR TITLE
bump integrations/http ; document its store options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/PlakarKorp/go-human2duration v0.1.6
 	github.com/PlakarKorp/integration-grpc v1.1.0
 	github.com/PlakarKorp/integrations/fs v1.1.2
-	github.com/PlakarKorp/integrations/http v1.1.0
+	github.com/PlakarKorp/integrations/http v1.1.1
 	github.com/PlakarKorp/integrations/ptar v1.1.0
 	github.com/PlakarKorp/integrations/stdio v1.1.0
 	github.com/PlakarKorp/integrations/tar v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/PlakarKorp/integrations/fs v1.1.2 h1:d6bFqTruBB1LCR86CrzMhRr8iV3ycyPD
 github.com/PlakarKorp/integrations/fs v1.1.2/go.mod h1:ileYIi1I+0VTvDI31xD+WY1vYbFijj+l0zUnHwHWlvI=
 github.com/PlakarKorp/integrations/http v1.1.0 h1:Fet/N1t4UjfMNjZAC0vzPg/2sjwo1JGmSM8pb7fUexQ=
 github.com/PlakarKorp/integrations/http v1.1.0/go.mod h1:+ZsrIfIy15M8mHJoCCTcWOEO5TZpewKHwWU9SPyfziY=
+github.com/PlakarKorp/integrations/http v1.1.1-0.20260618200805-a540b313dd3d h1:ZImGy+13ypemixQRsdC600yu9NPEoK7eMPBNRk+R6yw=
+github.com/PlakarKorp/integrations/http v1.1.1-0.20260618200805-a540b313dd3d/go.mod h1:+ZsrIfIy15M8mHJoCCTcWOEO5TZpewKHwWU9SPyfziY=
+github.com/PlakarKorp/integrations/http v1.1.1 h1:4zMUYwAqUoKSjvwaEhPCP7z/lwcymkFsjfKHhGSeqt0=
+github.com/PlakarKorp/integrations/http v1.1.1/go.mod h1:+ZsrIfIy15M8mHJoCCTcWOEO5TZpewKHwWU9SPyfziY=
 github.com/PlakarKorp/integrations/ptar v1.1.0 h1:UgRd7R0NemyQWkvpYY7gqKkgh6gRPOzZ897BrW1nO5I=
 github.com/PlakarKorp/integrations/ptar v1.1.0/go.mod h1:HeheyF9oVvFvclksHu1egJ6aNtTdB8uOddSh9A6RbKU=
 github.com/PlakarKorp/integrations/stdio v1.1.0 h1:kvZma7XfqW4p21DH/mHUC4WTa3tiPuJIZj5LgSUcZ1k=

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,6 @@ github.com/PlakarKorp/integration-grpc v1.1.0 h1:ZUa/4m/pZWOmB7XzBfeAA/pOAxev3zb
 github.com/PlakarKorp/integration-grpc v1.1.0/go.mod h1:QZ55M9kXa3DntUvS9njOLoFY1S09bYbHKR/3kflDi5o=
 github.com/PlakarKorp/integrations/fs v1.1.2 h1:d6bFqTruBB1LCR86CrzMhRr8iV3ycyPDn6GhUGQpMAs=
 github.com/PlakarKorp/integrations/fs v1.1.2/go.mod h1:ileYIi1I+0VTvDI31xD+WY1vYbFijj+l0zUnHwHWlvI=
-github.com/PlakarKorp/integrations/http v1.1.0 h1:Fet/N1t4UjfMNjZAC0vzPg/2sjwo1JGmSM8pb7fUexQ=
-github.com/PlakarKorp/integrations/http v1.1.0/go.mod h1:+ZsrIfIy15M8mHJoCCTcWOEO5TZpewKHwWU9SPyfziY=
-github.com/PlakarKorp/integrations/http v1.1.1-0.20260618200805-a540b313dd3d h1:ZImGy+13ypemixQRsdC600yu9NPEoK7eMPBNRk+R6yw=
-github.com/PlakarKorp/integrations/http v1.1.1-0.20260618200805-a540b313dd3d/go.mod h1:+ZsrIfIy15M8mHJoCCTcWOEO5TZpewKHwWU9SPyfziY=
 github.com/PlakarKorp/integrations/http v1.1.1 h1:4zMUYwAqUoKSjvwaEhPCP7z/lwcymkFsjfKHhGSeqt0=
 github.com/PlakarKorp/integrations/http v1.1.1/go.mod h1:+ZsrIfIy15M8mHJoCCTcWOEO5TZpewKHwWU9SPyfziY=
 github.com/PlakarKorp/integrations/ptar v1.1.0 h1:UgRd7R0NemyQWkvpYY7gqKkgh6gRPOzZ897BrW1nO5I=

--- a/subcommands/config/plakar-store.1
+++ b/subcommands/config/plakar-store.1
@@ -94,6 +94,23 @@ Remove the
 for the store entry identified by
 .Ar name .
 .El
+.Ss HTTP AND HTTPS STORE OPTIONS
+When using an
+.Cm http://
+or
+.Cm https://
+location, the following additional options are available:
+.Bl -tag -width tls_no_verify
+.It Cm auth_token
+Bearer token sent in the
+.Dq Authorization
+header for every request.
+.It Cm tls_no_verify
+Set to
+.Cm true
+to disable TLS certificate verification.
+Useful when the server uses a self-signed certificate.
+.El
 .Sh EXIT STATUS
 .Ex -std
 .Sh SEE ALSO

--- a/subcommands/help/docs/plakar-diag.md
+++ b/subcommands/help/docs/plakar-diag.md
@@ -7,7 +7,7 @@ PLAKAR-DIAG(1) - General Commands Manual
 # SYNOPSIS
 
 **plakar&nbsp;diag**
-\[**contenttype**&nbsp;|&nbsp;**locks**&nbsp;|&nbsp;**object**&nbsp;|&nbsp;**packfile**&nbsp;|&nbsp;**snapshot**&nbsp;|&nbsp;**state**&nbsp;|&nbsp;**vfs**&nbsp;|&nbsp;**xattr**]
+\[**chunks**&nbsp;|&nbsp;**contenttype**&nbsp;|&nbsp;**locks**&nbsp;|&nbsp;**object**&nbsp;|&nbsp;**packfile**&nbsp;|&nbsp;**snapshot**&nbsp;|&nbsp;**state**&nbsp;|&nbsp;**vfs**&nbsp;|&nbsp;**xattr**]
 
 # DESCRIPTION
 
@@ -18,6 +18,11 @@ The type of information displayed depends on the specified argument.
 Without any arguments, display information about the repository.
 
 The sub-commands are as follows:
+
+**chunks** *snapshotID*:*path*
+
+> Display the list of chunks for a file within a snapshot, including
+> the index, byte offset, length, MAC, and entropy of each chunk.
 
 **contenttype** *snapshotID*:*path*
 

--- a/subcommands/help/docs/plakar-store.md
+++ b/subcommands/help/docs/plakar-store.md
@@ -110,6 +110,27 @@ The subcommands are as follows:
 > for the store entry identified by
 > *name*.
 
+## HTTP AND HTTPS STORE OPTIONS
+
+When using an
+**http://**
+or
+**https://**
+location, the following additional options are available:
+
+**auth\_token**
+
+> Bearer token sent in the
+> "Authorization"
+> header for every request.
+
+**tls\_no\_verify**
+
+> Set to
+> **true**
+> to disable TLS certificate verification.
+> Useful when the server uses a self-signed certificate.
+
 # EXIT STATUS
 
 The **plakar-store** utility exits&#160;0 on success, and&#160;&gt;0 if an error occurs.


### PR DESCRIPTION
Depends on https://github.com/PlakarKorp/integrations/pull/46/changes 

To test:

```bash
$ openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes -keyout server.key -out server.crt -subj "/CN=localhost"
$ ./plakar server -cert ./server.crt -key ./server.key
$ ./plakar at https://localhost:9876 ls
./plakar: failed to open the repository at https://localhost:9876: Get "https://localhost:9876/": tls: failed to verify certificate: x509: certificate signed by unknown authority
To specify an alternative repository, please use "plakar at <location> <command>".
$ ./plakar -no-tls-verify at https://localhost:9876 ls
[OK]
```