### PR TITLE
test: raise overall coverage to 60%

### DIFF
--- a/api/api_branches_test.go
+++ b/api/api_branches_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// VerifyMiddleware: a signature minted for one path must be rejected when the
+// request targets a different path (claims.Path mismatch).
+func TestVerifyMiddlewareWrongPath(t *testing.T) {
+	token := "vm-token"
+	mux, idHex := buildRealRepoRouter(t, token)
+
+	signReq, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+idHex+":/subdir/dummy.txt", nil)
+	signReq.Header.Set("Authorization", "Bearer "+token)
+	signW := httptest.NewRecorder()
+	mux.ServeHTTP(signW, signReq)
+	require.Equal(t, http.StatusOK, signW.Code)
+
+	var sresp Item[struct {
+		Signature string `json:"signature"`
+	}]
+	require.NoError(t, json.Unmarshal(signW.Body.Bytes(), &sresp))
+
+	// Use the signature against a different (valid) path -> 401.
+	readReq, _ := http.NewRequest("GET", "/api/snapshot/reader/"+idHex+":/subdir/code.go?render=text&signature="+sresp.Item.Signature, nil)
+	readW := httptest.NewRecorder()
+	mux.ServeHTTP(readW, readReq)
+	require.Equal(t, http.StatusUnauthorized, readW.Code)
+}
+
+// repositoryLocatePathname with importer filters that don't match -> 0 results.
+func TestLocatePathnameImporterFilters(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	cases := []string{
+		"resource=/subdir/dummy.txt&importerType=nope",
+		"resource=/subdir/dummy.txt&importerOrigin=nope",
+		"resource=/subdir/dummy.txt&importerDirectory=/nope",
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			w := doReq(t, mux, "GET", "/api/repository/locate-pathname?"+q, "", "")
+			require.Equal(t, http.StatusOK, w.Code)
+			var res Items[TimelineLocation]
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+			require.Equal(t, 0, res.Total)
+		})
+	}
+}
+
+// repositoryLocatePathname descending sort branch.
+func TestLocatePathnameDescSort(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=-Timestamp", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[TimelineLocation]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 1, res.Total)
+}
+
+// repositorySnapshots with explicit limit/offset paging.
+func TestRepositorySnapshotsPaging(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/repository/snapshots?limit=1&offset=0&sort=-Timestamp", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 1, res.Total)
+	require.Len(t, res.Items, 1)
+
+	// offset beyond range -> empty items, total unchanged.
+	w = doReq(t, mux, "GET", "/api/repository/snapshots?offset=99", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 1, res.Total)
+	require.Empty(t, res.Items)
+}
+
+// snapshotVFSChildren with an offset on a directory exercises the non-first
+// page branch (offset-- accounting for "..").
+func TestSnapshotVFSChildrenPaging(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/children/"+idHex+":/subdir?offset=1&limit=10", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+// snapshotVFSErrors descending sort key branch + paging.
+func TestSnapshotVFSErrorsDescSort(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/errors/"+idHex+":/?sort=-Name&offset=0&limit=5", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// snapshotVFSSearch with a name pattern + paging limit.
+func TestSnapshotVFSSearchPattern(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?recursive=true&pattern=dummy&limit=1", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res ItemsPage[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+// snapshotReader for a directory path returns nil (non-regular file -> early
+// return after Open), yielding an empty 200 body.
+func TestSnapshotReaderDirectory(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/chunks/"+idHex+":/missing-file", "", "")
+	// chunks handler returns nil (200) for a missing entry path.
+	require.Equal(t, http.StatusOK, w.Code)
+}

--- a/api/api_handlers_test.go
+++ b/api/api_handlers_test.go
@@ -1,0 +1,365 @@
+package api
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRealRepoRouter creates a real fs-backed repository populated with a
+// single snapshot and returns a router wired with norefresh=true (so the
+// handlers don't try to rebuild state from a store config we don't have) along
+// with the snapshot id (hex) for use in request paths.
+func buildRealRepoRouter(t *testing.T, token string) (*http.ServeMux, string) {
+	t.Helper()
+
+	var bufOut, bufErr bytes.Buffer
+	repo, ctx := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("subdir/code.go", 0644, "package main\n\nfunc main() {}\n"),
+		ptesting.NewMockFile("top.txt", 0644, "top level content"),
+	})
+	t.Cleanup(func() { snap.Close() })
+
+	id := snap.Header.GetIndexID()
+	idHex := hex.EncodeToString(id[:])
+
+	mux := http.NewServeMux()
+	// norefresh=true: avoids cached.RebuildStateFromStore which needs StoreConfig.
+	SetupRoutes(mux, repo, ctx, token, true)
+
+	return mux, idHex
+}
+
+func doReq(t *testing.T, mux *http.ServeMux, method, target, auth string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest(method, target, strings.NewReader(body))
+	require.NoError(t, err)
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func TestApiInfo(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/info", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var res struct {
+		RepositoryId  string `json:"repository_id"`
+		Authenticated bool   `json:"authenticated"`
+		Version       string `json:"version"`
+		Browsable     bool   `json:"browsable"`
+		DemoMode      bool   `json:"demo_mode"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.NotEmpty(t, res.RepositoryId)
+	require.NotEmpty(t, res.Version)
+	require.False(t, res.Authenticated)
+	require.False(t, res.DemoMode)
+}
+
+func TestRepositoryInfo(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/info", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var res Item[RepositoryInfoResponse]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.NotEmpty(t, res.Item.Location)
+	require.Equal(t, 1, res.Item.Snapshots.Total)
+	require.NotEmpty(t, res.Item.OS)
+	require.NotEmpty(t, res.Item.Arch)
+}
+
+func TestRepositorySnapshots(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/snapshots", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 1, res.Total)
+	require.Len(t, res.Items, 1)
+}
+
+func TestRepositorySnapshotsFilters(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/snapshots?importer=doesnotexist", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 0, res.Total)
+	require.Empty(t, res.Items)
+}
+
+func TestRepositorySnapshotsBadParams(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	cases := []struct {
+		name   string
+		query  string
+		status int
+	}{
+		{"bad offset", "offset=abc", http.StatusBadRequest},
+		{"bad limit", "limit=abc", http.StatusBadRequest},
+		{"bad sort", "sort=NotAKey", http.StatusBadRequest},
+		{"bad since", "since=not-a-date", http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := doReq(t, mux, "GET", "/api/repository/snapshots?"+c.query, "", "")
+			require.Equal(t, c.status, w.Code)
+		})
+	}
+}
+
+func TestRepositorySnapshotsSinceValid(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/snapshots?since=2999-01-01T00:00:00Z", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 0, res.Total)
+}
+
+func TestRepositoryImporterTypes(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/importer-types", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[struct {
+		Name string `json:"name"`
+	}]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.GreaterOrEqual(t, res.Total, 1)
+}
+
+func TestRepositoryLocatePathname(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/locate-pathname?resource=/subdir/dummy.txt", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[TimelineLocation]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 1, res.Total)
+	require.Len(t, res.Items, 1)
+}
+
+func TestRepositoryLocatePathnameNoMatch(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/repository/locate-pathname?resource=/nope/missing.txt", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[TimelineLocation]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 0, res.Total)
+}
+
+func TestRepositoryLocatePathnameBadParams(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/repository/locate-pathname?offset=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = doReq(t, mux, "GET", "/api/repository/locate-pathname?sort=NotAKey", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotHeaderOK(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/"+idHex, "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Item[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.NotEmpty(t, res.Item)
+}
+
+func TestSnapshotVFSBrowse(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/"+idHex+":/", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Item[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.NotEmpty(t, res.Item)
+}
+
+func TestSnapshotVFSBrowseFile(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/"+idHex+":/subdir/dummy.txt", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSnapshotVFSBrowseNotFound(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/"+idHex+":/does/not/exist", "", "")
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSnapshotVFSChildren(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/children/"+idHex+":/", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.GreaterOrEqual(t, len(res.Items), 1)
+}
+
+func TestSnapshotVFSChildrenSubdir(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/children/"+idHex+":/subdir", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSnapshotVFSChildrenNotDir(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/children/"+idHex+":/top.txt", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotVFSChildrenBadParams(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/children/"+idHex+":/?offset=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = doReq(t, mux, "GET", "/api/snapshot/vfs/children/"+idHex+":/?sort=NotAKey", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotVFSChunks(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/chunks/"+idHex+":/subdir/dummy.txt", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+func TestSnapshotVFSChunksBadParams(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/chunks/"+idHex+":/subdir/dummy.txt?limit=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotVFSSearch(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?recursive=true", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res ItemsPage[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+func TestSnapshotVFSSearchBadParams(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?offset=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?limit=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotVFSSearchTooManyMimes(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	var sb strings.Builder
+	for i := 0; i < 21; i++ {
+		if i > 0 {
+			sb.WriteString("&")
+		}
+		sb.WriteString(fmt.Sprintf("mime=type%d", i))
+	}
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?"+sb.String(), "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotVFSErrors(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/errors/"+idHex+":/", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+func TestSnapshotVFSErrorsNotDir(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/errors/"+idHex+":/top.txt", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotVFSErrorsBadSort(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/errors/"+idHex+":/?sort=Bogus", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSnapshotReaderText(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?render=text", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "hello dummy")
+}
+
+func TestSnapshotReaderTextStyled(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?render=text_styled", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "hello dummy")
+	require.Contains(t, w.Body.String(), "<pre>")
+}
+
+func TestSnapshotReaderCode(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/code.go?render=code", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "<!DOCTYPE html>")
+}
+
+func TestSnapshotReaderAuto(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSnapshotReaderDownload(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?download=true&render=text", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+}
+
+func TestSnapshotReaderBadRender(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?render=bogus", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/api/api_misc_test.go
+++ b/api/api_misc_test.go
@@ -1,0 +1,331 @@
+package api
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// --- api_errors.go ---
+
+func TestApiErrorError(t *testing.T) {
+	e := &ApiError{HttpCode: 400, ErrCode: "bad", Message: "boom"}
+	require.Equal(t, "bad: boom", e.Error())
+}
+
+func TestParameterError(t *testing.T) {
+	e := parameterError("field", InvalidArgument, errors.New("nope"))
+	require.Equal(t, http.StatusBadRequest, e.HttpCode)
+	require.Equal(t, "invalid_params", e.ErrCode)
+	require.Contains(t, e.Params, "field")
+	require.Equal(t, InvalidArgument, e.Params["field"].Code)
+	require.Equal(t, "nope", e.Params["field"].Message)
+}
+
+func TestAuthErrorHelper(t *testing.T) {
+	e := authError("denied")
+	require.Equal(t, http.StatusUnauthorized, e.HttpCode)
+	require.Equal(t, "bad_auth", e.ErrCode)
+	require.Equal(t, "denied", e.Message)
+}
+
+// --- api.go: handleError mapping ---
+
+func TestHandleError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"not readable", repository.ErrNotReadable, 400},
+		{"blob not found", repository.ErrBlobNotFound, 404},
+		{"packfile not found", repository.ErrPackfileNotFound, 404},
+		{"fs not exist", fs.ErrNotExist, 404},
+		{"snapshot not found", snapshot.ErrNotFound, 404},
+		{"plain error -> 500", errors.New("whatever"), 500},
+		{"api error passthrough", &ApiError{HttpCode: 418, ErrCode: "teapot", Message: "no"}, 418},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/x", nil)
+			w := httptest.NewRecorder()
+			handleError(w, req, c.err)
+			require.Equal(t, c.want, w.Code)
+			var body ApiErrorRes
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			require.NotNil(t, body.Error)
+		})
+	}
+}
+
+func TestJSONAPIViewServeHTTP(t *testing.T) {
+	// success path: no error -> Content-Type set, body written by handler.
+	view := JSONAPIView(func(w http.ResponseWriter, r *http.Request) error {
+		_, err := w.Write([]byte(`{"ok":true}`))
+		return err
+	})
+	req, _ := http.NewRequest("GET", "/api/x", nil)
+	w := httptest.NewRecorder()
+	view.ServeHTTP(w, req)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"ok":true}`, w.Body.String())
+
+	// error path
+	view2 := JSONAPIView(func(w http.ResponseWriter, r *http.Request) error {
+		return &ApiError{HttpCode: 404, ErrCode: "not-found", Message: "x"}
+	})
+	w2 := httptest.NewRecorder()
+	view2.ServeHTTP(w2, req)
+	require.Equal(t, 404, w2.Code)
+}
+
+func TestAPIViewServeHTTP(t *testing.T) {
+	// success path leaves headers to the handler.
+	called := false
+	view := APIView(func(w http.ResponseWriter, r *http.Request) error {
+		called = true
+		return nil
+	})
+	req, _ := http.NewRequest("GET", "/api/x", nil)
+	w := httptest.NewRecorder()
+	view.ServeHTTP(w, req)
+	require.True(t, called)
+
+	// error path sets Content-Type and serializes the error.
+	view2 := APIView(func(w http.ResponseWriter, r *http.Request) error {
+		return &ApiError{HttpCode: 400, ErrCode: "bad-request", Message: "x"}
+	})
+	w2 := httptest.NewRecorder()
+	view2.ServeHTTP(w2, req)
+	require.Equal(t, 400, w2.Code)
+	require.Equal(t, "application/json", w2.Header().Get("Content-Type"))
+}
+
+func TestTokenAuthMiddleware(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// empty token -> no-op, passes through
+	mwNoop := TokenAuthMiddleware("")(next)
+	req, _ := http.NewRequest("GET", "/api/x", nil)
+	w := httptest.NewRecorder()
+	mwNoop.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	mw := TokenAuthMiddleware("secret")(next)
+
+	// missing header -> 401
+	req2, _ := http.NewRequest("GET", "/api/x", nil)
+	w2 := httptest.NewRecorder()
+	mw.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusUnauthorized, w2.Code)
+
+	// wrong token -> 401
+	req3, _ := http.NewRequest("GET", "/api/x", nil)
+	req3.Header.Set("Authorization", "Bearer wrong")
+	w3 := httptest.NewRecorder()
+	mw.ServeHTTP(w3, req3)
+	require.Equal(t, http.StatusUnauthorized, w3.Code)
+
+	// correct token -> passes
+	req4, _ := http.NewRequest("GET", "/api/x", nil)
+	req4.Header.Set("Authorization", "Bearer secret")
+	w4 := httptest.NewRecorder()
+	mw.ServeHTTP(w4, req4)
+	require.Equal(t, http.StatusOK, w4.Code)
+}
+
+// --- api_params.go ---
+
+func TestQueryParamToString(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/?a=hello&b=", nil)
+	v, ok, err := QueryParamToString(req, "a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "hello", v)
+
+	v, ok, err = QueryParamToString(req, "b")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, "", v)
+
+	v, ok, err = QueryParamToString(req, "missing")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestSnapshotPathParam(t *testing.T) {
+	var bufOut, bufErr bytes.Buffer
+	repo, _ := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	t.Cleanup(func() { snap.Close() })
+	id := snap.Header.GetIndexID()
+	idHex := hex.EncodeToString(id[:])
+
+	// empty id -> MissingArgument
+	req, _ := http.NewRequest("GET", "/path", nil)
+	req.SetPathValue("snapshot_path", "")
+	_, _, err := SnapshotPathParam(req, repo, "snapshot_path")
+	require.Error(t, err)
+
+	// invalid id -> InvalidArgument (locate fails)
+	req2, _ := http.NewRequest("GET", "/path", nil)
+	req2.SetPathValue("snapshot_path", "zzzz:/foo")
+	_, _, err = SnapshotPathParam(req2, repo, "snapshot_path")
+	require.Error(t, err)
+
+	// valid id prefix -> resolves on the real repo, returns path
+	req3, _ := http.NewRequest("GET", "/path", nil)
+	req3.SetPathValue("snapshot_path", idHex+":/subdir")
+	mac, path, err := SnapshotPathParam(req3, repo, "snapshot_path")
+	require.NoError(t, err)
+	require.Equal(t, "/subdir", path)
+	require.Equal(t, id[:], mac[:])
+}
+
+// --- api_snapshot.go: URL signer + downloader ---
+
+func TestSnapshotReaderSignAndVerify(t *testing.T) {
+	token := "sign-token"
+	mux, idHex := buildRealRepoRouter(t, token)
+
+	// Sign a URL for a real path.
+	signReq, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+idHex+":/subdir/dummy.txt", nil)
+	signReq.Header.Set("Authorization", "Bearer "+token)
+	signW := httptest.NewRecorder()
+	mux.ServeHTTP(signW, signReq)
+	require.Equal(t, http.StatusOK, signW.Code)
+
+	var sresp Item[struct {
+		Signature string `json:"signature"`
+	}]
+	require.NoError(t, json.Unmarshal(signW.Body.Bytes(), &sresp))
+	require.NotEmpty(t, sresp.Item.Signature)
+
+	// Use the signature to read content without the Authorization header.
+	readReq, _ := http.NewRequest("GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?render=text&signature="+sresp.Item.Signature, nil)
+	readW := httptest.NewRecorder()
+	mux.ServeHTTP(readW, readReq)
+	require.Equal(t, http.StatusOK, readW.Code)
+	require.Contains(t, readW.Body.String(), "hello dummy")
+}
+
+func TestSnapshotReaderInvalidSignature(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "sign-token")
+	readReq, _ := http.NewRequest("GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?signature=garbage", nil)
+	readW := httptest.NewRecorder()
+	mux.ServeHTTP(readW, readReq)
+	require.Equal(t, http.StatusUnauthorized, readW.Code)
+}
+
+func TestSnapshotReaderNoSignatureRequiresAuth(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "sign-token")
+	// no signature, no auth header -> falls back to token middleware -> 401
+	readReq, _ := http.NewRequest("GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt", nil)
+	readW := httptest.NewRecorder()
+	mux.ServeHTTP(readW, readReq)
+	require.Equal(t, http.StatusUnauthorized, readW.Code)
+}
+
+func TestSnapshotVFSDownloaderFlow(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
+	dlReq, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+idHex+":/", strings.NewReader(body))
+	dlW := httptest.NewRecorder()
+	mux.ServeHTTP(dlW, dlReq)
+	require.Equal(t, http.StatusOK, dlW.Code)
+
+	var idResp struct {
+		Id string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(dlW.Body.Bytes(), &idResp))
+	require.NotEmpty(t, idResp.Id)
+
+	// Now fetch the signed download as a tar archive.
+	getReq, _ := http.NewRequest("GET", "/api/snapshot/vfs/downloader-sign-url/"+idResp.Id+"?format=tar", nil)
+	getW := httptest.NewRecorder()
+	mux.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+	require.Contains(t, getW.Header().Get("Content-Type"), "tar")
+	require.Contains(t, getW.Header().Get("Content-Disposition"), "attachment")
+}
+
+func TestSnapshotVFSDownloaderBadBody(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+	dlReq, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+idHex+":/", strings.NewReader("not json"))
+	dlW := httptest.NewRecorder()
+	mux.ServeHTTP(dlW, dlReq)
+	require.Equal(t, http.StatusBadRequest, dlW.Code)
+}
+
+func TestSnapshotVFSDownloaderSignedNotFound(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	getReq, _ := http.NewRequest("GET", "/api/snapshot/vfs/downloader-sign-url/nonexistent-id?format=tar", nil)
+	getW := httptest.NewRecorder()
+	mux.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusNotFound, getW.Code)
+}
+
+func TestSnapshotVFSDownloaderSignedBadFormat(t *testing.T) {
+	mux, idHex := buildRealRepoRouter(t, "")
+
+	body := `{"items":[{"pathname":"/subdir/dummy.txt"}]}`
+	dlReq, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+idHex+":/", strings.NewReader(body))
+	dlW := httptest.NewRecorder()
+	mux.ServeHTTP(dlW, dlReq)
+	require.Equal(t, http.StatusOK, dlW.Code)
+	var idResp struct {
+		Id string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(dlW.Body.Bytes(), &idResp))
+
+	getReq, _ := http.NewRequest("GET", "/api/snapshot/vfs/downloader-sign-url/"+idResp.Id+"?format=bogus", nil)
+	getW := httptest.NewRecorder()
+	mux.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusBadRequest, getW.Code)
+}
+
+// Bad snapshot id format for path-param handlers -> 400.
+func TestSnapshotHandlersBadID(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	cases := []string{
+		"/api/snapshot/notahexid",
+		"/api/snapshot/vfs/notahexid:/",
+		"/api/snapshot/vfs/children/notahexid:/",
+		"/api/snapshot/vfs/chunks/notahexid:/x",
+		"/api/snapshot/vfs/search/notahexid:/",
+		"/api/snapshot/vfs/errors/notahexid:/",
+	}
+	for _, target := range cases {
+		t.Run(target, func(t *testing.T) {
+			w := doReq(t, mux, "GET", target, "", "")
+			require.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// Valid-but-unknown snapshot id -> 404 (not found) for the header handler.
+func TestSnapshotHeaderNotFound(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	missing := hex.EncodeToString(make([]byte, 32))
+	// flip a byte so it's a syntactically valid but unknown id
+	missing = "7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c"
+	w := doReq(t, mux, "GET", "/api/snapshot/"+missing, "", "")
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/api/api_more2_test.go
+++ b/api/api_more2_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRealRepoRouterCtx is like buildRealRepoRouter but also returns the
+// appcontext so tests can manipulate cookies/state before firing requests.
+func buildRealRepoRouterCtx(t *testing.T, token string) (*http.ServeMux, string, *appcontext.AppContext, *repository.Repository) {
+	t.Helper()
+
+	var bufOut, bufErr bytes.Buffer
+	repo, ctx := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("subdir/notes.md", 0644, "# title\n\nbody text\n"),
+		ptesting.NewMockFile("top.txt", 0644, "top level content"),
+	})
+	t.Cleanup(func() { snap.Close() })
+
+	id := snap.Header.GetIndexID()
+	idHex := hex.EncodeToString(id[:])
+
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, token, true)
+	return mux, idHex, ctx, repo
+}
+
+// apiInfo: when an auth token cookie is present, authenticated is reported true.
+func TestApiInfoAuthenticated(t *testing.T) {
+	mux, _, ctx, _ := buildRealRepoRouterCtx(t, "")
+	require.NoError(t, ctx.GetCookies().PutAuthToken("some-token"))
+	t.Cleanup(func() { ctx.GetCookies().DeleteAuthToken() })
+
+	w := doReq(t, mux, "GET", "/api/info", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var res struct {
+		Authenticated bool `json:"authenticated"`
+		DemoMode      bool `json:"demo_mode"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.True(t, res.Authenticated)
+}
+
+// apiInfo: demo mode flag is reflected in the response.
+func TestApiInfoDemoMode(t *testing.T) {
+	t.Setenv("PLAKAR_DEMO_MODE", "1")
+	mux, _, _, _ := buildRealRepoRouterCtx(t, "")
+
+	w := doReq(t, mux, "GET", "/api/info", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var res struct {
+		DemoMode bool `json:"demo_mode"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.True(t, res.DemoMode)
+}
+
+// QueryParamToInt64: a value below the configured minimum is rejected.
+func TestQueryParamToInt64BelowMin(t *testing.T) {
+	req, err := http.NewRequest("GET", "/?param=2", nil)
+	require.NoError(t, err)
+	_, err = QueryParamToInt64(req, "param", 5, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "param")
+}
+
+// renderCode on a file with no path-based lexer match exercises the
+// content-type / fallback lexer branch.
+func TestSnapshotReaderCodeFallbackLexer(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+	// dummy.txt has no source-code extension, so lexers.Match returns nil and
+	// the handler falls through to the content-type / fallback lexer.
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/dummy.txt?render=code", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "<!DOCTYPE html>")
+}
+
+// snapshotVFSChunks with explicit offset+limit exercises the paging loop.
+func TestSnapshotVFSChunksWithOffset(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/chunks/"+idHex+":/subdir/dummy.txt?offset=0&limit=1", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+// snapshotVFSSearch with positive offset/limit values drives the parse paths
+// that set non-default offset and limit.
+func TestSnapshotVFSSearchWithPaging(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?recursive=true&offset=0&limit=2", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res ItemsPage[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+}
+
+// snapshotVFSSearch with a non-positive limit gets clamped to the default.
+func TestSnapshotVFSSearchZeroLimit(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/search/"+idHex+":/?recursive=true&limit=0", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// snapshotVFSErrors with bad offset/limit query params -> 400.
+func TestSnapshotVFSErrorsBadParams(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/vfs/errors/"+idHex+":/?offset=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = doReq(t, mux, "GET", "/api/snapshot/vfs/errors/"+idHex+":/?limit=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// repositoryLocatePathname with an explicit limit value and a matching
+// importerDirectory filter exercises the directory-match and paging branches.
+func TestLocatePathnameDirectoryFilterAndLimit(t *testing.T) {
+	mux, _, _, repo := buildRealRepoRouterCtx(t, "")
+
+	// Discover the importer directory of the (single) snapshot via the
+	// snapshots listing, then filter by it.
+	w := doReq(t, mux, "GET", "/api/repository/snapshots", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var snaps Items[map[string]any]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &snaps))
+	require.Equal(t, 1, snaps.Total)
+	_ = repo
+
+	// Explicit limit/offset values exercise the paging slice branch.
+	w = doReq(t, mux, "GET", "/api/repository/locate-pathname?resource=/subdir/dummy.txt&limit=1&offset=0", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var res Items[TimelineLocation]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+	require.Equal(t, 1, res.Total)
+}
+
+// downloader-signed: the tarball (.tar.gz) archive format and a name that
+// already carries an extension (no auto-suffix) path.
+func TestSnapshotVFSDownloaderSignedTarball(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+
+	body := `{"name":"backup.tar.gz","items":[{"pathname":"/subdir/dummy.txt"}]}`
+	dlReq, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+idHex+":/", strings.NewReader(body))
+	dlW := httptest.NewRecorder()
+	mux.ServeHTTP(dlW, dlReq)
+	require.Equal(t, http.StatusOK, dlW.Code)
+
+	var idResp struct {
+		Id string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(dlW.Body.Bytes(), &idResp))
+
+	getReq, _ := http.NewRequest("GET", "/api/snapshot/vfs/downloader-sign-url/"+idResp.Id+"?format=tarball&name=backup.tar.gz", nil)
+	getW := httptest.NewRecorder()
+	mux.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+	require.Contains(t, getW.Header().Get("Content-Type"), "gzip")
+	require.Contains(t, getW.Header().Get("Content-Disposition"), "backup.tar.gz")
+}
+
+// downloader-signed: the zip archive format with a default (extensionless)
+// name, which triggers the extension auto-suffix branch.
+func TestSnapshotVFSDownloaderSignedZipDefaultName(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+
+	body := `{"items":[{"pathname":"/subdir/dummy.txt"}]}`
+	dlReq, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+idHex+":/", strings.NewReader(body))
+	dlW := httptest.NewRecorder()
+	mux.ServeHTTP(dlW, dlReq)
+	require.Equal(t, http.StatusOK, dlW.Code)
+
+	var idResp struct {
+		Id string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(dlW.Body.Bytes(), &idResp))
+
+	getReq, _ := http.NewRequest("GET", "/api/snapshot/vfs/downloader-sign-url/"+idResp.Id+"?format=zip", nil)
+	getW := httptest.NewRecorder()
+	mux.ServeHTTP(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+	require.Contains(t, getW.Header().Get("Content-Type"), "zip")
+	require.Contains(t, getW.Header().Get("Content-Disposition"), ".zip")
+}
+
+// snapshotReader download=true on the code render path sets the attachment
+// disposition before rendering.
+func TestSnapshotReaderDownloadCode(t *testing.T) {
+	mux, idHex, _, _ := buildRealRepoRouterCtx(t, "")
+	w := doReq(t, mux, "GET", "/api/snapshot/reader/"+idHex+":/subdir/notes.md?download=true&render=code", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+}

--- a/api/api_services_test.go
+++ b/api/api_services_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/PlakarKorp/pkg"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// buildRouterWithPkg builds a real repo router and attaches a FlatBackend-backed
+// pkg manager pointing at empty temp dirs (no installed plugins, no network for
+// local queries).
+func buildRouterWithPkg(t *testing.T, token string) *http.ServeMux {
+	t.Helper()
+
+	var bufOut, bufErr bytes.Buffer
+	repo, ctx := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "a"),
+	})
+	t.Cleanup(func() { snap.Close() })
+
+	pkgDir := t.TempDir()
+	cacheDir := t.TempDir()
+	backend, err := pkg.NewFlatBackend(ctx.GetInner(), pkgDir, cacheDir, &pkg.FlatBackendOptions{})
+	require.NoError(t, err)
+	mgr, err := pkg.New(backend, &pkg.Options{})
+	require.NoError(t, err)
+	ctx.SetPkgManager(mgr)
+
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, token, true)
+	return mux
+}
+
+// --- api_authentication.go ---
+
+func TestServicesLogoutNotLoggedIn(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	// No auth token stored -> DeleteAuthToken returns ErrNotLoggedIn, handler
+	// swallows it and returns nil -> 200.
+	w := doReq(t, mux, "POST", "/api/authentication/logout", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestServicesLoginGithubBadBody(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "POST", "/api/authentication/login/github", "", "not json")
+	// JSON decode failure -> wrapped error -> 500
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestServicesLoginEmailBadBody(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "POST", "/api/authentication/login/email", "", "not json")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- api_proxy.go: alerting config requires an auth token ---
+
+func TestGetAlertingNoAuth(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "GET", "/api/proxy/v1/account/services/alerting", "", "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "authorization_error")
+}
+
+func TestSetAlertingNoAuth(t *testing.T) {
+	mux, _ := buildRealRepoRouter(t, "")
+	w := doReq(t, mux, "PUT", "/api/proxy/v1/account/services/alerting", "", `{"enabled":true,"email_report":false}`)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "authorization_error")
+}
+
+// --- api_proxy.go: integration listing via pkg manager (empty/local) ---
+
+func TestServicesGetIntegrationBadParams(t *testing.T) {
+	mux := buildRouterWithPkg(t, "")
+	// offset/limit validation happens before the pkg manager Query, so these
+	// 400 without touching the (network-backed) catalog.
+	w := doReq(t, mux, "GET", "/api/proxy/v1/integration?offset=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = doReq(t, mux, "GET", "/api/proxy/v1/integration?limit=abc", "", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestServicesGetIntegrationPathNotImplemented(t *testing.T) {
+	mux := buildRouterWithPkg(t, "")
+	w := doReq(t, mux, "GET", "/api/proxy/v1/integration/foo/some/path", "", "")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- api_integrations.go ---
+
+func TestIntegrationsInstallBadBody(t *testing.T) {
+	mux := buildRouterWithPkg(t, "")
+	w := doReq(t, mux, "POST", "/api/integrations/install", "", "not json")
+	// Handler always returns a JSON body with status 200, but marks the
+	// operation as failed in the body.
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "failed")
+}
+
+func TestIntegrationsUninstallUnknown(t *testing.T) {
+	mux := buildRouterWithPkg(t, "")
+	w := doReq(t, mux, "DELETE", "/api/integrations/nonexistent", "", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	// Del is idempotent for the flat backend: removing an unknown plugin
+	// succeeds. We assert the handler produced a well-formed response.
+	require.Contains(t, w.Body.String(), "pkg_uninstall")
+}
+
+// --- api_integrations.go: response helpers (pure) ---
+
+func TestIntegrationsResponseHelpers(t *testing.T) {
+	resp := NewIntegrationsResponse("pkg_test")
+	require.Equal(t, "pkg_test", resp.Type)
+	require.Equal(t, "completed", resp.Status)
+	require.Empty(t, resp.Messages)
+
+	resp.AddMessage("hello")
+	require.Len(t, resp.Messages, 1)
+	require.Equal(t, "hello", resp.Messages[0].Message)
+}
+
+// --- demo mode wiring: write endpoints disabled when PLAKAR_DEMO_MODE=1 ---
+
+func TestDemoModeDisablesWriteEndpoints(t *testing.T) {
+	t.Setenv("PLAKAR_DEMO_MODE", "1")
+
+	var bufOut, bufErr bytes.Buffer
+	repo, ctx := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, "", true)
+
+	// logout is a write endpoint; in demo mode it is not registered, so the
+	// catch-all /api/ handler returns 404.
+	w := doReq(t, mux, "POST", "/api/authentication/logout", "", "")
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	os.Unsetenv("PLAKAR_DEMO_MODE")
+}

--- a/cached/cached_extra_test.go
+++ b/cached/cached_extra_test.go
@@ -1,0 +1,249 @@
+package cached
+
+import (
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/utils"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// shortTempDir returns a short-lived temp dir with a short absolute path.
+// t.TempDir() on macOS produces paths far longer than the 104-byte sun_path
+// limit for unix sockets, so we make our own short one under os.TempDir().
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "cd")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// newTestCtx builds a minimal AppContext with a temp CacheDir and a real
+// logger so the Trace() deferred calls in the Rebuild* helpers don't panic.
+func newTestCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.CacheDir = shortTempDir(t)
+	ctx.SetLogger(logging.NewLogger(io.Discard, io.Discard))
+	return ctx
+}
+
+// startFakeCachedServer listens on ctx.CacheDir/cached.sock and, for each
+// accepted connection, performs the version handshake (echoing the client's
+// version so it matches), reads one RequestPkt, then replies with resp and
+// closes the connection. It records the last request it saw. The listener is
+// closed via t.Cleanup.
+func startFakeCachedServer(t *testing.T, ctx *appcontext.AppContext, resp ResponsePkt) *struct {
+	mu  sync.Mutex
+	req *RequestPkt
+} {
+	t.Helper()
+
+	sockPath := filepath.Join(ctx.CacheDir, "cached.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	state := &struct {
+		mu  sync.Mutex
+		req *RequestPkt
+	}{}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				dec := msgpack.NewDecoder(conn)
+				enc := msgpack.NewEncoder(conn)
+
+				// handshake: read client version, echo it back
+				var clientVers []byte
+				if err := dec.Decode(&clientVers); err != nil {
+					return
+				}
+				if err := enc.Encode([]byte(utils.GetVersion())); err != nil {
+					return
+				}
+
+				// read the request packet
+				var req RequestPkt
+				if err := dec.Decode(&req); err != nil {
+					return
+				}
+				state.mu.Lock()
+				state.req = &req
+				state.mu.Unlock()
+
+				// reply with the canned response then close (EOF)
+				_ = enc.Encode(&resp)
+			}(conn)
+		}
+	}()
+
+	return state
+}
+
+// ---------------------------------------------------------------------------
+// newClient happy path over a real unix socket (no spawn, no version mismatch)
+// ---------------------------------------------------------------------------
+
+func TestNewClientConnectsAndHandshakes(t *testing.T) {
+	ctx := newTestCtx(t)
+	startFakeCachedServer(t, ctx, ResponsePkt{})
+
+	sockPath := filepath.Join(ctx.CacheDir, "cached.sock")
+	c, err := newClient(sockPath, false)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.NoError(t, c.Close())
+}
+
+func TestNewClientVersionMismatch(t *testing.T) {
+	ctx := newTestCtx(t)
+
+	sockPath := filepath.Join(ctx.CacheDir, "cached.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		dec := msgpack.NewDecoder(conn)
+		enc := msgpack.NewEncoder(conn)
+		var v []byte
+		_ = dec.Decode(&v)
+		_ = enc.Encode([]byte("0.0.0-bogus"))
+	}()
+
+	c, err := newClient(sockPath, false)
+	require.Nil(t, c)
+	require.ErrorIs(t, err, ErrWrongVersion)
+}
+
+// ---------------------------------------------------------------------------
+// RebuildStateFromStateFile / RebuildStateFromStore drive rebuildStateRequest
+// end-to-end against the fake server.
+// ---------------------------------------------------------------------------
+
+func TestRebuildStateFromStateFileSuccess(t *testing.T) {
+	ctx := newTestCtx(t)
+	ctx.SetSecret([]byte("topsecret"))
+	state := startFakeCachedServer(t, ctx, ResponsePkt{ExitCode: 0})
+
+	repoID := uuid.New()
+	storeConfig := map[string]string{"location": "fs:///tmp/x"}
+
+	var stateID [32]byte
+	stateID[0] = 0xab
+
+	code, err := RebuildStateFromStateFile(ctx, stateID, repoID, storeConfig, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+
+	// the server received the request we built
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	require.NotNil(t, state.req)
+	require.Equal(t, repoID, state.req.RepoID)
+	require.Equal(t, storeConfig, state.req.StoreConfig)
+	require.Equal(t, []byte("topsecret"), state.req.Secret)
+	require.True(t, state.req.FireAndForget)
+	require.Equal(t, stateID, [32]byte(state.req.StateID))
+}
+
+func TestRebuildStateFromStoreSuccess(t *testing.T) {
+	ctx := newTestCtx(t)
+	state := startFakeCachedServer(t, ctx, ResponsePkt{ExitCode: 0})
+
+	repoID := uuid.New()
+	storeConfig := map[string]string{"location": "fs:///tmp/y"}
+
+	code, err := RebuildStateFromStore(ctx, repoID, storeConfig, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	require.NotNil(t, state.req)
+	require.Equal(t, repoID, state.req.RepoID)
+	require.False(t, state.req.FireAndForget)
+	// StateID left zero for a full rebuild
+	require.Equal(t, [32]byte{}, [32]byte(state.req.StateID))
+}
+
+// The server returns a non-zero exit code and an error string: the client must
+// surface both.
+func TestRebuildStateFromStoreServerError(t *testing.T) {
+	ctx := newTestCtx(t)
+	startFakeCachedServer(t, ctx, ResponsePkt{ExitCode: 3, Err: "boom"})
+
+	code, err := RebuildStateFromStore(ctx, uuid.New(), map[string]string{}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+	require.Equal(t, 3, code)
+}
+
+// When the server hangs up before replying, the decode loop sees io.EOF and
+// returns (0, nil).
+func TestRebuildStateEOFNoResponse(t *testing.T) {
+	ctx := newTestCtx(t)
+
+	sockPath := filepath.Join(ctx.CacheDir, "cached.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		dec := msgpack.NewDecoder(conn)
+		enc := msgpack.NewEncoder(conn)
+		var v []byte
+		_ = dec.Decode(&v)
+		_ = enc.Encode([]byte(utils.GetVersion()))
+		// read the request then close without sending a response
+		var req RequestPkt
+		_ = dec.Decode(&req)
+		conn.Close()
+	}()
+
+	code, err := RebuildStateFromStore(ctx, uuid.New(), map[string]string{}, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+}
+
+// rebuildStateRequest returns an error when it can't reach a server and the
+// lockfile parent does not exist (so newClient fails fast rather than spawning).
+func TestRebuildStateRequestDialFailsFast(t *testing.T) {
+	ctx := newTestCtx(t)
+	// point CacheDir at a non-existent directory so both the socket dial and
+	// the lockfile creation fail, making newClient return quickly.
+	ctx.CacheDir = filepath.Join(shortTempDir(t), "does-not-exist")
+
+	req := &RequestPkt{RepoID: uuid.New()}
+	code, err := rebuildStateRequest(ctx, req)
+	require.Error(t, err)
+	require.Equal(t, 1, code)
+}
+
+// sanity: io is used (keep import even if a path changes)
+var _ = io.EOF

--- a/cached/cached_test.go
+++ b/cached/cached_test.go
@@ -1,0 +1,200 @@
+package cached
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/utils"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// ---------------------------------------------------------------------------
+// FileLock
+// ---------------------------------------------------------------------------
+
+func TestLockedFileAndUnlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.lock")
+
+	lock, err := LockedFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, path, lock.Path)
+
+	// the lock file should exist while held
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+
+	lock.Unlock()
+
+	// Unlock removes the file
+	_, statErr = os.Stat(path)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestFileLockLockDefaultAttempts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "y.lock")
+	lock := &FileLock{Path: path} // Attempts == 0 -> defaults to 1000
+	require.NoError(t, lock.Lock())
+	lock.Unlock()
+}
+
+func TestFileLockLockOpenError(t *testing.T) {
+	// a path whose parent does not exist cannot be opened
+	lock := &FileLock{Path: filepath.Join(t.TempDir(), "missing", "z.lock")}
+	require.Error(t, lock.Lock())
+}
+
+func TestFlockExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f.lock")
+	fp, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
+	require.NoError(t, err)
+	defer fp.Close()
+
+	require.NoError(t, flock(fp))
+}
+
+// ---------------------------------------------------------------------------
+// Request / Response packets round-trip
+// ---------------------------------------------------------------------------
+
+func TestPacketsMsgpackRoundTrip(t *testing.T) {
+	req := RequestPkt{
+		Secret:        []byte("s3cr3t"),
+		StoreConfig:   map[string]string{"location": "fs:///tmp/x"},
+		FireAndForget: true,
+	}
+	data, err := msgpack.Marshal(&req)
+	require.NoError(t, err)
+
+	var got RequestPkt
+	require.NoError(t, msgpack.Unmarshal(data, &got))
+	require.Equal(t, req.Secret, got.Secret)
+	require.Equal(t, req.StoreConfig, got.StoreConfig)
+	require.True(t, got.FireAndForget)
+
+	resp := ResponsePkt{Err: "boom", ExitCode: -1}
+	data, err = msgpack.Marshal(&resp)
+	require.NoError(t, err)
+	var gotResp ResponsePkt
+	require.NoError(t, msgpack.Unmarshal(data, &gotResp))
+	require.Equal(t, resp, gotResp)
+}
+
+// ---------------------------------------------------------------------------
+// Client.handshake / Close (driven over net.Pipe, no real daemon)
+// ---------------------------------------------------------------------------
+
+// fakeServer plays the server side of the handshake: it reads the client's
+// version then replies with serverVersion.
+func fakeServer(t *testing.T, conn net.Conn, serverVersion []byte) {
+	t.Helper()
+	dec := msgpack.NewDecoder(conn)
+	enc := msgpack.NewEncoder(conn)
+
+	var clientVers []byte
+	require.NoError(t, dec.Decode(&clientVers))
+	require.Equal(t, utils.GetVersion(), string(clientVers))
+	require.NoError(t, enc.Encode(serverVersion))
+}
+
+func newPipeClient(c net.Conn) *Client {
+	return &Client{
+		conn: c,
+		enc:  msgpack.NewEncoder(c),
+		dec:  msgpack.NewDecoder(c),
+	}
+}
+
+func TestClientHandshakeMatchingVersion(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fakeServer(t, serverSide, []byte(utils.GetVersion()))
+	}()
+
+	c := newPipeClient(clientSide)
+	require.NoError(t, c.handshake(false))
+	wg.Wait()
+}
+
+func TestClientHandshakeVersionMismatch(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fakeServer(t, serverSide, []byte("99.99.99-bogus"))
+	}()
+
+	c := newPipeClient(clientSide)
+	err := c.handshake(false)
+	require.ErrorIs(t, err, ErrWrongVersion)
+	wg.Wait()
+}
+
+func TestClientHandshakeIgnoreVersion(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	defer serverSide.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fakeServer(t, serverSide, []byte("99.99.99-bogus"))
+	}()
+
+	c := newPipeClient(clientSide)
+	// ignoreVersion=true skips the comparison even on a mismatch
+	require.NoError(t, c.handshake(true))
+	wg.Wait()
+}
+
+func TestClientHandshakeEncodeError(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	serverSide.Close()
+	clientSide.Close() // writing to a closed pipe fails the initial Encode
+
+	c := newPipeClient(clientSide)
+	require.Error(t, c.handshake(false))
+}
+
+func TestClientHandshakeDecodeError(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// read the client version then hang up without replying
+		dec := msgpack.NewDecoder(serverSide)
+		var v []byte
+		_ = dec.Decode(&v)
+		serverSide.Close()
+	}()
+
+	c := newPipeClient(clientSide)
+	require.Error(t, c.handshake(false))
+	wg.Wait()
+}
+
+func TestClientClose(t *testing.T) {
+	clientSide, serverSide := net.Pipe()
+	defer serverSide.Close()
+
+	c := newPipeClient(clientSide)
+	require.NoError(t, c.Close())
+}

--- a/config/config_extra_test.go
+++ b/config/config_extra_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfig(t *testing.T) {
+	cfg := NewConfig()
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Repositories)
+	require.NotNil(t, cfg.Sources)
+	require.NotNil(t, cfg.Destinations)
+	require.Empty(t, cfg.Repositories)
+	require.Empty(t, cfg.Sources)
+	require.Empty(t, cfg.Destinations)
+	require.Equal(t, "", cfg.DefaultRepository)
+}
+
+func TestHasDestination(t *testing.T) {
+	cfg := NewConfig()
+
+	require.False(t, cfg.HasDestination("test-dest"))
+
+	cfg.Destinations["test-dest"] = DestinationConfig{"location": "fs:///tmp"}
+	require.True(t, cfg.HasDestination("test-dest"))
+}
+
+func TestGetDestination(t *testing.T) {
+	cfg := NewConfig()
+
+	// Non-existent destination
+	dest, ok := cfg.GetDestination("missing")
+	require.False(t, ok)
+	require.Nil(t, dest)
+
+	// Existing destination
+	cfg.Destinations["test-dest"] = DestinationConfig{"location": "fs:///tmp"}
+	dest, ok = cfg.GetDestination("test-dest")
+	require.True(t, ok)
+	require.Equal(t, "fs:///tmp", dest["location"])
+
+	// Returned map is a copy: mutating it must not affect the stored config.
+	dest["location"] = "mutated"
+	again, ok := cfg.GetDestination("test-dest")
+	require.True(t, ok)
+	require.Equal(t, "fs:///tmp", again["location"])
+}
+
+func TestGetDestinationWithRootOverride(t *testing.T) {
+	cfg := NewConfig()
+	cfg.Destinations["d"] = DestinationConfig{"location": "/base/path"}
+
+	// Relative root override is joined onto the local path.
+	dest, ok := cfg.GetDestination("d:sub/dir")
+	require.True(t, ok)
+	require.Equal(t, "/base/path/sub/dir", dest["location"])
+
+	// Absolute root override replaces the local path.
+	dest, ok = cfg.GetDestination("d:/abs/override")
+	require.True(t, ok)
+	require.Equal(t, "/abs/override", dest["location"])
+}
+
+func TestGetSourceWithRootOverride(t *testing.T) {
+	cfg := NewConfig()
+	cfg.Sources["s"] = SourceConfig{"location": "/base/path"}
+
+	dest, ok := cfg.GetSource("s:sub")
+	require.True(t, ok)
+	require.Equal(t, "/base/path/sub", dest["location"])
+
+	// Returned map is a copy.
+	dest["location"] = "mutated"
+	again, ok := cfg.GetSource("s")
+	require.True(t, ok)
+	require.Equal(t, "/base/path", again["location"])
+}
+
+func TestGetRepositoryWithRootOverride(t *testing.T) {
+	cfg := NewConfig()
+
+	// Local path repository, relative override is joined.
+	cfg.Repositories["local"] = RepositoryConfig{"location": "/base/repo"}
+	repo, err := cfg.GetRepository("@local:sub")
+	require.NoError(t, err)
+	require.Equal(t, "/base/repo/sub", repo["location"])
+
+	// Absolute override replaces the path.
+	repo, err = cfg.GetRepository("@local:/elsewhere")
+	require.NoError(t, err)
+	require.Equal(t, "/elsewhere", repo["location"])
+
+	// URL-style location: relative override is joined onto the URL path.
+	cfg.Repositories["remote"] = RepositoryConfig{"location": "s3://bucket/prefix"}
+	repo, err = cfg.GetRepository("@remote:more")
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket/prefix/more", repo["location"])
+
+	// URL-style location: absolute override sets the URL path.
+	repo, err = cfg.GetRepository("@remote:/abs")
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket/abs", repo["location"])
+}

--- a/login/login_test.go
+++ b/login/login_test.go
@@ -1,0 +1,103 @@
+package login
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestContext builds a hermetic AppContext with an on-disk cookies.Manager
+// rooted in a temp dir, so nothing touches the real home directory.
+func newTestContext(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	t.Cleanup(ctx.Close)
+	return ctx
+}
+
+func TestNewLoginFlow(t *testing.T) {
+	ctx := newTestContext(t)
+
+	flow, err := NewLoginFlow(ctx, false)
+	require.NoError(t, err)
+	require.NotNil(t, flow)
+	require.Equal(t, ctx, flow.appCtx)
+	require.False(t, flow.noSpawn)
+
+	flow2, err := NewLoginFlow(ctx, true)
+	require.NoError(t, err)
+	require.True(t, flow2.noSpawn)
+}
+
+func TestLoginFlowClose(t *testing.T) {
+	ctx := newTestContext(t)
+	flow, err := NewLoginFlow(ctx, false)
+	require.NoError(t, err)
+	require.NoError(t, flow.Close())
+}
+
+// Poll with zero iterations never performs network I/O: the loop body never
+// runs and it returns the "could not obtain token" exhaustion error.
+func TestPollZeroIterations(t *testing.T) {
+	ctx := newTestContext(t)
+	flow, err := NewLoginFlow(ctx, false)
+	require.NoError(t, err)
+
+	token, err := flow.Poll("some-poll-id", 0, time.Second, func() {})
+	require.Error(t, err)
+	require.Empty(t, token)
+	require.Contains(t, err.Error(), "could not obtain token after 0 iterations")
+}
+
+// Poll returns the context error when the context is already cancelled, before
+// any HTTP request is attempted.
+func TestPollContextCancelled(t *testing.T) {
+	ctx := newTestContext(t)
+	flow, err := NewLoginFlow(ctx, false)
+	require.NoError(t, err)
+
+	ctx.Cancel(context.Canceled)
+
+	token, err := flow.Poll("some-poll-id", 5, time.Second, func() {})
+	require.Error(t, err)
+	require.Empty(t, token)
+}
+
+func TestRunUnsupportedProvider(t *testing.T) {
+	ctx := newTestContext(t)
+	flow, err := NewLoginFlow(ctx, false)
+	require.NoError(t, err)
+
+	token, err := flow.Run("unsupported", map[string]string{})
+	require.Error(t, err)
+	require.Empty(t, token)
+	require.Contains(t, err.Error(), "unsupported provider: unsupported")
+}
+
+func TestRunUIUnsupportedProvider(t *testing.T) {
+	ctx := newTestContext(t)
+	flow, err := NewLoginFlow(ctx, false)
+	require.NoError(t, err)
+
+	url, err := flow.RunUI("unsupported", map[string]string{})
+	require.Error(t, err)
+	require.Empty(t, url)
+	require.Contains(t, err.Error(), "unsupported provider: unsupported")
+}
+
+// DeriveToken bails out before any network call when there is no auth token
+// available (no PLAKAR_TOKEN env var and no on-disk cookie).
+func TestDeriveTokenNoAuthToken(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx := newTestContext(t)
+
+	token, err := DeriveToken(ctx)
+	require.Error(t, err)
+	require.Empty(t, token)
+	require.Contains(t, err.Error(), "no auth token found")
+}

--- a/main_more_test.go
+++ b/main_more_test.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// withEntryPointEnv prepares a fully hermetic environment for entryPoint():
+//   - config/cache/data dirs are redirected to temp dirs via the XDG_* env vars
+//     honored by utils.Get{Config,Cache,Data}Dir.
+//   - HOME is redirected so the fallback "fs:$HOME/.plakar" repository never
+//     touches the real home directory.
+//   - the global flag.CommandLine FlagSet is reset, because entryPoint()
+//     registers flags on it and would otherwise panic ("flag redefined") on a
+//     second call within the same test binary.
+//   - os.Args is saved and restored around the call.
+//
+// It returns nothing; callers set os.Args themselves after calling this.
+func withEntryPointEnv(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	// Force the non-TUI stdio renderer so we never start the bubbletea UI.
+	t.Setenv("TERM", "dumb")
+	// Make sure no stray passphrase leaks in from the runner's environment.
+	t.Setenv("PLAKAR_PASSPHRASE", "")
+	os.Unsetenv("PLAKAR_PASSPHRASE")
+	t.Setenv("PLAKAR_REPOSITORY", "")
+	os.Unsetenv("PLAKAR_REPOSITORY")
+
+	// Reset the global flag set: entryPoint defines flags on flag.CommandLine.
+	origArgs := os.Args
+	origFlags := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(origArgs[0], flag.ContinueOnError)
+	t.Cleanup(func() {
+		os.Args = origArgs
+		flag.CommandLine = origFlags
+	})
+}
+
+func TestEntryPointDisableSecurityCheck(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar", "-disable-security-check"}
+
+	status := entryPoint()
+	require.Equal(t, 0, status)
+}
+
+func TestEntryPointEnableSecurityCheck(t *testing.T) {
+	withEntryPointEnv(t)
+
+	// First disable (this is what creates the "disabled" cookie). Then enabling
+	// removes it and returns 0. Enabling without a prior disable is an error in
+	// the cookie store, so the two calls must share the same HOME/cache dir.
+	os.Args = []string{"plakar", "-disable-security-check"}
+	require.Equal(t, 0, entryPoint())
+
+	// reset the global flag set before the second entryPoint() call
+	flag.CommandLine = flag.NewFlagSet("plakar", flag.ContinueOnError)
+
+	os.Args = []string{"plakar", "-enable-security-check"}
+	require.Equal(t, 0, entryPoint())
+}
+
+func TestEntryPointNoSubcommand(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointInvalidCPU(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar", "-cpu", "0", "version"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointTooManyCPU(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar", "-cpu", "100000", "version"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointInvalidConcurrency(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar", "-concurrency", "0", "version"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointBadFlag(t *testing.T) {
+	withEntryPointEnv(t)
+	// An unknown flag makes flag.Parse fail. flag.CommandLine was created with
+	// ContinueOnError, so Parse returns an error rather than exiting; entryPoint
+	// continues with default (empty) flags and then reports "a subcommand must
+	// be provided".
+	os.Args = []string{"plakar", "-not-a-flag"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointKeyfileMissing(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar", "-keyfile", filepath.Join(t.TempDir(), "nope.key"), "version"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointCPUProfileBadPath(t *testing.T) {
+	withEntryPointEnv(t)
+	// A profile path inside a non-existent directory cannot be created.
+	bad := filepath.Join(t.TempDir(), "missing", "cpu.prof")
+	os.Args = []string{"plakar", "-profile-cpu", bad, "version"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointUnknownCommand(t *testing.T) {
+	withEntryPointEnv(t)
+	os.Args = []string{"plakar", "this-command-does-not-exist"}
+
+	status := entryPoint()
+	require.Equal(t, 1, status)
+}
+
+func TestEntryPointVersion(t *testing.T) {
+	withEntryPointEnv(t)
+	// "version" is a BeforeRepositoryOpen command, so it runs without opening a
+	// repository. This drives the full happy-path dispatch end to end.
+	os.Args = []string{"plakar", "version"}
+
+	status := entryPoint()
+	require.Equal(t, 0, status)
+}
+
+func TestEntryPointAtVersion(t *testing.T) {
+	withEntryPointEnv(t)
+	// Exercise the "at <location> <command>" argument-parsing branch. version is
+	// BeforeRepositoryOpen so the location is parsed but never opened.
+	os.Args = []string{"plakar", "at", t.TempDir(), "version"}
+
+	status := entryPoint()
+	require.Equal(t, 0, status)
+}
+
+func TestEntryPointOpenMissingRepository(t *testing.T) {
+	withEntryPointEnv(t)
+	// "ls" needs to open a repository; the temp location is empty, so opening
+	// fails and entryPoint returns the RepoNotFound exit code (non-zero).
+	os.Args = []string{"plakar", "at", t.TempDir(), "ls"}
+
+	status := entryPoint()
+	require.NotEqual(t, 0, status)
+}
+
+// --- getPassphraseFromEnv -------------------------------------------------
+
+func newBareContext(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	t.Cleanup(func() { ctx.Close() })
+	return ctx
+}
+
+func TestGetPassphraseFromEnv(t *testing.T) {
+	t.Run("from KeyFromFile takes precedence", func(t *testing.T) {
+		ctx := newBareContext(t)
+		ctx.KeyFromFile = "secretkey"
+		got, err := getPassphraseFromEnv(ctx, map[string]string{"passphrase": "other"})
+		require.NoError(t, err)
+		require.Equal(t, "secretkey", got)
+	})
+
+	t.Run("from params passphrase", func(t *testing.T) {
+		ctx := newBareContext(t)
+		params := map[string]string{"passphrase": "frompar"}
+		got, err := getPassphraseFromEnv(ctx, params)
+		require.NoError(t, err)
+		require.Equal(t, "frompar", got)
+		_, ok := params["passphrase"]
+		require.False(t, ok, "passphrase key should be consumed")
+	})
+
+	t.Run("from PLAKAR_PASSPHRASE env", func(t *testing.T) {
+		ctx := newBareContext(t)
+		t.Setenv("PLAKAR_PASSPHRASE", "fromenv")
+		got, err := getPassphraseFromEnv(ctx, map[string]string{})
+		require.NoError(t, err)
+		require.Equal(t, "fromenv", got)
+	})
+
+	t.Run("none available", func(t *testing.T) {
+		ctx := newBareContext(t)
+		os.Unsetenv("PLAKAR_PASSPHRASE")
+		got, err := getPassphraseFromEnv(ctx, map[string]string{})
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("from passphrase_cmd", func(t *testing.T) {
+		ctx := newBareContext(t)
+		os.Unsetenv("PLAKAR_PASSPHRASE")
+		params := map[string]string{"passphrase_cmd": "printf hunter2"}
+		got, err := getPassphraseFromEnv(ctx, params)
+		require.NoError(t, err)
+		require.Equal(t, "hunter2", got)
+		_, ok := params["passphrase_cmd"]
+		require.False(t, ok, "passphrase_cmd key should be consumed")
+	})
+}
+
+// --- setupEncryption ------------------------------------------------------
+
+func TestSetupEncryptionNoEncryption(t *testing.T) {
+	ctx := newBareContext(t)
+	cfg := &storage.Configuration{Encryption: nil}
+	require.NoError(t, setupEncryption(ctx, cfg))
+	require.Nil(t, ctx.GetSecret())
+}
+
+func TestSetupEncryptionWithKeyfile(t *testing.T) {
+	// Build an encrypted repository to obtain a valid encryption configuration,
+	// then verify setupEncryption unlocks it from ctx.KeyFromFile.
+	pass := []byte("correct horse battery staple")
+	repo, ctx := ptesting.GenerateRepository(t, &bytes.Buffer{}, &bytes.Buffer{}, &pass)
+
+	cfg := repo.Configuration()
+	require.NotNil(t, cfg.Encryption)
+
+	// fresh context that only has the passphrase, to exercise the keyfile branch
+	ctx2 := appcontext.NewAppContext()
+	ctx2.SetCookies(cookies.NewManager(t.TempDir()))
+	t.Cleanup(func() { ctx2.Close() })
+	ctx2.KeyFromFile = string(pass)
+
+	require.NoError(t, setupEncryption(ctx2, &cfg))
+	require.NotNil(t, ctx2.GetSecret())
+
+	// wrong passphrase must fail to unlock
+	ctx3 := appcontext.NewAppContext()
+	ctx3.SetCookies(cookies.NewManager(t.TempDir()))
+	t.Cleanup(func() { ctx3.Close() })
+	ctx3.KeyFromFile = "wrong passphrase"
+	err := setupEncryption(ctx3, &cfg)
+	require.ErrorIs(t, err, ErrCantUnlock)
+
+	_ = ctx // silence unused if helper changes
+}
+
+// --- listCmds -------------------------------------------------------------
+
+func TestListCmds(t *testing.T) {
+	var buf bytes.Buffer
+	listCmds(&buf, "  ")
+	out := buf.String()
+	require.NotEmpty(t, out)
+	// a well-known top-level command should appear
+	require.Contains(t, out, "version")
+	// the "diag" and "cached" commands are intentionally hidden
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			require.NotEqual(t, "diag", fields[0])
+			require.NotEqual(t, "cached", fields[0])
+		}
+	}
+	// every emitted line is prefixed
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		require.True(t, strings.HasPrefix(line, "  "), "line %q lacks prefix", line)
+	}
+}
+
+func TestListCmdsWriterReceivesEverything(t *testing.T) {
+	// sanity: listCmds writes to the provided writer only
+	var buf bytes.Buffer
+	listCmds(io.Writer(&buf), "> ")
+	require.Contains(t, buf.String(), "> ")
+}

--- a/pkg_more_test.go
+++ b/pkg_more_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/PlakarKorp/pkg"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/stretchr/testify/require"
+)
+
+func pkgTestContext(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	ctx.Stdout = &bytes.Buffer{}
+	ctx.Stderr = &bytes.Buffer{}
+	t.Cleanup(func() { ctx.Close() })
+	return ctx
+}
+
+func TestSetupPkgManagerHermetic(t *testing.T) {
+	ctx := pkgTestContext(t)
+	dataDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	// Empty plugin directories: NewFlatBackend + LoadAll succeed with nothing
+	// to load. No network is touched (the install/api URLs are configured but
+	// never reached without an install command).
+	err := setupPkgManager(ctx, dataDir, cacheDir)
+	require.NoError(t, err)
+
+	mgr := ctx.GetPkgManager()
+	require.NotNil(t, mgr)
+
+	// the API-versioned plugin/cache subdirectories should now exist
+	require.DirExists(t, filepath.Join(dataDir, "plugins", pkg.PLUGIN_API_VERSION))
+}
+
+func TestPkgPreloadHookUnknownTypeSkipped(t *testing.T) {
+	// An unknown connector type is skipped (warning only), not an error.
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{Type: pkg.ConnectorType("totallybogus"), Protocols: []string{"whatever"}},
+		},
+	}
+	require.NoError(t, pkgpreloadhook(m))
+}
+
+func TestPkgPreloadHookNoConnectors(t *testing.T) {
+	require.NoError(t, pkgpreloadhook(&pkg.Manifest{}))
+}
+
+func TestPkgPreloadHookConflictingProtocol(t *testing.T) {
+	// "fs" is registered as an importer/exporter/storage backend by the blank
+	// imports in main.go, so a package claiming it must be rejected.
+	for _, typ := range []pkg.ConnectorType{
+		pkg.ConnectorTypeImporter,
+		pkg.ConnectorTypeExporter,
+		pkg.ConnectorTypeStorage,
+	} {
+		t.Run(string(typ), func(t *testing.T) {
+			m := &pkg.Manifest{
+				Connectors: []pkg.ManifestConnector{
+					{Type: typ, Protocols: []string{"fs"}},
+				},
+			}
+			err := pkgpreloadhook(m)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "already provided")
+		})
+	}
+}
+
+func TestPkgPreloadHookFreshProtocolOK(t *testing.T) {
+	// A protocol no backend provides passes the preload check.
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{Type: pkg.ConnectorTypeStorage, Protocols: []string{"this-protocol-does-not-exist-xyz"}},
+		},
+	}
+	require.NoError(t, pkgpreloadhook(m))
+}
+
+func TestPkgLoadAndUnloadHookErrorPaths(t *testing.T) {
+	// A manifest pointing at a non-existent plugin directory makes plugins.Load
+	// and plugins.Unload fail; the hooks swallow the error and only print to
+	// stderr, so they must not panic.
+	m := &pkg.Manifest{Name: "bogus"}
+	p := &pkg.Package{Version: "0.0.0"}
+
+	require.NotPanics(t, func() {
+		pkgloadhook(m, p, filepath.Join(t.TempDir(), "missing-plugin-dir"))
+	})
+	require.NotPanics(t, func() {
+		pkgunloadhook(m, p)
+	})
+}

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -1,0 +1,125 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/exporter"
+	"github.com/PlakarKorp/kloset/connectors/importer"
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/location"
+	"github.com/PlakarKorp/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+// Registration only stores a constructor closure; the plugin executable is never
+// spawned unless the backend is actually opened, so these tests stay hermetic.
+
+func TestRegisterImporter(t *testing.T) {
+	proto := "test-plugin-importer"
+	err := RegisterImporter(proto, location.Flags(0), "/nonexistent/exe", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { importer.Unregister(proto) })
+
+	// re-registering the same proto must fail
+	err = RegisterImporter(proto, location.Flags(0), "/nonexistent/exe", nil)
+	require.Error(t, err)
+}
+
+func TestRegisterExporter(t *testing.T) {
+	proto := "test-plugin-exporter"
+	err := RegisterExporter(proto, location.Flags(0), "/nonexistent/exe", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { exporter.Unregister(proto) })
+
+	err = RegisterExporter(proto, location.Flags(0), "/nonexistent/exe", nil)
+	require.Error(t, err)
+}
+
+func TestRegisterStorage(t *testing.T) {
+	proto := "test-plugin-storage"
+	err := RegisterStorage(proto, location.Flags(0), "/nonexistent/exe", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { storage.Unregister(proto) })
+
+	err = RegisterStorage(proto, location.Flags(0), "/nonexistent/exe", nil)
+	require.Error(t, err)
+}
+
+func TestLoadEmptyManifest(t *testing.T) {
+	m := &pkg.Manifest{}
+	require.NoError(t, Load(m, t.TempDir()))
+}
+
+func TestLoadUnknownConnectorTypeIgnored(t *testing.T) {
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{
+				Type:      "bogus-type",
+				Protocols: []string{"whatever"},
+			},
+		},
+	}
+	// Unknown types are silently ignored, so Load succeeds without registering.
+	require.NoError(t, Load(m, t.TempDir()))
+}
+
+func TestLoadAndUnloadImporter(t *testing.T) {
+	proto := "test-load-importer"
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{
+				Type:       "importer",
+				Protocols:  []string{proto},
+				Executable: "plugin-bin",
+			},
+		},
+	}
+	pkgdir := t.TempDir()
+
+	require.NoError(t, Load(m, pkgdir))
+
+	// Loading again must fail because the protocol is already registered.
+	err := Load(m, pkgdir)
+	require.Error(t, err)
+
+	// Unload removes the registration so a subsequent Load works again.
+	require.NoError(t, Unload(m))
+	require.NoError(t, Load(m, pkgdir))
+	require.NoError(t, Unload(m))
+}
+
+func TestLoadExporterAndStorage(t *testing.T) {
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{Type: "exporter", Protocols: []string{"test-load-exporter"}, Executable: "e"},
+			{Type: "storage", Protocols: []string{"test-load-storage"}, Executable: "s"},
+		},
+	}
+	require.NoError(t, Load(m, t.TempDir()))
+	t.Cleanup(func() { Unload(m) })
+
+	require.NoError(t, Unload(m))
+}
+
+func TestUnloadUnknownTypeIgnored(t *testing.T) {
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{Type: "bogus", Protocols: []string{"x"}},
+		},
+	}
+	require.NoError(t, Unload(m))
+}
+
+func TestLoadInvalidLocationFlag(t *testing.T) {
+	m := &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{
+				Type:          "importer",
+				Protocols:     []string{"test-bad-flag"},
+				LocationFlags: []string{"this-is-not-a-valid-flag"},
+			},
+		},
+	}
+	err := Load(m, t.TempDir())
+	require.Error(t, err)
+}

--- a/plugins/stdioconn_test.go
+++ b/plugins/stdioconn_test.go
@@ -1,0 +1,75 @@
+package plugins
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdioConnReadWrite(t *testing.T) {
+	// Build a connection whose "stdin" (read side) and "stdout" (write side)
+	// are wired through OS pipes so we can exercise Read/Write end to end.
+	inR, inW, err := os.Pipe()
+	require.NoError(t, err)
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+
+	conn := NewStdioConn(inR, outW, nil)
+
+	// addresses
+	require.Equal(t, stdioaddr, conn.LocalAddr())
+	require.Equal(t, stdioaddr, conn.RemoteAddr())
+	require.Equal(t, "stdio", conn.LocalAddr().String())
+
+	// Write goes to outW; read it back from outR.
+	go func() {
+		conn.Write([]byte("ping"))
+	}()
+	buf := make([]byte, 4)
+	n, err := outR.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "ping", string(buf[:n]))
+
+	// Feed inW; Read on conn reads from inR.
+	go func() {
+		inW.Write([]byte("pong"))
+	}()
+	n, err = conn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "pong", string(buf[:n]))
+
+	outR.Close()
+	inW.Close()
+	require.NoError(t, conn.Close())
+}
+
+func TestStdioConnDeadlines(t *testing.T) {
+	inR, _, err := os.Pipe()
+	require.NoError(t, err)
+	_, outW, err := os.Pipe()
+	require.NoError(t, err)
+
+	conn := NewStdioConn(inR, outW, nil)
+	t.Cleanup(func() { conn.Close() })
+
+	deadline := time.Now().Add(time.Hour)
+	require.NoError(t, conn.SetReadDeadline(deadline))
+	require.NoError(t, conn.SetWriteDeadline(deadline))
+	require.NoError(t, conn.SetDeadline(deadline))
+
+	// implements net.Conn
+	var _ net.Conn = conn
+}
+
+func TestSpawnNonexistentBinary(t *testing.T) {
+	_, err := spawn(t.Context(), "/nonexistent/plugin/binary", nil)
+	require.Error(t, err)
+}
+
+func TestConnectPluginNonexistentBinary(t *testing.T) {
+	_, err := connectPlugin(t.Context(), "/nonexistent/plugin/binary", nil)
+	require.Error(t, err)
+}

--- a/reporting/helpers_test.go
+++ b/reporting/helpers_test.go
@@ -1,0 +1,28 @@
+package reporting
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+)
+
+// newReporterCtx returns an AppContext wired with a logger and a cookies manager
+// backed by a temp dir (so getEmitter can query the auth token without panicking;
+// with no token configured it returns the empty string).
+func newReporterCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetLogger(logging.NewLogger(io.Discard, io.Discard))
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	// Ensure no env token leaks in from the host.
+	t.Setenv("PLAKAR_TOKEN", "")
+	return ctx
+}
+
+func readAll(r *http.Request) ([]byte, error) {
+	return io.ReadAll(r.Body)
+}

--- a/reporting/reporting_more_test.go
+++ b/reporting/reporting_more_test.go
@@ -1,0 +1,258 @@
+package reporting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullEmitter(t *testing.T) {
+	e := &NullEmitter{}
+	require.NoError(t, e.Emit(context.Background(), &Report{}))
+}
+
+func TestHttpEmitterSuccess(t *testing.T) {
+	var gotBody []byte
+	var gotAuth, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+		gotBody, _ = readAll(r)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	e := &HttpEmitter{url: srv.URL, token: "secret"}
+	report := &Report{
+		Task: &ReportTask{Type: "backup", Name: "n", Status: StatusOK},
+	}
+	require.NoError(t, e.Emit(context.Background(), report))
+
+	require.Equal(t, "Bearer secret", gotAuth)
+	require.Equal(t, "application/json", gotCT)
+
+	// body must be the JSON-serialized report
+	var decoded Report
+	require.NoError(t, json.Unmarshal(gotBody, &decoded))
+	require.NotNil(t, decoded.Task)
+	require.Equal(t, "backup", decoded.Task.Type)
+	require.Equal(t, StatusOK, decoded.Task.Status)
+}
+
+func TestHttpEmitterNoToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	e := &HttpEmitter{url: srv.URL}
+	require.NoError(t, e.Emit(context.Background(), &Report{}))
+}
+
+func TestHttpEmitterBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	e := &HttpEmitter{url: srv.URL}
+	err := e.Emit(context.Background(), &Report{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "request failed with status")
+}
+
+func TestHttpEmitterBadURL(t *testing.T) {
+	e := &HttpEmitter{url: "http://\x7f"}
+	err := e.Emit(context.Background(), &Report{})
+	require.Error(t, err)
+}
+
+func TestHttpEmitterConnRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	e := &HttpEmitter{url: url}
+	err := e.Emit(context.Background(), &Report{})
+	require.Error(t, err)
+}
+
+func TestReportTaskDone(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore() // do not actually emit
+	r.TaskStart("backup", "mybackup")
+	require.NotNil(t, r.Task)
+	require.Equal(t, "backup", r.Task.Type)
+	require.Equal(t, "mybackup", r.Task.Name)
+
+	r.TaskDone()
+	require.Equal(t, StatusOK, r.Task.Status)
+	require.True(t, r.Task.Duration >= 0)
+}
+
+func TestReportTaskWarning(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore()
+	r.TaskStart("check", "c")
+	r.TaskWarning("careful: %d", 7)
+	require.Equal(t, StatusWarning, r.Task.Status)
+	require.Equal(t, "careful: 7", r.Task.ErrorMessage)
+}
+
+func TestReportTaskFailed(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore()
+	r.TaskStart("restore", "r")
+	r.TaskFailed(TaskErrorCode(42), "boom")
+	require.Equal(t, StatusFailed, r.Task.Status)
+	require.Equal(t, TaskErrorCode(42), r.Task.ErrorCode)
+	require.Equal(t, "boom", r.Task.ErrorMessage)
+}
+
+func TestReportTaskStartTwiceWarns(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore()
+	r.TaskStart("a", "1")
+	r.TaskStart("b", "2") // logs a warning, overwrites
+	require.Equal(t, "b", r.Task.Type)
+	r.TaskDone()
+}
+
+func TestReportWithRepositoryName(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore()
+	r.WithRepositoryName("myrepo")
+	require.NotNil(t, r.Repository)
+	require.Equal(t, "myrepo", r.Repository.Name)
+
+	// second call warns but overwrites
+	r.WithRepositoryName("other")
+	require.Equal(t, "other", r.Repository.Name)
+
+	// Every NewReport must be published, otherwise StopAndWait blocks.
+	r.TaskStart("backup", "n")
+	r.TaskDone()
+}
+
+func TestReportWithRepositoryAndSnapshot(t *testing.T) {
+	var bufOut, bufErr bytes.Buffer
+	repo, _ := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("d"),
+		ptesting.NewMockFile("d/f.txt", 0644, "hello"),
+	})
+	defer snap.Close()
+
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore()
+	r.WithRepositoryName("repo")
+	r.WithRepository(repo)
+	require.NotNil(t, r.Repository.Storage)
+
+	r.WithSnapshot(snap)
+	require.NotNil(t, r.Snapshot)
+	require.Equal(t, snap.Header.Identifier, r.Snapshot.Header.Identifier)
+	r.TaskStart("backup", "n")
+	r.TaskDone()
+
+	// WithSnapshotID loads from the repo and populates Snapshot
+	r2 := reporter.NewReport()
+	r2.SetIgnore()
+	r2.WithRepositoryName("repo")
+	r2.WithRepository(repo)
+	r2.WithSnapshotID(snap.Header.GetIndexID())
+	require.NotNil(t, r2.Snapshot)
+	r2.TaskStart("backup", "n2")
+	r2.TaskDone()
+}
+
+func TestReportWithSnapshotIDLoadError(t *testing.T) {
+	var bufOut, bufErr bytes.Buffer
+	repo, _ := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	r := reporter.NewReport()
+	r.SetIgnore()
+	r.WithRepositoryName("repo")
+	r.WithRepository(repo)
+
+	// A snapshot id that does not exist -> load fails, Snapshot stays nil.
+	var bogus [32]byte
+	bogus[0] = 0xab
+	r.WithSnapshotID(bogus)
+	require.Nil(t, r.Snapshot)
+	r.TaskStart("backup", "n")
+	r.TaskDone()
+}
+
+// getEmitter: with no auth token the emitter must be the NullEmitter.
+func TestGetEmitterNullWhenNoToken(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	e := reporter.getEmitter()
+	_, ok := e.(*NullEmitter)
+	require.True(t, ok)
+
+	// cached path: second call returns the same emitter while not timed out.
+	reporter.emitter_timeout = time.Now().Add(time.Minute)
+	e2 := reporter.getEmitter()
+	require.Same(t, e, e2)
+}
+
+// Process with an ignored report returns immediately (no emit attempt).
+func TestProcessIgnored(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+	defer reporter.StopAndWait()
+
+	reporter.Process(&Report{ignore: true})
+}
+
+// Full publish path through the reporter goroutine using a NullEmitter.
+func TestPublishThroughReporter(t *testing.T) {
+	ctx := newReporterCtx(t)
+	reporter := NewReporter(ctx)
+
+	r := reporter.NewReport()
+	r.TaskStart("backup", "b")
+	r.TaskDone() // publishes -> goroutine processes via NullEmitter
+
+	reporter.StopAndWait()
+}

--- a/server/httpd/httpd_test.go
+++ b/server/httpd/httpd_test.go
@@ -1,0 +1,272 @@
+package httpd
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/objects"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServer builds an httpd server backed by a real (mock-backed) repo store.
+func newTestServer(t *testing.T, noDelete bool) (*server, http.Handler) {
+	t.Helper()
+	var bufOut, bufErr bytes.Buffer
+	repo, _ := ptesting.GenerateRepository(t, &bufOut, &bufErr, nil)
+
+	s := &server{
+		store:    repo.Store(),
+		noDelete: noDelete,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", s.openRepository)
+	mux.HandleFunc("GET /resources/{resource}", s.listResource)
+	mux.HandleFunc("GET /resources/{resource}/{mac}", s.getResource)
+	mux.HandleFunc("PUT /resources/{resource}/{mac}", s.putResource)
+	mux.HandleFunc("DELETE /resources/{resource}/{mac}", s.deleteResource)
+	return s, mux
+}
+
+func macHex() string {
+	var m objects.MAC
+	for i := range m {
+		m[i] = byte(i)
+	}
+	return hex.EncodeToString(m[:])
+}
+
+func TestOpenRepository(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/octet-stream", rr.Header().Get("Content-Type"))
+	require.NotEmpty(t, rr.Body.Bytes())
+}
+
+func TestListResource(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/resources/packfiles", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	// must be valid JSON (an array, possibly empty/null)
+	var macs []objects.MAC
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &macs))
+}
+
+func TestListResourceInvalidType(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/resources/bogus", nil))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), ErrInvalidResourceType.Error())
+}
+
+func TestPutGetDeleteResourceRoundTrip(t *testing.T) {
+	s, h := newTestServer(t, false)
+	payload := []byte("hello packfile payload")
+	mac := macHex()
+
+	// PUT
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("PUT", "/resources/packfiles/"+mac, bytes.NewReader(payload)))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// GET
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/resources/packfiles/"+mac, nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/octet-stream", rr.Header().Get("Content-Type"))
+	require.Equal(t, payload, rr.Body.Bytes())
+
+	// GET with a Range header
+	rr = httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/resources/packfiles/"+mac, nil)
+	req.Header.Set("Range", "bytes=0-5")
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, payload[:5], rr.Body.Bytes())
+
+	// DELETE
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("DELETE", "/resources/packfiles/"+mac, nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	_ = s
+}
+
+func TestGetResourceInvalidType(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/resources/bogus/"+macHex(), nil))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetResourceInvalidMac(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/resources/packfiles/zzzz", nil))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), ErrInvalidMAC.Error())
+}
+
+func TestGetResourceInvalidRange(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/resources/packfiles/"+macHex(), nil)
+	req.Header.Set("Range", "items=0-5")
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), ErrInvalidRange.Error())
+}
+
+func TestGetResourceMissing(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/resources/packfiles/"+macHex(), nil))
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestPutResourceInvalidType(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("PUT", "/resources/bogus/"+macHex(), strings.NewReader("x")))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestPutResourceInvalidMac(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("PUT", "/resources/packfiles/nothex", strings.NewReader("x")))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeleteResourceForbidden(t *testing.T) {
+	_, h := newTestServer(t, true) // noDelete
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("DELETE", "/resources/packfiles/"+macHex(), nil))
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	require.Contains(t, rr.Body.String(), "not allowed to delete")
+}
+
+func TestDeleteResourceInvalidType(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("DELETE", "/resources/bogus/"+macHex(), nil))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDeleteResourceInvalidMac(t *testing.T) {
+	_, h := newTestServer(t, false)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("DELETE", "/resources/packfiles/nothex", nil))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestGetResourcePure(t *testing.T) {
+	cases := map[string]struct {
+		resource string
+		want     storage.StorageResource
+		wantErr  bool
+	}{
+		"packfiles":   {"packfiles", storage.StorageResourcePackfile, false},
+		"states":      {"states", storage.StorageResourceState, false},
+		"locks":       {"locks", storage.StorageResourceLock, false},
+		"eccpackfiles": {"eccpackfiles", storage.StorageResourceECCPackfile, false},
+		"eccstates":   {"eccstates", storage.StorageResourceECCState, false},
+		"invalid":     {"nope", 0, true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/resources/"+tc.resource, nil)
+			req.SetPathValue("resource", tc.resource)
+			got, err := getResource(req)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGetMacPure(t *testing.T) {
+	// valid
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetPathValue("mac", macHex())
+	mac, err := getMac(req)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), mac[0])
+	require.Equal(t, byte(31), mac[31])
+
+	// not hex
+	req.SetPathValue("mac", "zz")
+	_, err = getMac(req)
+	require.ErrorIs(t, err, ErrInvalidMAC)
+
+	// wrong length (valid hex but only 1 byte)
+	req.SetPathValue("mac", "ab")
+	_, err = getMac(req)
+	require.ErrorIs(t, err, ErrInvalidMAC)
+}
+
+func TestGetRangePure(t *testing.T) {
+	mk := func(v string) *http.Request {
+		r := httptest.NewRequest("GET", "/", nil)
+		if v != "" {
+			r.Header.Set("Range", v)
+		}
+		return r
+	}
+
+	// no header -> nil, nil
+	rg, err := getRange(mk(""))
+	require.NoError(t, err)
+	require.Nil(t, rg)
+
+	// valid
+	rg, err = getRange(mk("bytes=10-30"))
+	require.NoError(t, err)
+	require.NotNil(t, rg)
+	require.Equal(t, uint64(10), rg.Offset)
+	require.Equal(t, uint32(20), rg.Length)
+
+	// missing bytes= prefix
+	_, err = getRange(mk("items=0-5"))
+	require.ErrorIs(t, err, ErrInvalidRange)
+
+	// missing dash
+	_, err = getRange(mk("bytes=10"))
+	require.ErrorIs(t, err, ErrInvalidRange)
+
+	// bad start
+	_, err = getRange(mk("bytes=x-5"))
+	require.ErrorIs(t, err, ErrInvalidRange)
+
+	// bad end
+	_, err = getRange(mk("bytes=5-y"))
+	require.ErrorIs(t, err, ErrInvalidRange)
+
+	// end <= offset
+	_, err = getRange(mk("bytes=10-10"))
+	require.ErrorIs(t, err, ErrInvalidRange)
+
+	// length overflow uint32
+	_, err = getRange(mk("bytes=0-4294967296"))
+	require.ErrorIs(t, err, ErrInvalidRange)
+}
+
+// ensure io import is used even if a path changes
+var _ = io.Discard

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -1,0 +1,333 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestConnector(t *testing.T, endpoint string) *ServiceConnector {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.Client = "plakar-test/1.0.0"
+	ctx.OperatingSystem = "testos"
+	ctx.Architecture = "testarch"
+	sc := NewServiceConnector(ctx, "tok")
+	sc.endpoint = endpoint
+	return sc
+}
+
+func TestNewServiceConnector(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	sc := NewServiceConnector(ctx, "abc")
+	require.NotNil(t, sc)
+	require.Equal(t, "abc", sc.authToken)
+	require.Equal(t, SERVICE_ENDPOINT, sc.endpoint)
+	require.Same(t, ctx, sc.appCtx)
+}
+
+func TestValidateConfigAlwaysNil(t *testing.T) {
+	sd := &ServiceDescription{Name: "alerting"}
+	require.NoError(t, sd.ValidateConfig(nil))
+	require.NoError(t, sd.ValidateConfig(map[string]string{"k": "v"}))
+}
+
+func TestGetServiceList(t *testing.T) {
+	want := []ServiceDescription{
+		{Name: "alerting", DisplayName: "Alerting"},
+		{Name: "backup", DisplayName: "Backup"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account/services", r.URL.Path)
+		require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	got, err := sc.GetServiceList()
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	// second call must come from cache (server would still work, but verify identity)
+	got2, err := sc.GetServiceList()
+	require.NoError(t, err)
+	require.Equal(t, want, got2)
+}
+
+func TestGetServiceListCachedSkipsHTTP(t *testing.T) {
+	sc := newTestConnector(t, "http://127.0.0.1:0")
+	sc.servicesList = []ServiceDescription{{Name: "x"}}
+	got, err := sc.GetServiceList()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+}
+
+func TestGetServiceListBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	_, err := sc.GetServiceList()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get service list")
+}
+
+func TestGetServiceListBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	_, err := sc.GetServiceList()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal response")
+}
+
+func TestGetServiceListBadURL(t *testing.T) {
+	// control characters in the URL cause http.NewRequest to fail.
+	sc := newTestConnector(t, "http://\x7f")
+	_, err := sc.GetServiceList()
+	require.Error(t, err)
+}
+
+func TestGetServiceListConnRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing listening now
+	sc := newTestConnector(t, url)
+	_, err := sc.GetServiceList()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get service list")
+}
+
+func TestValidateServiceConfiguration(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]ServiceDescription{{Name: "alerting"}})
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	require.NoError(t, sc.ValidateServiceConfiguration("alerting", map[string]string{}))
+
+	err := sc.ValidateServiceConfiguration("missing", map[string]string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service not found")
+}
+
+func TestValidateServiceConfigurationListError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	err := sc.ValidateServiceConfiguration("alerting", nil)
+	require.Error(t, err)
+}
+
+func TestGetServiceStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account/services/alerting", r.URL.Path)
+		json.NewEncoder(w).Encode(map[string]bool{"enabled": true})
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	enabled, err := sc.GetServiceStatus("alerting")
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestGetServiceStatusDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"enabled":false}`))
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	enabled, err := sc.GetServiceStatus("alerting")
+	require.NoError(t, err)
+	require.False(t, enabled)
+}
+
+func TestGetServiceStatusBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	_, err := sc.GetServiceStatus("alerting")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get service status")
+}
+
+func TestGetServiceStatusBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("garbage"))
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	_, err := sc.GetServiceStatus("alerting")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal response")
+}
+
+func TestGetServiceStatusBadURL(t *testing.T) {
+	sc := newTestConnector(t, "http://\x7f")
+	_, err := sc.GetServiceStatus("alerting")
+	require.Error(t, err)
+}
+
+func TestGetServiceStatusNoToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.Write([]byte(`{"enabled":true}`))
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	sc.authToken = ""
+	enabled, err := sc.GetServiceStatus("alerting")
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+func TestSetServiceStatus(t *testing.T) {
+	var got struct {
+		Enabled bool `json:"enabled"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "PUT", r.Method)
+		require.Equal(t, "/v1/account/services/alerting", r.URL.Path)
+		json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	require.NoError(t, sc.SetServiceStatus("alerting", true))
+	require.True(t, got.Enabled)
+}
+
+func TestSetServiceStatusBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	err := sc.SetServiceStatus("alerting", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to set service status")
+}
+
+func TestSetServiceStatusBadURL(t *testing.T) {
+	sc := newTestConnector(t, "http://\x7f")
+	err := sc.SetServiceStatus("alerting", true)
+	require.Error(t, err)
+}
+
+func TestGetServiceConfiguration(t *testing.T) {
+	want := map[string]string{"foo": "bar"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account/services/alerting/configuration", r.URL.Path)
+		json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	got, err := sc.GetServiceConfiguration("alerting")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestGetServiceConfigurationBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	_, err := sc.GetServiceConfiguration("alerting")
+	require.Error(t, err)
+}
+
+func TestGetServiceConfigurationBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	_, err := sc.GetServiceConfiguration("alerting")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal response")
+}
+
+func TestGetServiceConfigurationBadURL(t *testing.T) {
+	sc := newTestConnector(t, "http://\x7f")
+	_, err := sc.GetServiceConfiguration("alerting")
+	require.Error(t, err)
+}
+
+func TestSetServiceConfiguration(t *testing.T) {
+	var got map[string]string
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		// first call: ValidateServiceConfiguration -> getServicesList
+		if r.URL.Path == "/v1/account/services" {
+			json.NewEncoder(w).Encode([]ServiceDescription{{Name: "alerting"}})
+			return
+		}
+		require.Equal(t, "PUT", r.Method)
+		require.Equal(t, "/v1/account/services/alerting/configuration", r.URL.Path)
+		json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	cfg := map[string]string{"k": "v"}
+	require.NoError(t, sc.SetServiceConfiguration("alerting", cfg))
+	require.Equal(t, cfg, got)
+}
+
+func TestSetServiceConfigurationInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// service list does not contain "alerting" -> validation fails
+		json.NewEncoder(w).Encode([]ServiceDescription{{Name: "other"}})
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	err := sc.SetServiceConfiguration("alerting", map[string]string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid configuration")
+}
+
+func TestSetServiceConfigurationPutBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/account/services" {
+			json.NewEncoder(w).Encode([]ServiceDescription{{Name: "alerting"}})
+			return
+		}
+		http.Error(w, "no", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	sc := newTestConnector(t, srv.URL)
+	err := sc.SetServiceConfiguration("alerting", map[string]string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to set service status")
+}

--- a/subcommands/backup/backup_branches_test.go
+++ b/subcommands/backup/backup_branches_test.go
@@ -1,0 +1,260 @@
+package backup
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/config"
+	"github.com/PlakarKorp/plakar/ui/stdio"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupNoProgressFlag(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"-no-progress", tmpBackupDir}))
+	require.True(t, subcommand.NoProgress)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "backup completed")
+}
+
+func TestBackupCacheNo(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"-cache", "no", tmpBackupDir}))
+	require.Equal(t, "no", subcommand.Cache)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "backup completed")
+}
+
+func TestBackupPackfilesMemory(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	ctx.MaxConcurrency = 1
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"-packfiles", "memory", tmpBackupDir}))
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupExcludeMultiplePatterns(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	ctx.MaxConcurrency = 1
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{
+		"-ignore", "**/foo.txt",
+		"-ignore", "**/bar",
+		tmpBackupDir,
+	}))
+	require.Equal(t, []string{"**/foo.txt", "**/bar"}, subcommand.Excludes)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.NotContains(t, out, "/foo.txt")
+	require.NotContains(t, out, "/another_subdir/bar")
+}
+
+func TestBackupIgnoreFile(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	ignoreFile := filepath.Join(t.TempDir(), "ignore")
+	require.NoError(t, os.WriteFile(ignoreFile, []byte("# a comment\n\n**/foo.txt\n"), 0644))
+
+	ctx.MaxConcurrency = 1
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"-ignore-file", ignoreFile, tmpBackupDir}))
+	require.Equal(t, []string{"**/foo.txt"}, subcommand.Excludes)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotContains(t, bufOut.String(), "/foo.txt")
+}
+
+func TestBackupIgnoreFileMissing(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	_, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	subcommand := &Backup{}
+	err := subcommand.Parse(ctx, []string{"-ignore-file", "/no/such/ignore/file", tmpBackupDir})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to open excludes file")
+}
+
+func TestBackupDryRun(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	ctx.MaxConcurrency = 1
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"-dry-run", tmpBackupDir}))
+	require.True(t, subcommand.DryRun)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// Dry-run still emits per-path lines but must not commit a snapshot.
+	require.NotContains(t, bufOut.String(), "backup completed")
+}
+
+func TestBackupSecondBackupUsesParent(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	ctx.MaxConcurrency = 1
+
+	// First backup: nothing to inherit from.
+	first := &Backup{}
+	require.NoError(t, first.Parse(ctx, []string{tmpBackupDir}))
+	status, err := first.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.NoError(t, repo.RebuildState())
+
+	// Second backup with default (vfs) cache: it should locate the previous
+	// snapshot as a parent and reuse its VFS cache.
+	bufOut.Reset()
+	second := &Backup{}
+	require.NoError(t, second.Parse(ctx, []string{tmpBackupDir}))
+	require.Equal(t, "vfs", second.Cache)
+	status, err = second.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupUnknownScheme(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, _, ctx := generateFixtures(t, bufOut, bufErr)
+
+	ctx.MaxConcurrency = 1
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"definitely-not-a-scheme://nope"}))
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "failed to create an importer")
+}
+
+func TestBackupSourceResolution(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["mysrc"] = map[string]string{"location": "fs://" + tmpBackupDir}
+
+	ctx.MaxConcurrency = 1
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"@mysrc"}))
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupSourceUnresolved(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, _, ctx := generateFixtures(t, bufOut, bufErr)
+	ctx.Config = config.NewConfig()
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"@ghost"}))
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "could not resolve importer")
+}
+
+func TestBackupSourceEmptyLocation(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, _, ctx := generateFixtures(t, bufOut, bufErr)
+	ctx.Config = config.NewConfig()
+	// Source exists but resolves to an empty location: the @ resolution
+	// succeeds, but importer creation then fails on the bad location.
+	ctx.Config.Sources["nolocsrc"] = map[string]string{"option": "value"}
+
+	subcommand := &Backup{}
+	require.NoError(t, subcommand.Parse(ctx, []string{"@nolocsrc"}))
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "failed to create an importer")
+}

--- a/subcommands/cached/cached_test.go
+++ b/subcommands/cached/cached_test.go
@@ -1,0 +1,280 @@
+package cached
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/encryption"
+	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// shortSocket returns a unix socket path short enough to satisfy the OS sun_path
+// limit (108 on Linux, 104 on macOS), which t.TempDir() can exceed.
+func shortSocket(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "cs")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "c.sock")
+}
+
+// wrapConfig serializes a storage.Configuration into the same wrapped on-disk
+// format that storage.Open produces, so it can be fed to getSecret.
+func wrapConfig(t *testing.T, config *storage.Configuration) []byte {
+	t.Helper()
+	hasher := hashing.GetHasher(storage.DEFAULT_HASHING_ALGORITHM)
+	serialized, err := config.ToBytes()
+	require.NoError(t, err)
+	rd, err := storage.Serialize(hasher, resources.RT_CONFIG,
+		versioning.GetCurrentVersion(resources.RT_CONFIG), bytes.NewReader(serialized))
+	require.NoError(t, err)
+	wrapped, err := io.ReadAll(rd)
+	require.NoError(t, err)
+	return wrapped
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+func TestCachedParseForeground(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{"-foreground"})
+	require.NoError(t, err)
+
+	// defaults / initialization
+	require.Equal(t, 5*time.Second, cmd.teardown)
+	require.Equal(t, filepath.Join(ctx.CacheDir, "cached.sock"), cmd.socketPath)
+	require.NotNil(t, cmd.jobQueue)
+	require.NotNil(t, cmd.runningJobs)
+}
+
+func TestCachedParseTeardown(t *testing.T) {
+	_, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{"-foreground", "-teardown", "42s"})
+	require.NoError(t, err)
+	require.Equal(t, 42*time.Second, cmd.teardown)
+}
+
+func TestCachedParseTooManyArgs(t *testing.T) {
+	_, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{"-foreground", "extra"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+func TestCachedParseLogfileCreates(t *testing.T) {
+	_, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	logfile := filepath.Join(t.TempDir(), "cached.log")
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{"-foreground", "-log", logfile})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(logfile)
+	require.NoError(t, statErr)
+}
+
+func TestCachedParseLogfileError(t *testing.T) {
+	_, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	// point the log at a path whose parent directory does not exist -> open fails
+	logfile := filepath.Join(t.TempDir(), "missingdir", "cached.log")
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{"-foreground", "-log", logfile})
+	require.Error(t, err)
+}
+
+// Parse uses REEXEC to skip the daemonize fork even without -foreground.
+func TestCachedParseReexec(t *testing.T) {
+	_, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	t.Setenv("REEXEC", "1")
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(ctx.CacheDir, "cached.sock"), cmd.socketPath)
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+
+func TestCachedCloseMissingSocket(t *testing.T) {
+	cmd := &Cached{
+		socketPath: filepath.Join(t.TempDir(), "does-not-exist.sock"),
+	}
+	// no listener, socket file absent -> Close should be a no-op (no error)
+	require.NoError(t, cmd.Close())
+}
+
+func TestCachedClosePresentSocket(t *testing.T) {
+	sock := shortSocket(t)
+
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	cmd := &Cached{
+		socketPath: sock,
+		listener:   listener,
+	}
+	require.NoError(t, cmd.Close())
+
+	// the socket file must be gone
+	_, statErr := os.Stat(sock)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+func TestWatcherTearsDownWhenIdle(t *testing.T) {
+	sock := shortSocket(t)
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	cmd := &Cached{
+		teardown:    20 * time.Millisecond,
+		runningJobs: make(chan int),
+	}
+
+	go cmd.Watcher(listener)
+
+	// With nothing in flight, the watcher should close the listener after the
+	// teardown delay. A subsequent Accept must fail.
+	done := make(chan error, 1)
+	go func() {
+		_, e := listener.Accept()
+		done <- e
+	}()
+
+	select {
+	case e := <-done:
+		require.Error(t, e)
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not close the listener")
+	}
+}
+
+func TestWatcherStaysAliveWhileInflight(t *testing.T) {
+	sock := shortSocket(t)
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	cmd := &Cached{
+		teardown:    20 * time.Millisecond,
+		runningJobs: make(chan int),
+	}
+
+	go cmd.Watcher(listener)
+
+	// Mark a job as in-flight: the watcher must not close the listener.
+	cmd.runningJobs <- newJob
+
+	accepted := make(chan error, 1)
+	go func() {
+		conn, e := listener.Accept()
+		if conn != nil {
+			conn.Close()
+		}
+		accepted <- e
+	}()
+
+	// Connect to prove the listener is still open after more than one teardown.
+	time.Sleep(60 * time.Millisecond)
+	conn, dialErr := net.Dial("unix", sock)
+	require.NoError(t, dialErr)
+	conn.Close()
+
+	require.NoError(t, <-accepted)
+
+	// release the job so the watcher goroutine can eventually exit cleanly
+	cmd.runningJobs <- jobDone
+}
+
+// ---------------------------------------------------------------------------
+// isDisconnectError
+// ---------------------------------------------------------------------------
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestIsDisconnectError(t *testing.T) {
+	require.True(t, isDisconnectError(io.EOF))
+	require.True(t, isDisconnectError(io.ErrUnexpectedEOF))
+	require.True(t, isDisconnectError(timeoutErr{}))
+	require.False(t, isDisconnectError(io.ErrClosedPipe))
+	require.False(t, isDisconnectError(nil))
+}
+
+// ---------------------------------------------------------------------------
+// getSecret
+// ---------------------------------------------------------------------------
+
+func TestGetSecretNoEncryption(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+
+	config := storage.NewConfiguration()
+	config.Encryption = nil
+	wrapped := wrapConfig(t, config)
+
+	key, err := getSecret(ctx, []byte("ignored"), wrapped)
+	require.NoError(t, err)
+	require.Nil(t, key)
+}
+
+func TestGetSecretMalformedConfig(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+
+	_, err := getSecret(ctx, nil, []byte("not a wrapped config"))
+	require.Error(t, err)
+}
+
+func TestGetSecretWrongKey(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+
+	// build an encrypted configuration with a canary derived from the real key
+	config := storage.NewConfiguration()
+	passphrase := []byte("correct horse battery staple")
+	key, err := encryption.DeriveKey(config.Encryption.KDFParams, passphrase)
+	require.NoError(t, err)
+	canary, err := encryption.DeriveCanary(config.Encryption, key)
+	require.NoError(t, err)
+	config.Encryption.Canary = canary
+
+	wrapped := wrapConfig(t, config)
+
+	// correct key verifies
+	got, err := getSecret(ctx, key, wrapped)
+	require.NoError(t, err)
+	require.Equal(t, key, got)
+
+	// wrong key fails the canary check
+	_, err = getSecret(ctx, []byte("the wrong key......the wrong key"), wrapped)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to verify key")
+}

--- a/subcommands/cat/cat_coverage_test.go
+++ b/subcommands/cat/cat_coverage_test.go
@@ -1,0 +1,160 @@
+package cat
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"testing"
+
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func gzipString(t *testing.T, s string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write([]byte(s))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return buf.String()
+}
+
+// An entirely unknown snapshot prefix fails OpenSnapshotByPath and is reported
+// via the logger, returning exit status 1.
+func TestExecuteCmdCatUnknownSnapshot(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	snap.Close()
+
+	args := []string{"deadbeef:subdir/dummy.txt"}
+
+	cmd := &Cat{}
+	require.NoError(t, cmd.Parse(ctx, args))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, bufErr.String(), "cat:")
+}
+
+// Multiple paths in one invocation are concatenated to stdout in order.
+func TestExecuteCmdCatMultiplePaths(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("subdir/foo.txt", 0644, "hello foo"),
+	})
+	snap.Close()
+
+	args := []string{":subdir/dummy.txt", ":subdir/foo.txt"}
+
+	cmd := &Cat{}
+	require.NoError(t, cmd.Parse(ctx, args))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "hello dummyhello foo", bufOut.String())
+}
+
+// -decompress on a file that is not gzip is a no-op (the content type guard is
+// not satisfied) and the raw bytes are emitted unchanged.
+func TestExecuteCmdCatDecompressNonGzip(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	snap.Close()
+
+	args := []string{"-decompress", ":subdir/dummy.txt"}
+
+	cmd := &Cat{}
+	require.NoError(t, cmd.Parse(ctx, args))
+	require.True(t, cmd.Decompress)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "hello dummy", bufOut.String())
+}
+
+// -decompress on a genuine gzip file walks the gzip.NewReader branch and emits
+// the decompressed content.
+func TestExecuteCmdCatDecompressGzip(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/data.gz", 0644, gzipString(t, "decompressed payload")),
+	})
+	snap.Close()
+
+	args := []string{"-decompress", ":subdir/data.gz"}
+
+	cmd := &Cat{}
+	require.NoError(t, cmd.Parse(ctx, args))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "decompressed payload", bufOut.String())
+}
+
+// A path that resolves to a directory (not a regular file) is reported and
+// counts as an error, while other valid paths still succeed.
+func TestExecuteCmdCatMixedErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	snap.Close()
+
+	args := []string{
+		":subdir/dummy.txt",
+		fmt.Sprintf("%s:subdir/missing.txt", ""),
+	}
+
+	cmd := &Cat{}
+	require.NoError(t, cmd.Parse(ctx, args))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	// the valid file was still emitted
+	require.Contains(t, bufOut.String(), "hello dummy")
+	require.Contains(t, bufErr.String(), "no such file")
+}
+
+// Parse with no arguments is rejected.
+func TestExecuteCmdCatParseNoArgs(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Cat{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one parameter is required")
+}

--- a/subcommands/check/check_coverage_test.go
+++ b/subcommands/check/check_coverage_test.go
@@ -1,0 +1,122 @@
+package check
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/ui/stdio"
+	"github.com/stretchr/testify/require"
+)
+
+// An invalid (non-hex) snapshot prefix is rejected by Execute.
+func TestExecuteCmdCheckInvalidPrefix(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"zzzz:"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "invalid snapshot prefix")
+}
+
+// Checking a specific snapshot constrained to a sub-path walks the
+// path-scoped branch of Execute.
+func TestExecuteCmdCheckSnapshotWithPath(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	short := snap.Header.GetIndexShortID()
+	args := []string{fmt.Sprintf("%x:subdir", short)}
+
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, args))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// -fast and -no-verify flags flow through Parse and Execute without verifying
+// signatures or digests.
+func TestExecuteCmdCheckFastNoVerify(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-fast", "-no-verify"}))
+	require.True(t, cmd.FastCheck)
+	require.True(t, cmd.NoVerify)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// A valid hex prefix that matches no snapshot resolves to an empty set and
+// completes with no failures.
+func TestExecuteCmdCheckValidPrefixNoMatch(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"deadbeef:"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// Specifying both a snapshot and a filter warns that filters are ignored.
+func TestExecuteCmdCheckSnapshotWithFilterWarns(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+	_ = repo
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	defer renderer.Wait()
+	defer ctx.Close()
+
+	short := snap.Header.GetIndexShortID()
+	cmd := &Check{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-latest", fmt.Sprintf("%x", short)}))
+}

--- a/subcommands/config/config_more_test.go
+++ b/subcommands/config/config_more_test.go
@@ -1,0 +1,529 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	_ "github.com/PlakarKorp/integration-fs/importer"
+	_ "github.com/PlakarKorp/integration-fs/storage"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCtx builds an appcontext backed by a temporary config dir, mirroring
+// the setup used by the existing tests in this package.
+func newTestCtx(t *testing.T) (*appcontext.AppContext, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	tmpDir := t.TempDir()
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg, err := utils.LoadOldConfigIfExists(configPath)
+	require.NoError(t, err)
+
+	ctx := appcontext.NewAppContext()
+	ctx.ConfigDir = tmpDir
+	ctx.Config = cfg
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	return ctx, bufOut, bufErr
+}
+
+// ---------------------------------------------------------------------------
+// Parse() coverage for every command type, good and bad args.
+// ---------------------------------------------------------------------------
+
+func TestParseStore(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	// no action -> error
+	cmd := &ConfigStoreCmd{}
+	require.EqualError(t, cmd.Parse(ctx, []string{}), "no action specified")
+
+	// good args -> stored
+	cmd = &ConfigStoreCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"show", "foo"}))
+	require.Equal(t, []string{"show", "foo"}, cmd.args)
+}
+
+func TestParseSource(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	cmd := &ConfigSourceCmd{}
+	require.EqualError(t, cmd.Parse(ctx, []string{}), "no action specified")
+
+	cmd = &ConfigSourceCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"add", "n", "fs://x"}))
+	require.Equal(t, []string{"add", "n", "fs://x"}, cmd.args)
+}
+
+func TestParseDestination(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	cmd := &ConfigDestinationCmd{}
+	require.EqualError(t, cmd.Parse(ctx, []string{}), "no action specified")
+
+	cmd = &ConfigDestinationCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"rm", "n"}))
+	require.Equal(t, []string{"rm", "n"}, cmd.args)
+}
+
+func TestParsePolicy(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	cmd := &ConfigPolicyCmd{}
+	require.EqualError(t, cmd.Parse(ctx, []string{}), "no action specified")
+
+	cmd = &ConfigPolicyCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"add", "daily"}))
+	require.Equal(t, []string{"add", "daily"}, cmd.args)
+}
+
+// ---------------------------------------------------------------------------
+// Execute path: end-to-end through Parse + Execute for store/source/dest.
+// ---------------------------------------------------------------------------
+
+func TestExecuteStoreAddAndShow(t *testing.T) {
+	ctx, bufOut, _ := newTestCtx(t)
+	repo := &repository.Repository{}
+
+	add := &ConfigStoreCmd{}
+	require.NoError(t, add.Parse(ctx, []string{"add", "r1", "fs:///tmp/r1"}))
+	status, err := add.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	show := &ConfigStoreCmd{}
+	require.NoError(t, show.Parse(ctx, []string{"show", "r1"}))
+	status, err = show.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "r1")
+	require.Contains(t, bufOut.String(), "location")
+}
+
+func TestExecuteStoreError(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	repo := &repository.Repository{}
+
+	// rm of a non-existent store -> Execute returns status 1 + error
+	rm := &ConfigStoreCmd{}
+	require.NoError(t, rm.Parse(ctx, []string{"rm", "nope"}))
+	status, err := rm.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// ---------------------------------------------------------------------------
+// dispatchSubcommand: exhaustive over store/source/destination + subcommands.
+// ---------------------------------------------------------------------------
+
+func TestDispatchUnknownCmd(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	err := dispatchSubcommand(ctx, "bogus", "show", nil)
+	require.EqualError(t, err, `unknown cmd "bogus"`)
+}
+
+func TestDispatchUnknownSubcommand(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	err := dispatchSubcommand(ctx, "store", "frobnicate", nil)
+	require.EqualError(t, err, "usage: plakar store [add|check|import|ping|rm|set|show|unset]")
+}
+
+func TestDispatchAdd(t *testing.T) {
+	for _, cmd := range []string{"store", "source", "destination"} {
+		t.Run(cmd, func(t *testing.T) {
+			ctx, _, _ := newTestCtx(t)
+
+			// too few args
+			err := dispatchSubcommand(ctx, cmd, "add", []string{"only-name"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "<name> <location>")
+
+			// good add with @-prefixed name and location= prefix + extra kv
+			err = dispatchSubcommand(ctx, cmd, "add", []string{"@thing", "location=fs:///tmp/x", "opt=val"})
+			require.NoError(t, err)
+
+			// duplicate add -> already exists
+			err = dispatchSubcommand(ctx, cmd, "add", []string{"thing", "fs:///tmp/x"})
+			require.EqualError(t, err, cmd+` "thing" already exists`)
+
+			// bad kv (no '=')
+			err = dispatchSubcommand(ctx, cmd, "add", []string{"other", "fs:///tmp/y", "badkv"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "<key>=<value>")
+		})
+	}
+}
+
+func TestDispatchSetUnset(t *testing.T) {
+	for _, cmd := range []string{"store", "source", "destination"} {
+		t.Run(cmd, func(t *testing.T) {
+			ctx, _, _ := newTestCtx(t)
+			require.NoError(t, dispatchSubcommand(ctx, cmd, "add", []string{"n", "fs:///tmp/x"}))
+
+			// set good
+			require.NoError(t, dispatchSubcommand(ctx, cmd, "set", []string{"n", "a=1", "b=2"}))
+
+			// set too few args
+			err := dispatchSubcommand(ctx, cmd, "set", []string{"n"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "<key>=<value>")
+
+			// set on missing name
+			err = dispatchSubcommand(ctx, cmd, "set", []string{"missing", "a=1"})
+			require.EqualError(t, err, cmd+` "missing" does not exist`)
+
+			// set bad kv
+			err = dispatchSubcommand(ctx, cmd, "set", []string{"n", "nope"})
+			require.Error(t, err)
+
+			// unset good
+			require.NoError(t, dispatchSubcommand(ctx, cmd, "unset", []string{"n", "a"}))
+
+			// unset location forbidden
+			err = dispatchSubcommand(ctx, cmd, "unset", []string{"n", "location"})
+			require.EqualError(t, err, "cannot unset location")
+
+			// unset too few args
+			err = dispatchSubcommand(ctx, cmd, "unset", []string{"n"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "<key>")
+
+			// unset missing name
+			err = dispatchSubcommand(ctx, cmd, "unset", []string{"missing", "a"})
+			require.EqualError(t, err, cmd+` "missing" does not exist`)
+		})
+	}
+}
+
+func TestDispatchRm(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"n", "fs:///tmp/x"}))
+
+	// rm too many args
+	err := dispatchSubcommand(ctx, "store", "rm", []string{"a", "b"})
+	require.Error(t, err)
+
+	// rm missing
+	err = dispatchSubcommand(ctx, "store", "rm", []string{"missing"})
+	require.EqualError(t, err, `store "missing" does not exist`)
+
+	// rm good
+	require.NoError(t, dispatchSubcommand(ctx, "store", "rm", []string{"n"}))
+	require.False(t, ctx.Config.HasRepository("n"))
+}
+
+func TestDispatchShowFormats(t *testing.T) {
+	ctx, bufOut, bufErr := newTestCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add",
+		[]string{"n", "fs:///tmp/x", "access_key=topsecret", "plain=visible"}))
+
+	// secrets revealed first (show masks cfgMap in place, so test -secrets before masking)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", []string{"-secrets", "n"}))
+	require.Contains(t, bufOut.String(), "topsecret")
+	bufOut.Reset()
+
+	// json
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", []string{"-json", "n"}))
+	require.Contains(t, bufOut.String(), `"n"`)
+	bufOut.Reset()
+
+	// ini
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", []string{"-ini", "n"}))
+	require.Contains(t, bufOut.String(), "[n]")
+	bufOut.Reset()
+
+	// default (yaml) hides secrets
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", []string{"n"}))
+	out := bufOut.String()
+	require.Contains(t, out, "********")
+	require.Contains(t, out, "visible")
+	bufOut.Reset()
+
+	// no names -> dumps all
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", nil))
+	require.Contains(t, bufOut.String(), "n")
+	bufOut.Reset()
+
+	// unknown name -> stderr message + aggregate error
+	err := dispatchSubcommand(ctx, "store", "show", []string{"ghost"})
+	require.EqualError(t, err, "one or more stores do not exist")
+	require.Contains(t, bufErr.String(), `store "ghost" does not exist`)
+}
+
+// ---------------------------------------------------------------------------
+// check / ping success and error branches per command type.
+// ---------------------------------------------------------------------------
+
+func TestDispatchCheckStore(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	// missing name
+	err := dispatchSubcommand(ctx, "store", "check", []string{"missing"})
+	require.EqualError(t, err, `store "missing" does not exist`)
+
+	// wrong arg count
+	err = dispatchSubcommand(ctx, "store", "check", []string{"a", "b"})
+	require.EqualError(t, err, "usage: plakar store check <name>")
+
+	// good: fs storage never does I/O on New/Close
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"s", "fs:///tmp/store-check"}))
+	require.NoError(t, dispatchSubcommand(ctx, "store", "check", []string{"s"}))
+
+	// unknown backend -> error from storage.New
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"bad", "invalid://x"}))
+	err = dispatchSubcommand(ctx, "store", "check", []string{"bad"})
+	require.Error(t, err)
+}
+
+func TestDispatchPingStore(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	// wrong arg count
+	err := dispatchSubcommand(ctx, "store", "ping", nil)
+	require.EqualError(t, err, "usage: plakar store ping <name>")
+
+	// missing name
+	err = dispatchSubcommand(ctx, "store", "ping", []string{"missing"})
+	require.EqualError(t, err, `store "missing" does not exist`)
+
+	// good
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"s", "fs:///tmp/store-ping"}))
+	require.NoError(t, dispatchSubcommand(ctx, "store", "ping", []string{"s"}))
+
+	// unknown backend
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"bad", "invalid://x"}))
+	err = dispatchSubcommand(ctx, "store", "ping", []string{"bad"})
+	require.Error(t, err)
+}
+
+func TestDispatchCheckPingSource(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	dir := t.TempDir() // existing dir, required by fs importer
+
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"s", "fs://" + dir}))
+	require.NoError(t, dispatchSubcommand(ctx, "source", "check", []string{"s"}))
+	require.NoError(t, dispatchSubcommand(ctx, "source", "ping", []string{"s"}))
+
+	// unsupported protocol -> NewImporter error
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"bad", "invalid://nope"}))
+	require.Error(t, dispatchSubcommand(ctx, "source", "check", []string{"bad"}))
+	require.Error(t, dispatchSubcommand(ctx, "source", "ping", []string{"bad"}))
+}
+
+func TestDispatchCheckPingDestination(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	dir := t.TempDir()
+
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"d", "fs://" + dir}))
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "check", []string{"d"}))
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "ping", []string{"d"}))
+
+	// unsupported protocol -> NewExporter error
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"bad", "invalid://nope"}))
+	require.Error(t, dispatchSubcommand(ctx, "destination", "check", []string{"bad"}))
+	require.Error(t, dispatchSubcommand(ctx, "destination", "ping", []string{"bad"}))
+}
+
+// ---------------------------------------------------------------------------
+// import subcommand.
+// ---------------------------------------------------------------------------
+
+func TestDispatchImportFromFile(t *testing.T) {
+	ctx, _, bufErr := newTestCtx(t)
+
+	// Write an INI-style config file with two sections.
+	cfgFile := filepath.Join(t.TempDir(), "in.ini")
+	content := "[alpha]\nlocation = fs:///tmp/alpha\n\n[beta]\nlocation = fs:///tmp/beta\n"
+	require.NoError(t, os.WriteFile(cfgFile, []byte(content), 0644))
+
+	// import all sections
+	require.NoError(t, dispatchSubcommand(ctx, "store", "import", []string{"-config", cfgFile}))
+	require.True(t, ctx.Config.HasRepository("alpha"))
+	require.True(t, ctx.Config.HasRepository("beta"))
+
+	// re-import without overwrite -> skipped messages on stderr
+	require.NoError(t, dispatchSubcommand(ctx, "store", "import", []string{"-config", cfgFile}))
+	require.Contains(t, bufErr.String(), "already exists, skipping")
+
+	// import a specific section with rename
+	require.NoError(t, dispatchSubcommand(ctx, "store", "import",
+		[]string{"-config", cfgFile, "alpha:alpha-copy"}))
+	require.True(t, ctx.Config.HasRepository("alpha-copy"))
+
+	// requesting a non-existent section
+	bufErr.Reset()
+	require.NoError(t, dispatchSubcommand(ctx, "store", "import",
+		[]string{"-config", cfgFile, "ghost"}))
+	require.Contains(t, bufErr.String(), `does not exist in config`)
+}
+
+func TestDispatchImportErrors(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	// non-existent file
+	err := dispatchSubcommand(ctx, "store", "import", []string{"-config", "/no/such/file.ini"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to open file")
+
+	// malformed/empty config -> GetConf fails -> "failed to load config"
+	empty := filepath.Join(t.TempDir(), "empty.ini")
+	require.NoError(t, os.WriteFile(empty, []byte(""), 0644))
+	err = dispatchSubcommand(ctx, "store", "import", []string{"-config", empty})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to load config")
+}
+
+// ---------------------------------------------------------------------------
+// dispatchPolicy: add/rm/set/unset/show + error branches.
+// ---------------------------------------------------------------------------
+
+func TestDispatchPolicyUnknown(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	err := dispatchPolicy(ctx, "policy", "frobnicate", nil)
+	require.EqualError(t, err, "usage: plakar policy [add|rm|set|show|unset]")
+}
+
+func TestDispatchPolicyAdd(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+
+	// no name
+	err := dispatchPolicy(ctx, "policy", "add", []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "<name>")
+
+	// good add with valid key=value (name is a string filter field)
+	require.NoError(t, dispatchPolicy(ctx, "policy", "add", []string{"@daily", "name=foo", "days=3"}))
+
+	// duplicate
+	err = dispatchPolicy(ctx, "policy", "add", []string{"daily"})
+	require.EqualError(t, err, `policy "daily" already exists`)
+
+	// bad kv (no '=')
+	err = dispatchPolicy(ctx, "policy", "add", []string{"other", "badkv"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "<key>=<value>")
+
+	// invalid policy key -> failed to set key
+	err = dispatchPolicy(ctx, "policy", "add", []string{"another", "boguskey=1"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to set key")
+}
+
+func TestDispatchPolicySetUnset(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	require.NoError(t, dispatchPolicy(ctx, "policy", "add", []string{"p"}))
+
+	// set good
+	require.NoError(t, dispatchPolicy(ctx, "policy", "set", []string{"p", "days=7"}))
+
+	// set too few args
+	err := dispatchPolicy(ctx, "policy", "set", []string{"p"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "<key>=<value>")
+
+	// set missing name
+	err = dispatchPolicy(ctx, "policy", "set", []string{"missing", "days=1"})
+	require.EqualError(t, err, `policy "missing" does not exist`)
+
+	// set bad kv
+	err = dispatchPolicy(ctx, "policy", "set", []string{"p", "nope"})
+	require.Error(t, err)
+
+	// set invalid key
+	err = dispatchPolicy(ctx, "policy", "set", []string{"p", "bogus=1"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to set key")
+
+	// unset good
+	require.NoError(t, dispatchPolicy(ctx, "policy", "unset", []string{"p", "days"}))
+
+	// unset too few args
+	err = dispatchPolicy(ctx, "policy", "unset", []string{"p"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "<key>")
+
+	// unset missing name
+	err = dispatchPolicy(ctx, "policy", "unset", []string{"missing", "days"})
+	require.EqualError(t, err, `policy "missing" does not exist`)
+}
+
+func TestDispatchPolicyRm(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	require.NoError(t, dispatchPolicy(ctx, "policy", "add", []string{"p"}))
+
+	// too many args
+	err := dispatchPolicy(ctx, "policy", "rm", []string{"a", "b"})
+	require.Error(t, err)
+
+	// missing
+	err = dispatchPolicy(ctx, "policy", "rm", []string{"missing"})
+	require.EqualError(t, err, `policy "missing" does not exist`)
+
+	// good
+	require.NoError(t, dispatchPolicy(ctx, "policy", "rm", []string{"p"}))
+}
+
+func TestDispatchPolicyShow(t *testing.T) {
+	ctx, bufOut, _ := newTestCtx(t)
+	require.NoError(t, dispatchPolicy(ctx, "policy", "add", []string{"p", "days=2"}))
+
+	// yaml (default), named
+	require.NoError(t, dispatchPolicy(ctx, "policy", "show", []string{"p"}))
+	require.Contains(t, bufOut.String(), "p")
+	bufOut.Reset()
+
+	// json
+	require.NoError(t, dispatchPolicy(ctx, "policy", "show", []string{"-json", "p"}))
+	require.True(t, strings.Contains(bufOut.String(), "{") || strings.Contains(bufOut.String(), "p"))
+	bufOut.Reset()
+
+	// no names -> all
+	require.NoError(t, dispatchPolicy(ctx, "policy", "show", nil))
+}
+
+func TestExecutePolicyEndToEnd(t *testing.T) {
+	ctx, _, _ := newTestCtx(t)
+	repo := &repository.Repository{}
+
+	add := &ConfigPolicyCmd{}
+	require.NoError(t, add.Parse(ctx, []string{"add", "daily", "days=5"}))
+	status, err := add.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// error path through Execute: rm missing -> status 1
+	rm := &ConfigPolicyCmd{}
+	require.NoError(t, rm.Parse(ctx, []string{"rm", "ghost"}))
+	status, err = rm.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers.
+// ---------------------------------------------------------------------------
+
+func TestNormalizeHelpers(t *testing.T) {
+	require.Equal(t, "name", normalizeName("@name"))
+	require.Equal(t, "name", normalizeName("name"))
+	require.Equal(t, "fs://x", normalizeLocation("location=fs://x"))
+	require.Equal(t, "fs://x", normalizeLocation("fs://x"))
+}
+
+func TestMarshalINISections(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, MarshalINISections("sect", map[string]string{"k": "v"}, &buf))
+	out := buf.String()
+	require.Contains(t, out, "[sect]")
+	require.Contains(t, out, "k")
+	require.Contains(t, out, "v")
+}

--- a/subcommands/diag/diag_more2_test.go
+++ b/subcommands/diag/diag_more2_test.go
@@ -1,0 +1,270 @@
+package diag
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// run is a small helper that looks up, parses and executes a diag subcommand,
+// returning the status and execution error. Parse errors are surfaced via the
+// returned parseErr.
+func run(t *testing.T, ctx *appcontext.AppContext, repo *repository.Repository, args ...string) (status int, execErr error, parseErr error) {
+	t.Helper()
+	subcommand, _, rest := subcommands.Lookup(args)
+	require.NotNil(t, subcommand)
+	if perr := subcommand.Parse(ctx, rest); perr != nil {
+		return 0, nil, perr
+	}
+	status, execErr = subcommand.Execute(ctx, repo)
+	return status, execErr, nil
+}
+
+func TestDiagStateListAndErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// No args: lists state ids (one per line).
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "state")
+	require.NoError(t, parseErr)
+	require.NoError(t, execErr)
+	require.Equal(t, 0, status)
+	require.NotEmpty(t, strings.TrimSpace(bufOut.String()))
+
+	// Wrong-length hash -> Execute error.
+	bufOut.Reset()
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "state", "deadbeef")
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+	require.Contains(t, execErr.Error(), "invalid packfile hash")
+
+	// Right length but invalid hex -> Execute error.
+	bufOut.Reset()
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "state", strings.Repeat("zz", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+}
+
+func TestDiagPackfileListAndErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// No args: lists packfile ids.
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "packfile")
+	require.NoError(t, parseErr)
+	require.NoError(t, execErr)
+	require.Equal(t, 0, status)
+	require.NotEmpty(t, strings.TrimSpace(bufOut.String()))
+
+	// Wrong-length hash -> Execute error.
+	bufOut.Reset()
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "packfile", "deadbeef")
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+	require.Contains(t, execErr.Error(), "invalid packfile hash")
+
+	// Right length but invalid hex -> Execute error.
+	bufOut.Reset()
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "packfile", strings.Repeat("zz", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+
+	// Valid length & hex but unknown packfile -> GetPackfile error.
+	bufOut.Reset()
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "packfile", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+}
+
+func TestDiagObjectErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Missing argument -> Parse error.
+	_, _, parseErr := run(t, ctx, repo, "diag", "object")
+	require.Error(t, parseErr)
+
+	// Wrong-length hash -> Execute error.
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "object", "deadbeef")
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+	require.Contains(t, execErr.Error(), "invalid object hash")
+
+	// Right length, invalid hex -> Execute error.
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "object", strings.Repeat("zz", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+
+	// Valid hash that does not exist -> GetBlob error.
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "object", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+}
+
+func TestDiagVFSErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Missing argument -> Parse error.
+	_, _, parseErr := run(t, ctx, repo, "diag", "vfs")
+	require.Error(t, parseErr)
+
+	// Unknown snapshot prefix -> Execute error from OpenSnapshotByPath.
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "vfs", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+
+	// Valid snapshot but missing path -> GetEntry error.
+	indexID := snap.Header.GetIndexID()
+	status, execErr, parseErr = run(t, ctx, repo,
+		"diag", "vfs", hex.EncodeToString(indexID[:])+":/does/not/exist")
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+}
+
+func TestDiagXattrErrorsAndDirVariant(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Missing argument -> Parse error.
+	_, _, parseErr := run(t, ctx, repo, "diag", "xattr")
+	require.Error(t, parseErr)
+
+	// Unknown snapshot prefix -> Execute error.
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "xattr", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+
+	// Snapshot with no path: pathname defaults to "/" and the directory branch
+	// runs over an empty xattr tree (no output, status 0).
+	bufOut.Reset()
+	indexID := snap.Header.GetIndexID()
+	status, execErr, parseErr = run(t, ctx, repo,
+		"diag", "xattr", hex.EncodeToString(indexID[:]))
+	require.NoError(t, parseErr)
+	require.NoError(t, execErr)
+	require.Equal(t, 0, status)
+}
+
+func TestDiagContentTypeErrorsAndVariant(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Missing argument -> Parse error.
+	_, _, parseErr := run(t, ctx, repo, "diag", "contenttype")
+	require.Error(t, parseErr)
+
+	// Unknown snapshot prefix -> Execute error.
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "contenttype", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+
+	// No path: defaults pathname to "/" and walks the whole content-type index.
+	bufOut.Reset()
+	indexID := snap.Header.GetIndexID()
+	status, execErr, parseErr = run(t, ctx, repo,
+		"diag", "contenttype", hex.EncodeToString(indexID[:]))
+	require.NoError(t, parseErr)
+	require.NoError(t, execErr)
+	require.Equal(t, 0, status)
+}
+
+func TestDiagSearchVariantsAndErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// No args -> Parse error (default branch of the NArg switch).
+	_, _, parseErr := run(t, ctx, repo, "diag", "search")
+	require.Error(t, parseErr)
+
+	// Three args -> Parse error.
+	_, _, parseErr = run(t, ctx, repo, "diag", "search", "a", "b", "c")
+	require.Error(t, parseErr)
+
+	indexID := snap.Header.GetIndexID()
+	// Two-arg form with a mime filter exercises the case-2 parse branch.
+	bufOut.Reset()
+	status, execErr, parseErr := run(t, ctx, repo,
+		"diag", "search", hex.EncodeToString(indexID[:])+":subdir/", "text/plain")
+	require.NoError(t, parseErr)
+	require.NoError(t, execErr)
+	require.Equal(t, 0, status)
+
+	// Unknown snapshot prefix -> Execute error.
+	bufOut.Reset()
+	status, execErr, parseErr = run(t, ctx, repo, "diag", "search", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+}
+
+func TestDiagSnapshotBadIDError(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Unknown snapshot id -> Execute error.
+	status, execErr, parseErr := run(t, ctx, repo, "diag", "snapshot", strings.Repeat("00", 32))
+	require.NoError(t, parseErr)
+	require.Error(t, execErr)
+	require.Equal(t, 1, status)
+}
+
+func TestDiagRepositoryEncrypted(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	passphrase := []byte("a-very-strong-test-passphrase")
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap.Close()
+
+	// Default `diag` over an encrypted repo prints the Encryption block.
+	status, execErr, parseErr := run(t, ctx, repo, "diag")
+	require.NoError(t, parseErr)
+	require.NoError(t, execErr)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.Contains(t, output, "Encryption:")
+	require.Contains(t, output, "KDF:")
+	require.Contains(t, output, "Canary:")
+	require.Contains(t, output, "Snapshots: 1")
+}

--- a/subcommands/diag/diag_more_test.go
+++ b/subcommands/diag/diag_more_test.go
@@ -1,0 +1,274 @@
+package diag
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// dumpState runs `diag state` (no args) to get the state id, then `diag state
+// <id>` and returns the detailed listing (lines like "chunk <mac> : ...").
+func dumpState(t *testing.T, ctx *appcontext.AppContext, repo *repository.Repository, bufOut *bytes.Buffer) string {
+	t.Helper()
+
+	bufOut.Reset()
+	args := []string{"diag", "state"}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	stateID := strings.Trim(bufOut.String(), "\n")
+	require.NotEmpty(t, stateID)
+
+	bufOut.Reset()
+	args = []string{"diag", "state", stateID}
+	subcommand, _, args = subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err = subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	return bufOut.String()
+}
+
+// macForPrefix returns the MAC of the first state line starting with prefix
+// (e.g. "chunk ", "object ").
+func macForPrefix(t *testing.T, stateOutput, prefix string) string {
+	t.Helper()
+	for _, line := range strings.Split(stateOutput, "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		var mac, packfile []byte
+		var offset, length int
+		format := prefix + "%x : packfile %x, offset %d, length %d"
+		if _, err := fmt.Sscanf(line, format, &mac, &packfile, &offset, &length); err == nil && len(mac) == 32 {
+			return hex.EncodeToString(mac)
+		}
+	}
+	t.Fatalf("no %q entry found in state output", prefix)
+	return ""
+}
+
+func TestExecuteCmdDiagBlobSnapshot(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	stateOut := dumpState(t, ctx, repo, bufOut)
+	snapMAC := macForPrefix(t, stateOut, "snapshot ")
+
+	bufOut.Reset()
+	args := []string{"diag", "blob", "snapshot", snapMAC}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	require.NotNil(t, subcommand)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.NotEmpty(t, strings.TrimSpace(bufOut.String()))
+}
+
+func TestExecuteCmdDiagBlobObject(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	stateOut := dumpState(t, ctx, repo, bufOut)
+	objectMAC := macForPrefix(t, stateOut, "object ")
+
+	bufOut.Reset()
+	args := []string{"diag", "blob", "object", objectMAC}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.NotEmpty(t, strings.TrimSpace(bufOut.String()))
+}
+
+func TestExecuteCmdDiagBlobParseAndExecuteErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Missing arguments -> Parse error.
+	args := []string{"diag", "blob", "chunk"}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.Error(t, subcommand.Parse(ctx, args))
+
+	// Unknown blob type -> Execute error.
+	args = []string{"diag", "blob", "not-a-type", strings.Repeat("00", 32)}
+	subcommand, _, args = subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err := subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Bad hex mac -> Execute error.
+	args = []string{"diag", "blob", "chunk", "zz"}
+	subcommand, _, args = subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err = subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Wrong mac length -> Execute error.
+	args = []string{"diag", "blob", "chunk", "00ff"}
+	subcommand, _, args = subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err = subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestExecuteCmdDiagBlobSearch(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	stateOut := dumpState(t, ctx, repo, bufOut)
+	objectMAC := macForPrefix(t, stateOut, "object ")
+
+	bufOut.Reset()
+	args := []string{"diag", "blobsearch", objectMAC}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	require.NotNil(t, subcommand)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.Contains(t, output, "Warning this command is slow and expensive")
+	require.Contains(t, output, "Found candidate")
+	require.Contains(t, output, "object: ")
+}
+
+func TestExecuteCmdDiagBlobSearchErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Missing argument -> Parse error.
+	args := []string{"diag", "blobsearch"}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.Error(t, subcommand.Parse(ctx, args))
+
+	// Wrong-length hash -> Execute error.
+	bufOut.Reset()
+	args = []string{"diag", "blobsearch", "deadbeef"}
+	subcommand, _, args = subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err := subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Right length but invalid hex -> Execute error.
+	bufOut.Reset()
+	args = []string{"diag", "blobsearch", strings.Repeat("zz", 32)}
+	subcommand, _, args = subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err = subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestExecuteCmdDiagDirPack(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	args := []string{"diag", "dirpack", hex.EncodeToString(indexID[:])}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	require.NotNil(t, subcommand)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.Contains(t, bufOut.String(), "vfs-entry ")
+}
+
+func TestExecuteCmdDiagDirPackParseError(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	args := []string{"diag", "dirpack"}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.Error(t, subcommand.Parse(ctx, args))
+}
+
+func TestExecuteCmdDiagDirPackBadSnapshot(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	args := []string{"diag", "dirpack", strings.Repeat("00", 32)}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	status, err := subcommand.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestExecuteCmdDiagRepository(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Default action: `diag` with no subcommand maps to DiagRepository.
+	args := []string{"diag"}
+	subcommand, _, args := subcommands.Lookup(args)
+	require.NoError(t, subcommand.Parse(ctx, args))
+	require.NotNil(t, subcommand)
+
+	status, err := subcommand.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.Contains(t, output, "Version:")
+	require.Contains(t, output, "RepositoryID:")
+	require.Contains(t, output, "Packfile:")
+	require.Contains(t, output, "Chunking:")
+	require.Contains(t, output, "Hashing:")
+	require.Contains(t, output, "Snapshots: 1")
+	require.Contains(t, output, "Size:")
+}

--- a/subcommands/diff/diff_more_test.go
+++ b/subcommands/diff/diff_more_test.go
@@ -1,0 +1,288 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func shortID(snap *snapshot.Snapshot) string {
+	id := snap.Header.GetIndexShortID()
+	return hex.EncodeToString(id[:])
+}
+
+func twoSnapshots(t *testing.T, bufOut, bufErr *bytes.Buffer, files1, files2 []ptesting.MockFile) (*repository.Repository, *appcontext.AppContext, *snapshot.Snapshot, *snapshot.Snapshot) {
+	t.Helper()
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap1 := ptesting.GenerateSnapshot(t, repo, files1)
+	snap2 := ptesting.GenerateSnapshot(t, repo, files2)
+	t.Cleanup(func() { snap1.Close(); snap2.Close() })
+	return repo, ctx, snap1, snap2
+}
+
+func TestDiffParse(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	// One positional arg: Path1 set, Path2 empty.
+	cmd := &Diff{}
+	err := cmd.Parse(ctx, []string{"abc:/x"})
+	require.NoError(t, err)
+	require.Equal(t, "abc:/x", cmd.Path1)
+	require.Equal(t, "", cmd.Path2)
+	require.Equal(t, "diff", cmd.Name())
+
+	// Two positional args.
+	cmd = &Diff{}
+	err = cmd.Parse(ctx, []string{"a:/x", "b:/y"})
+	require.NoError(t, err)
+	require.Equal(t, "a:/x", cmd.Path1)
+	require.Equal(t, "b:/y", cmd.Path2)
+
+	// Flags are honoured.
+	cmd = &Diff{}
+	err = cmd.Parse(ctx, []string{"-highlight", "-recursive", "a:/x", "b:/y"})
+	require.NoError(t, err)
+	require.True(t, cmd.Highlight)
+	require.True(t, cmd.Recursive)
+
+	// No positional args -> error.
+	cmd = &Diff{}
+	err = cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+}
+
+func TestDiffExecuteSameFile(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	files := []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	}
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr, files, files)
+
+	cmd := &Diff{
+		Path1: fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap1)),
+		Path2: fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// Identical files produce no unified-diff body.
+	require.NotContains(t, bufOut.String(), "@@")
+}
+
+func TestDiffExecuteChangedFile(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr,
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy\n"),
+		},
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy changed\n"),
+		},
+	)
+
+	cmd := &Diff{
+		Path1: fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap1)),
+		Path2: fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.Contains(t, output, "@@")
+	require.Contains(t, output, "-hello dummy")
+	require.Contains(t, output, "+hello dummy changed")
+}
+
+func TestDiffExecuteHighlight(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr,
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy\n"),
+		},
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy changed\n"),
+		},
+	)
+
+	cmd := &Diff{
+		Highlight: true,
+		Path1:     fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap1)),
+		Path2:     fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// Highlighted output still carries the changed content.
+	require.Contains(t, bufOut.String(), "hello dummy changed")
+}
+
+func TestDiffExecuteDirFlat(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr,
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockDir("subdir/common"),
+			ptesting.NewMockFile("subdir/only1.txt", 0644, "one"),
+			ptesting.NewMockFile("subdir/shared.txt", 0644, "shared"),
+		},
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockDir("subdir/common"),
+			ptesting.NewMockFile("subdir/only2.txt", 0644, "two"),
+			ptesting.NewMockFile("subdir/shared.txt", 0644, "shared"),
+		},
+	)
+
+	cmd := &Diff{
+		Path1: fmt.Sprintf("%s:/subdir", shortID(snap1)),
+		Path2: fmt.Sprintf("%s:/subdir", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.Contains(t, output, "only1.txt")
+	require.Contains(t, output, "only2.txt")
+	require.Contains(t, output, "Common subdirectories")
+}
+
+func TestDiffExecuteDirRecursive(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr,
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockDir("subdir/nested"),
+			ptesting.NewMockFile("subdir/nested/file.txt", 0644, "content a\n"),
+			ptesting.NewMockFile("subdir/top.txt", 0644, "top\n"),
+		},
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockDir("subdir/nested"),
+			ptesting.NewMockFile("subdir/nested/file.txt", 0644, "content b\n"),
+			ptesting.NewMockFile("subdir/top.txt", 0644, "top\n"),
+		},
+	)
+
+	cmd := &Diff{
+		Recursive: true,
+		Path1:     fmt.Sprintf("%s:/subdir", shortID(snap1)),
+		Path2:     fmt.Sprintf("%s:/subdir", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.Contains(t, output, "Common subdirectories")
+	require.Contains(t, output, "nested")
+	// nested/file.txt differs -> unified diff emitted.
+	require.Contains(t, output, "-content a")
+	require.Contains(t, output, "+content b")
+}
+
+func TestDiffExecuteBinary(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	// Embed a NUL byte to make the content classify as binary.
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr,
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/bin.dat", 0644, "abc\x00def"),
+		},
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/bin.dat", 0644, "abc\x00xyz"),
+		},
+	)
+
+	cmd := &Diff{
+		Path1: fmt.Sprintf("%s:/subdir/bin.dat", shortID(snap1)),
+		Path2: fmt.Sprintf("%s:/subdir/bin.dat", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "Binary files")
+}
+
+func TestDiffExecuteTypeMismatch(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	// snap1 has /subdir/item as a file, snap2 has /subdir/item as a dir.
+	repo, ctx, snap1, snap2 := twoSnapshots(t, bufOut, bufErr,
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockFile("subdir/item", 0644, "i am a file"),
+		},
+		[]ptesting.MockFile{
+			ptesting.NewMockDir("subdir"),
+			ptesting.NewMockDir("subdir/item"),
+			ptesting.NewMockFile("subdir/item/inner.txt", 0644, "inner"),
+		},
+	)
+
+	cmd := &Diff{
+		Path1: fmt.Sprintf("%s:/subdir/item", shortID(snap1)),
+		Path2: fmt.Sprintf("%s:/subdir/item", shortID(snap2)),
+	}
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "different file types")
+}
+
+func TestDiffExecuteBadSnapshot(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello"),
+	})
+	defer snap.Close()
+
+	// First path bad.
+	cmd := &Diff{Path1: "deadbeef:/subdir/dummy.txt"}
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Second path bad.
+	cmd = &Diff{
+		Path1: fmt.Sprintf("%s:/subdir/dummy.txt", shortID(snap)),
+		Path2: "deadbeef:/subdir/dummy.txt",
+	}
+	status, err = cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}

--- a/subcommands/dup/dup_test.go
+++ b/subcommands/dup/dup_test.go
@@ -1,0 +1,92 @@
+package dup
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func generateSnapshot(t *testing.T, bufOut, bufErr *bytes.Buffer) (*repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	return repo, snap, ctx
+}
+
+func TestParseNoArgsErrors(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+
+	cmd := &Dup{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one parameter is required")
+}
+
+func TestParseStoresSnapshotIDs(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	defer ctx.Close()
+
+	cmd := &Dup{}
+	err := cmd.Parse(ctx, []string{"aabbcc", "ddeeff:/path"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"aabbcc", "ddeeff:/path"}, cmd.SnapshotIDS)
+}
+
+// Lookup should return a *Dup for the registered "dup" command.
+func TestLookupRegistersDup(t *testing.T) {
+	subcommand, _, _ := subcommands.Lookup([]string{"dup", "aabbcc"})
+	require.NotNil(t, subcommand)
+	_, ok := subcommand.(*Dup)
+	require.True(t, ok)
+}
+
+// Execute against a real snapshot duplicates it without error.
+func TestExecuteDuplicatesSnapshot(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	cmd := &Dup{}
+	require.NoError(t, cmd.Parse(ctx, []string{hex.EncodeToString(indexID[:])}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// Execute with a bogus snapshot id exercises the error/continue path and still
+// returns status 0 (errors are only counted, not returned).
+func TestExecuteBadSnapshotID(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Dup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"deadbeefdeadbeef"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufErr.String(), "deadbeefdeadbeef")
+}

--- a/subcommands/info/info_coverage_test.go
+++ b/subcommands/info/info_coverage_test.go
@@ -1,0 +1,102 @@
+package info
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// executeRepository over an encrypted repo exercises the Encryption branch
+// (SubkeyAlgorithm, Canary, KDF/ARGON2ID params) that the unencrypted default
+// test never reaches.
+func TestExecuteCmdInfoEncryptedRepository(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	passphrase := []byte("correct-horse-battery-staple")
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap.Close()
+
+	cmd := &Info{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.Contains(t, out, "Encryption:")
+	require.Contains(t, out, "KDF: ARGON2ID")
+	require.Contains(t, out, "Snapshots: 1")
+}
+
+// An unknown snapshot id must surface as an error from executeSnapshot.
+func TestExecuteCmdInfoSnapshotNotFound(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Info{SnapshotID: "deadbeefdeadbeefdeadbeefdeadbeef"}
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// info -errors on an unknown snapshot id goes through executeErrors and errors
+// out on snapshot open.
+func TestExecuteCmdInfoErrorsSnapshotNotFound(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Info{SnapshotID: "deadbeefdeadbeefdeadbeefdeadbeef", Errors: true}
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// info -errors on a valid snapshot with no errors walks executeErrors to
+// completion (returns 0 and prints nothing about errors).
+func TestExecuteCmdInfoErrorsValidSnapshot(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	cmd := &Info{Errors: true}
+	require.NoError(t, cmd.Parse(ctx, []string{"-errors"}))
+	cmd.SnapshotID = hex.EncodeToString(indexID[:])
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// Parse rejects more than one positional argument.
+func TestExecuteCmdInfoTooManyArgs(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+	_ = repo
+
+	cmd := &Info{}
+	err := cmd.Parse(ctx, []string{"a", "b"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}

--- a/subcommands/login/login_test.go
+++ b/subcommands/login/login_test.go
@@ -1,0 +1,186 @@
+package login
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestContext builds a hermetic AppContext backed by an on-disk
+// cookies.Manager rooted in a temp dir. Stdout is wired to a buffer.
+func newTestContext(t *testing.T) (*appcontext.AppContext, *bytes.Buffer) {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	bufOut := bytes.NewBuffer(nil)
+	ctx.Stdout = bufOut
+	t.Cleanup(ctx.Close)
+	return ctx, bufOut
+}
+
+func TestLoginParseStatusAlone(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	cmd := &Login{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-status"}))
+	require.True(t, cmd.Status)
+
+	// -status combined with another option is rejected.
+	cmd = &Login{}
+	err := cmd.Parse(ctx, []string{"-status", "-github"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be used alone")
+}
+
+func TestLoginParseConflicts(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	cmd := &Login{}
+	err := cmd.Parse(ctx, []string{"-github", "-env"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the -github option cannot be used with -email or -env")
+
+	cmd = &Login{}
+	err = cmd.Parse(ctx, []string{"-email", "foo@example.com", "-env"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the -email option cannot be used with -env")
+
+	// -no-spawn combined with -email (a non-github method) is rejected.
+	cmd = &Login{}
+	err = cmd.Parse(ctx, []string{"-no-spawn", "-email", "user@example.com"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the -no-spawn option is only valid with -github")
+
+	cmd = &Login{}
+	err = cmd.Parse(ctx, []string{"extra-arg"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+func TestLoginParseEmailValidation(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	cmd := &Login{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-email", "user@example.com"}))
+	require.Equal(t, "user@example.com", cmd.Email)
+
+	cmd = &Login{}
+	err := cmd.Parse(ctx, []string{"-email", "not-an-email"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid email address")
+}
+
+func TestLoginParseDefaultsToGithub(t *testing.T) {
+	ctx, _ := newTestContext(t)
+
+	cmd := &Login{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.True(t, cmd.Github)
+}
+
+func TestLoginExecuteStatusNotLoggedIn(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx, bufOut := newTestContext(t)
+
+	cmd := &Login{Status: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "not logged in")
+}
+
+func TestLoginExecuteStatusLoggedIn(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx, bufOut := newTestContext(t)
+	require.NoError(t, ctx.GetCookies().PutAuthToken("a-token"))
+
+	cmd := &Login{Status: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	out := bufOut.String()
+	require.Contains(t, out, "logged in")
+	require.NotContains(t, out, "not logged in")
+}
+
+func TestLoginExecuteEnvWithToken(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "env-token-value")
+	ctx, _ := newTestContext(t)
+
+	cmd := &Login{Env: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// The env token should have been persisted to the cookies store.
+	got, err := ctx.GetCookies().GetAuthToken()
+	require.NoError(t, err)
+	require.Equal(t, "env-token-value", got)
+}
+
+func TestLoginExecuteEnvWithoutToken(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx, _ := newTestContext(t)
+
+	cmd := &Login{Env: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "no auth token found in environment variable PLAKAR_TOKEN")
+}
+
+func TestLogoutParseTooManyArgs(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	cmd := &Logout{}
+	err := cmd.Parse(ctx, []string{"extra"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+func TestLogoutExecuteNotLoggedIn(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx, _ := newTestContext(t)
+
+	cmd := &Logout{}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestLogoutExecuteSuccess(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx, _ := newTestContext(t)
+	require.NoError(t, ctx.GetCookies().PutAuthToken("a-token"))
+
+	cmd := &Logout{}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// Token should be gone now.
+	_, err = ctx.GetCookies().GetAuthToken()
+	require.Error(t, err)
+}
+
+func TestTokenCreateParseTooManyArgs(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	cmd := &TokenCreate{}
+	err := cmd.Parse(ctx, []string{"extra"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Too many arguments")
+}
+
+// DeriveToken bails out before any network call when no auth token is available.
+func TestTokenCreateExecuteNoToken(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx, _ := newTestContext(t)
+
+	cmd := &TokenCreate{}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "no auth token found")
+}

--- a/subcommands/mount/http/http_test.go
+++ b/subcommands/mount/http/http_test.go
@@ -1,0 +1,129 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func TestDynamicHandlerRootCallsList(t *testing.T) {
+	listed := false
+	h := NewDynamicSnapshotHandler(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			listed = true
+			fmt.Fprint(w, "INDEX")
+		},
+		func(ctx context.Context, snap string) (fs.FS, error) {
+			t.Fatalf("open should not be called for root")
+			return nil, nil
+		},
+	)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.True(t, listed)
+	require.Contains(t, rec.Body.String(), "INDEX")
+}
+
+func TestDynamicHandlerNotFound(t *testing.T) {
+	h := NewDynamicSnapshotHandler(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {},
+		func(ctx context.Context, snap string) (fs.FS, error) {
+			return nil, fs.ErrNotExist
+		},
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/abcd/", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDynamicHandlerOpenError(t *testing.T) {
+	h := NewDynamicSnapshotHandler(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {},
+		func(ctx context.Context, snap string) (fs.FS, error) {
+			return nil, fmt.Errorf("boom")
+		},
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/abcd/file", nil))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestDynamicHandlerServesSnapshotFile(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	_ = ctx
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap.Close()
+
+	vfs, err := snap.Filesystem()
+	require.NoError(t, err)
+
+	const snapID = "deadbeef"
+	h := NewDynamicSnapshotHandler(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {},
+		func(ctx context.Context, s string) (fs.FS, error) {
+			require.Equal(t, snapID, s)
+			return vfs, nil
+		},
+	)
+
+	// The snapshot vfs is rooted at the import directory; resolve the absolute
+	// path of dummy.txt within the vfs.
+	backupDir := snap.Header.GetSource(0).Importer.Directory
+	filePath := "/" + snapID + backupDir + "/subdir/dummy.txt"
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, filePath, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body, _ := io.ReadAll(rec.Body)
+	require.Equal(t, "hello dummy", string(body))
+}
+
+// chroot serving: http.FileServer over the chroot vfs serves files directly
+// (mirrors the chrootfs branch of ExecuteHTTP).
+func TestChrootFileServing(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap.Close()
+
+	vfs, err := snap.Filesystem()
+	require.NoError(t, err)
+
+	backupDir := snap.Header.GetSource(0).Importer.Directory
+	subPath := path.Join(backupDir, "subdir")
+	chroot, err := fs.Sub(vfs, strings.TrimPrefix(subPath, "/"))
+	require.NoError(t, err)
+
+	handler := http.FileServer(http.FS(chroot))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/dummy.txt", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body, _ := io.ReadAll(rec.Body)
+	require.Equal(t, "hello dummy", string(body))
+}

--- a/subcommands/mount/mount_parse_test.go
+++ b/subcommands/mount/mount_parse_test.go
@@ -1,0 +1,63 @@
+package mount
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// NOTE: Execute() is intentionally not covered here. It ends in
+// fuse.ExecuteFUSE or http.ExecuteHTTP; the FUSE path requires a real OS mount
+// (privileges + platform support) unavailable in the test environment. Only
+// Parse is exercised. The http branch is covered by subcommands/mount/http.
+
+func TestMountRegistered(t *testing.T) {
+	cmd, matched, _ := subcommands.Lookup([]string{"mount", "-to", "/mnt"})
+	require.NotNil(t, cmd)
+	require.Equal(t, []string{"mount"}, matched)
+	_, ok := cmd.(*Mount)
+	require.True(t, ok)
+}
+
+func TestParseRepositoryLevel(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Mount{}
+	err := cmd.Parse(ctx, []string{"-to", "http://localhost:9999"})
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:9999", cmd.Mountpoint)
+	require.Empty(t, cmd.SnapshotPath)
+	require.NotNil(t, cmd.LocateOptions)
+}
+
+func TestParseSnapshotLevelResetsLocateOptions(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Mount{}
+	// A single positional arg switches to snapshot level.
+	err := cmd.Parse(ctx, []string{"-to", "/mnt", "abcdef:/some/path"})
+	require.NoError(t, err)
+	require.Equal(t, "/mnt", cmd.Mountpoint)
+	require.Equal(t, "abcdef:/some/path", cmd.SnapshotPath)
+	require.NotNil(t, cmd.LocateOptions)
+}
+
+func TestParseNoArgs(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Mount{}
+	err := cmd.Parse(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, cmd.Mountpoint)
+	require.Empty(t, cmd.SnapshotPath)
+	require.NotNil(t, cmd.LocateOptions)
+}

--- a/subcommands/pkg/pkg_extra_test.go
+++ b/subcommands/pkg/pkg_extra_test.go
@@ -1,0 +1,289 @@
+package pkg
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// getRecipe: http transport error and malformed-body parse error
+// ---------------------------------------------------------------------------
+
+func TestGetRecipeHTTPTransportError(t *testing.T) {
+	ctx := newCtx(t)
+	// nothing listens on this port -> http.Get returns a transport error
+	var r pkg.Recipe
+	err := getRecipe(ctx, "http://127.0.0.1:1/recipe.yaml", &r)
+	require.Error(t, err)
+}
+
+func TestGetRecipeHTTPMalformedBody(t *testing.T) {
+	ctx := newCtx(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// invalid yaml content so recipe.Parse fails
+		w.Write([]byte("\t: : not valid yaml : :\n  - broken"))
+	}))
+	defer srv.Close()
+
+	var r pkg.Recipe
+	err := getRecipe(ctx, srv.URL, &r)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// PkgBuild.Parse: recipe with an empty name fails the namere check
+// ---------------------------------------------------------------------------
+
+func TestPkgBuildParseEmptyName(t *testing.T) {
+	ctx := newCtx(t)
+	recipe := writeFile(t, ctx.CWD, "empty.yaml",
+		"version: v1.0.0\nrepository: https://example.com/x.git\n")
+	cmd := &PkgBuild{}
+	err := cmd.Parse(ctx, []string{recipe})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a valid plugin name")
+}
+
+func TestPkgBuildParseHTTPMalformed(t *testing.T) {
+	ctx := newCtx(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("\t: : broken"))
+	}))
+	defer srv.Close()
+
+	cmd := &PkgBuild{}
+	err := cmd.Parse(ctx, []string{srv.URL})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse")
+}
+
+// ---------------------------------------------------------------------------
+// PkgCreate.Parse: GOOS/GOARCH env overrides shape the default output name
+// ---------------------------------------------------------------------------
+
+func TestPkgCreateParseGOOSGOARCHOverride(t *testing.T) {
+	ctx := newCtx(t)
+	dir := t.TempDir()
+	manifest := writeFile(t, dir, "manifest.yaml",
+		"name: myplugin\nversion: v1.0.0\nconnectors: []\n")
+
+	t.Setenv("GOOS", "plan9")
+	t.Setenv("GOARCH", "mips")
+
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{manifest, "v1.0.0"})
+	require.NoError(t, err)
+
+	expected := filepath.Join(ctx.CWD, "myplugin_v1.0.0_plan9_mips.ptar")
+	require.Equal(t, expected, cmd.Out)
+}
+
+// PkgCreate.Parse with an absolute manifest path goes through the
+// filepath.Clean branch rather than Join(CWD, ...).
+func TestPkgCreateParseAbsoluteManifest(t *testing.T) {
+	ctx := newCtx(t)
+	dir := t.TempDir()
+	manifest := writeFile(t, dir, "manifest.yaml",
+		"name: myplugin\nversion: v1.0.0\nconnectors: []\n")
+
+	// pass a non-clean absolute path to exercise filepath.Clean
+	messy := filepath.Join(dir, ".", "manifest.yaml")
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{messy, "v1.0.0"})
+	require.NoError(t, err)
+	require.Equal(t, manifest, cmd.ManifestPath)
+	require.Equal(t, dir, cmd.Base)
+}
+
+// PkgCreate.Parse: a manifest.yaml whose contents are invalid fails at parse.
+func TestPkgCreateParseBadManifest(t *testing.T) {
+	ctx := newCtx(t)
+	dir := t.TempDir()
+	manifest := writeFile(t, dir, "manifest.yaml", "\t: : not valid : :")
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{manifest, "v1.0.0"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse the manifest")
+}
+
+// ---------------------------------------------------------------------------
+// pkgerImporter.Import drives scan and closes the channel
+// ---------------------------------------------------------------------------
+
+func TestPkgerImporterImport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	srcdir := t.TempDir()
+	exe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Connectors: []pkg.ManifestConnector{{Executable: "myconnector"}},
+		},
+	}
+
+	records := make(chan *connectors.Record, 64)
+	// Import closes the records channel itself.
+	err := imp.Import(context.Background(), records, nil)
+	require.NoError(t, err)
+
+	recs := drain(records)
+	names := map[string]bool{}
+	for _, r := range recs {
+		names[r.Pathname] = true
+	}
+	require.True(t, names["/"])
+	require.True(t, names["/manifest.yaml"])
+	require.True(t, names["/myconnector"])
+}
+
+// Import surfaces the error when a connector executable is missing entirely:
+// dofile records an error record but returns nil, so Import returns nil and
+// the error is carried in-band on the record.
+func TestPkgerImporterImportMissingExe(t *testing.T) {
+	srcdir := t.TempDir()
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Connectors: []pkg.ManifestConnector{{Executable: "nope"}},
+		},
+	}
+
+	records := make(chan *connectors.Record, 64)
+	err := imp.Import(context.Background(), records, nil)
+	require.NoError(t, err)
+
+	var sawErr bool
+	for _, r := range drain(records) {
+		if r.Err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr)
+}
+
+// ---------------------------------------------------------------------------
+// dofile with the extra-files / validator paths through a connector
+// ---------------------------------------------------------------------------
+
+func TestPkgerImporterScanExtraMissing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	srcdir := t.TempDir()
+	exe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Connectors: []pkg.ManifestConnector{
+				{Executable: "myconnector", ExtraFiles: []string{"missing.txt"}},
+			},
+		},
+	}
+
+	ch := make(chan *connectors.Record, 64)
+	err := imp.scan(ch)
+	close(ch)
+	require.NoError(t, err)
+
+	var sawErr bool
+	for _, r := range drain(ch) {
+		if r.Err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr, "expected error record for the missing extra file")
+}
+
+// dofile rejects an extra file that escapes the manifest dir, and scan
+// propagates that error.
+func TestPkgerImporterScanExtraEscapes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	srcdir := t.TempDir()
+	exe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	outside := filepath.Join(filepath.Dir(srcdir), "escape.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("x"), 0644))
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Connectors: []pkg.ManifestConnector{
+				{Executable: "myconnector", ExtraFiles: []string{outside}},
+			},
+		},
+	}
+
+	ch := make(chan *connectors.Record, 64)
+	err := imp.scan(ch)
+	close(ch)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not below the manifest")
+}
+
+// ---------------------------------------------------------------------------
+// clone: with PLAKAR_CLONE_TOKEN set, a repository URL that cannot be parsed
+// fails before git is ever invoked.
+// ---------------------------------------------------------------------------
+
+func TestCloneTokenURLParseError(t *testing.T) {
+	t.Setenv("PLAKAR_CLONE_TOKEN", "secrettoken")
+
+	// a control byte makes url.Parse fail
+	recipe := &pkg.Recipe{
+		Name:       "x",
+		Version:    "v1.0.0",
+		Repository: "http://example.com/\x7frepo.git",
+	}
+	err := clone(t.TempDir(), recipe)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse repository URL")
+}
+
+// dofile with an absolute in-tree path exercises the absolutify abs branch.
+func TestPkgerImporterDofileAbsolute(t *testing.T) {
+	srcdir := t.TempDir()
+	f := filepath.Join(srcdir, "data.txt")
+	require.NoError(t, os.WriteFile(f, []byte("hello"), 0644))
+
+	imp := &pkgerImporter{cwd: srcdir, manifest: &pkg.Manifest{}}
+	ch := make(chan *connectors.Record, 8)
+	err := imp.dofile(f, ch, itextra)
+	close(ch)
+	require.NoError(t, err)
+
+	recs := drain(ch)
+	var found bool
+	for _, r := range recs {
+		if r.Pathname == "/data.txt" && r.Err == nil {
+			found = true
+		}
+	}
+	require.True(t, found)
+}

--- a/subcommands/pkg/pkg_test.go
+++ b/subcommands/pkg/pkg_test.go
@@ -1,0 +1,605 @@
+package pkg
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/pkg"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+// newCtx returns a minimal AppContext suitable for Parse() tests that don't
+// touch the package manager or storage. CWD is set to a temp dir.
+func newCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.CWD = t.TempDir()
+	return ctx
+}
+
+// ---------------------------------------------------------------------------
+// Pkg (dispatcher) Parse / Execute
+// ---------------------------------------------------------------------------
+
+func TestPkgParse(t *testing.T) {
+	ctx := newCtx(t)
+
+	// no action specified
+	cmd := &Pkg{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no action specified")
+
+	// invalid argument
+	cmd = &Pkg{}
+	err = cmd.Parse(ctx, []string{"bogus"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid argument")
+}
+
+func TestPkgExecute(t *testing.T) {
+	ctx := newCtx(t)
+	cmd := &Pkg{}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// ---------------------------------------------------------------------------
+// PkgAdd.Parse
+// ---------------------------------------------------------------------------
+
+func TestPkgAddParse(t *testing.T) {
+	ctx := newCtx(t)
+
+	// not enough arguments without -u
+	cmd := &PkgAdd{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not enough arguments")
+
+	// -u with no args is allowed
+	cmd = &PkgAdd{}
+	err = cmd.Parse(ctx, []string{"-u"})
+	require.NoError(t, err)
+	require.True(t, cmd.upgrade)
+
+	// a recipe name (not a file) passes through verbatim
+	cmd = &PkgAdd{}
+	err = cmd.Parse(ctx, []string{"imap"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"imap"}, cmd.Args)
+
+	// an existing relative file is absolutified
+	f := filepath.Join(ctx.CWD, "plugin.ptar")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0644))
+	cmd = &PkgAdd{}
+	err = cmd.Parse(ctx, []string{"plugin.ptar"})
+	require.NoError(t, err)
+	require.Equal(t, []string{f}, cmd.Args)
+
+	// an absolute path that does not exist is an error
+	missing := filepath.Join(ctx.CWD, "does-not-exist.ptar")
+	cmd = &PkgAdd{}
+	err = cmd.Parse(ctx, []string{missing})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file not found")
+}
+
+// ---------------------------------------------------------------------------
+// PkgRm.Parse
+// ---------------------------------------------------------------------------
+
+func TestPkgRmParse(t *testing.T) {
+	ctx := newCtx(t)
+
+	cmd := &PkgRm{}
+	err := cmd.Parse(ctx, []string{})
+	require.NoError(t, err)
+	require.Empty(t, cmd.Args)
+
+	cmd = &PkgRm{}
+	err = cmd.Parse(ctx, []string{"foo", "bar"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo", "bar"}, cmd.Args)
+}
+
+// ---------------------------------------------------------------------------
+// PkgList.Parse
+// ---------------------------------------------------------------------------
+
+func TestPkgListParse(t *testing.T) {
+	ctx := newCtx(t)
+
+	cmd := &PkgList{}
+	err := cmd.Parse(ctx, []string{})
+	require.NoError(t, err)
+	require.False(t, cmd.LongName)
+	require.False(t, cmd.ListAll)
+
+	cmd = &PkgList{}
+	err = cmd.Parse(ctx, []string{"-long", "-available"})
+	require.NoError(t, err)
+	require.True(t, cmd.LongName)
+	require.True(t, cmd.ListAll)
+
+	cmd = &PkgList{}
+	err = cmd.Parse(ctx, []string{"extra"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+// ---------------------------------------------------------------------------
+// PkgBuild.Parse (recipe validation)
+// ---------------------------------------------------------------------------
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(content), 0644))
+	return p
+}
+
+func TestPkgBuildParseWrongUsage(t *testing.T) {
+	ctx := newCtx(t)
+	cmd := &PkgBuild{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong usage")
+
+	cmd = &PkgBuild{}
+	err = cmd.Parse(ctx, []string{"a.yaml", "b.yaml"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong usage")
+}
+
+func TestPkgBuildParseRecipeFromFile(t *testing.T) {
+	ctx := newCtx(t)
+
+	// valid recipe (path contains a separator -> file branch of getRecipe)
+	recipe := writeFile(t, ctx.CWD, "recipe.yaml",
+		"name: myplugin\nversion: v1.0.0\nrepository: https://example.com/x.git\n")
+	cmd := &PkgBuild{}
+	err := cmd.Parse(ctx, []string{recipe})
+	require.NoError(t, err)
+	require.Equal(t, "myplugin", cmd.Recipe.Name)
+	require.Equal(t, "v1.0.0", cmd.Recipe.Version)
+
+	// invalid plugin name
+	badname := writeFile(t, ctx.CWD, "badname.yaml",
+		"name: bad name!\nversion: v1.0.0\nrepository: https://example.com/x.git\n")
+	cmd = &PkgBuild{}
+	err = cmd.Parse(ctx, []string{badname})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a valid plugin name")
+
+	// invalid version string
+	badver := writeFile(t, ctx.CWD, "badver.yaml",
+		"name: myplugin\nversion: notsemver\nrepository: https://example.com/x.git\n")
+	cmd = &PkgBuild{}
+	err = cmd.Parse(ctx, []string{badver})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a valid version string")
+
+	// nonexistent recipe path (contains a separator -> file open fails)
+	cmd = &PkgBuild{}
+	err = cmd.Parse(ctx, []string{filepath.Join(ctx.CWD, "nope.yaml")})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse")
+}
+
+// ---------------------------------------------------------------------------
+// getRecipe path branches
+// ---------------------------------------------------------------------------
+
+func TestGetRecipeFileBranch(t *testing.T) {
+	ctx := newCtx(t)
+
+	// absolute path
+	p := writeFile(t, ctx.CWD, "r.yaml",
+		"name: x\nversion: v1.0.0\nrepository: https://example.com/x.git\n")
+	var r pkg.Recipe
+	err := getRecipe(ctx, p, &r)
+	require.NoError(t, err)
+	require.Equal(t, "x", r.Name)
+
+	// path with a separator that does not exist
+	var r2 pkg.Recipe
+	err = getRecipe(ctx, filepath.Join(ctx.CWD, "missing.yaml"), &r2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couldn't open")
+}
+
+func TestGetRecipeHTTPBranch(t *testing.T) {
+	ctx := newCtx(t)
+
+	// successful fetch over http
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "name: web\nversion: v2.0.0\nrepository: https://example.com/x.git\n")
+	}))
+	defer ok.Close()
+
+	var r pkg.Recipe
+	err := getRecipe(ctx, ok.URL, &r)
+	require.NoError(t, err)
+	require.Equal(t, "web", r.Name)
+	require.Equal(t, "v2.0.0", r.Version)
+
+	// non-200 response
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer bad.Close()
+
+	var r2 pkg.Recipe
+	err = getRecipe(ctx, bad.URL, &r2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couldn't fetch recipe")
+}
+
+func TestPkgBuildParseRecipeFromHTTP(t *testing.T) {
+	ctx := newCtx(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "name: web\nversion: v2.0.0\nrepository: https://example.com/x.git\n")
+	}))
+	defer srv.Close()
+
+	cmd := &PkgBuild{}
+	err := cmd.Parse(ctx, []string{srv.URL})
+	require.NoError(t, err)
+	require.Equal(t, "web", cmd.Recipe.Name)
+}
+
+// ---------------------------------------------------------------------------
+// PkgCreate.Parse argument validation
+// ---------------------------------------------------------------------------
+
+func TestPkgCreateParseValidation(t *testing.T) {
+	ctx := newCtx(t)
+
+	// wrong usage (need exactly 2 args)
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{"manifest.yaml"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong usage")
+
+	// bad version string
+	cmd = &PkgCreate{}
+	err = cmd.Parse(ctx, []string{"manifest.yaml", "notsemver"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bad version string")
+
+	// file name must be manifest.yaml
+	other := writeFile(t, ctx.CWD, "other.yaml", "name: x\n")
+	cmd = &PkgCreate{}
+	err = cmd.Parse(ctx, []string{other, "v1.0.0"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "manifest.yaml")
+
+	// manifest does not exist
+	cmd = &PkgCreate{}
+	err = cmd.Parse(ctx, []string{filepath.Join(ctx.CWD, "manifest.yaml"), "v1.0.0"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "can't open")
+}
+
+func TestPkgCreateParseDefaultOut(t *testing.T) {
+	ctx := newCtx(t)
+	dir := t.TempDir()
+	manifest := writeFile(t, dir, "manifest.yaml",
+		"name: myplugin\nversion: v1.0.0\nconnectors: []\n")
+
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{manifest, "v1.0.0"})
+	require.NoError(t, err)
+	require.Equal(t, dir, cmd.Base)
+	require.Equal(t, manifest, cmd.ManifestPath)
+	// default out name uses the manifest name + version + GOOS/GOARCH
+	expected := filepath.Join(ctx.CWD,
+		"myplugin_v1.0.0_"+runtime.GOOS+"_"+runtime.GOARCH+".ptar")
+	require.Equal(t, expected, cmd.Out)
+}
+
+func TestPkgCreateParseExplicitOut(t *testing.T) {
+	ctx := newCtx(t)
+	dir := t.TempDir()
+	manifest := writeFile(t, dir, "manifest.yaml",
+		"name: myplugin\nversion: v1.0.0\nconnectors: []\n")
+
+	out := filepath.Join(t.TempDir(), "explicit.ptar")
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{"-out", out, manifest, "v1.0.0"})
+	require.NoError(t, err)
+	require.Equal(t, out, cmd.Out)
+}
+
+// ---------------------------------------------------------------------------
+// PkgCreate full Parse + Execute building a real .ptar
+// ---------------------------------------------------------------------------
+
+func TestPkgCreateExecuteBuildsPtar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	// Build a plugin source tree: manifest + a fake executable connector.
+	srcdir := t.TempDir()
+	exe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\necho hi\n"), 0755))
+	manifest := writeFile(t, srcdir, "manifest.yaml",
+		"name: myplugin\n"+
+			"version: v1.0.0\n"+
+			"connectors:\n"+
+			"  - type: importer\n"+
+			"    executable: myconnector\n")
+
+	out := filepath.Join(t.TempDir(), "myplugin.ptar")
+
+	cmd := &PkgCreate{}
+	err := cmd.Parse(ctx, []string{"-out", out, manifest, "v1.0.0"})
+	require.NoError(t, err)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// the .ptar was created and is non-empty
+	info, err := os.Stat(out)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0))
+
+	require.Contains(t, bufOut.String(), "Plugin created successfully")
+}
+
+func TestPkgCreateExecuteNonExecutableFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	srcdir := t.TempDir()
+	// connector file is NOT executable -> Backup should record an error
+	notexe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(notexe, []byte("nope"), 0644))
+	manifest := writeFile(t, srcdir, "manifest.yaml",
+		"name: myplugin\n"+
+			"version: v1.0.0\n"+
+			"connectors:\n"+
+			"  - type: importer\n"+
+			"    executable: myconnector\n")
+
+	out := filepath.Join(t.TempDir(), "myplugin.ptar")
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-out", out, manifest, "v1.0.0"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "failed to package all the files")
+}
+
+// ---------------------------------------------------------------------------
+// Lookup wiring for the subcommands (registration coverage)
+// ---------------------------------------------------------------------------
+
+func TestPkgLookup(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+	}{
+		{[]string{"pkg"}},
+		{[]string{"pkg", "add"}},
+		{[]string{"pkg", "rm"}},
+		{[]string{"pkg", "list"}},
+		{[]string{"pkg", "show"}},
+		{[]string{"pkg", "create"}},
+		{[]string{"pkg", "build"}},
+	} {
+		sub, _, _ := subcommands.Lookup(tc.args)
+		require.NotNil(t, sub, "lookup %v", tc.args)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pkgerImporter pure helpers
+// ---------------------------------------------------------------------------
+
+func TestAbsolutify(t *testing.T) {
+	require.Equal(t, "/a/b", absolutify("/cwd", "/a/b/"))
+	require.Equal(t, filepath.Join("/cwd", "rel"), absolutify("/cwd", "rel"))
+}
+
+func TestPkgerImporterMeta(t *testing.T) {
+	imp := &pkgerImporter{}
+	require.Equal(t, "", imp.Origin())
+	require.Equal(t, "pkger", imp.Type())
+	require.Equal(t, "/", imp.Root())
+	require.Equal(t, 0, int(imp.Flags()))
+	require.NoError(t, imp.Ping(nil))
+	require.NoError(t, imp.Close(nil))
+}
+
+func drain(ch <-chan *connectors.Record) []*connectors.Record {
+	var recs []*connectors.Record
+	for r := range ch {
+		recs = append(recs, r)
+	}
+	return recs
+}
+
+func TestPkgerImporterScan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	srcdir := t.TempDir()
+	exe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+	validator := filepath.Join(srcdir, "validator.json")
+	require.NoError(t, os.WriteFile(validator, []byte(`{"a":1}`), 0644))
+	extra := filepath.Join(srcdir, "extra.txt")
+	require.NoError(t, os.WriteFile(extra, []byte("data"), 0644))
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Name: "x",
+			Connectors: []pkg.ManifestConnector{
+				{
+					Executable: "myconnector",
+					Validator:  "validator.json",
+					ExtraFiles: []string{"extra.txt"},
+				},
+			},
+		},
+	}
+
+	ch := make(chan *connectors.Record, 64)
+	err := imp.scan(ch)
+	close(ch)
+	require.NoError(t, err)
+
+	recs := drain(ch)
+	names := map[string]bool{}
+	for _, r := range recs {
+		names[r.Pathname] = true
+	}
+	require.True(t, names["/"])
+	require.True(t, names["/manifest.yaml"])
+	require.True(t, names["/myconnector"])
+	require.True(t, names["/validator.json"])
+	require.True(t, names["/extra.txt"])
+}
+
+func TestPkgerImporterScanNonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	srcdir := t.TempDir()
+	notexe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(notexe, []byte("nope"), 0644))
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Connectors: []pkg.ManifestConnector{{Executable: "myconnector"}},
+		},
+	}
+
+	ch := make(chan *connectors.Record, 64)
+	err := imp.scan(ch)
+	close(ch)
+	require.NoError(t, err)
+
+	recs := drain(ch)
+	var sawErr bool
+	for _, r := range recs {
+		if r.Err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr, "expected an error record for the non-executable")
+}
+
+func TestPkgerImporterScanInvalidJSON(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	srcdir := t.TempDir()
+	exe := filepath.Join(srcdir, "myconnector")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+	validator := filepath.Join(srcdir, "validator.json")
+	require.NoError(t, os.WriteFile(validator, []byte("not json"), 0644))
+	manifest := writeFile(t, srcdir, "manifest.yaml", "name: x\nversion: v1.0.0\n")
+
+	imp := &pkgerImporter{
+		cwd:          srcdir,
+		manifestPath: manifest,
+		manifest: &pkg.Manifest{
+			Connectors: []pkg.ManifestConnector{
+				{Executable: "myconnector", Validator: "validator.json"},
+			},
+		},
+	}
+
+	ch := make(chan *connectors.Record, 64)
+	err := imp.scan(ch)
+	close(ch)
+	require.NoError(t, err)
+
+	recs := drain(ch)
+	var sawErr bool
+	for _, r := range recs {
+		if r.Err != nil {
+			sawErr = true
+		}
+	}
+	require.True(t, sawErr, "expected an error record for invalid json")
+}
+
+func TestPkgerImporterDofileMissing(t *testing.T) {
+	srcdir := t.TempDir()
+	imp := &pkgerImporter{cwd: srcdir, manifest: &pkg.Manifest{}}
+
+	ch := make(chan *connectors.Record, 8)
+	err := imp.dofile(filepath.Join(srcdir, "nope"), ch, itextra)
+	close(ch)
+	require.NoError(t, err)
+
+	recs := drain(ch)
+	require.Len(t, recs, 1)
+	require.NotNil(t, recs[0].Err)
+}
+
+func TestPkgerImporterDofileEscape(t *testing.T) {
+	srcdir := t.TempDir()
+	imp := &pkgerImporter{cwd: srcdir, manifest: &pkg.Manifest{}}
+
+	// a file that resolves outside the manifest dir must be rejected
+	outside := filepath.Join(filepath.Dir(srcdir), "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("x"), 0644))
+
+	ch := make(chan *connectors.Record, 8)
+	err := imp.dofile(outside, ch, itextra)
+	close(ch)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not below the manifest")
+}
+
+func TestMkstruct(t *testing.T) {
+	ch := make(chan *connectors.Record, 16)
+	mkstruct("/a/b/c/file.txt", ch)
+	close(ch)
+	recs := drain(ch)
+	got := map[string]bool{}
+	for _, r := range recs {
+		got[r.Pathname] = true
+	}
+	require.True(t, got["/a/b/c"])
+	require.True(t, got["/a/b"])
+	require.True(t, got["/a"])
+	require.False(t, got["/"])
+}

--- a/subcommands/prune/prune_coverage_test.go
+++ b/subcommands/prune/prune_coverage_test.go
@@ -1,0 +1,83 @@
+package prune
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Parse with neither a filter nor a retention option is rejected.
+func TestPruneParseNoFilter(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, bufOut, bufErr)
+	defer snap1.Close()
+	defer snap2.Close()
+	_ = repo
+
+	cmd := &Prune{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no filter specified")
+}
+
+// Referencing a policy that does not exist surfaces a "policy not found" error.
+func TestPruneParseUnknownPolicy(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, bufOut, bufErr)
+	defer snap1.Close()
+	defer snap2.Close()
+	_ = repo
+
+	// ConfigDir defaults to a path with no policies.yml, so loading fails.
+	ctx.ConfigDir = t.TempDir()
+
+	cmd := &Prune{}
+	err := cmd.Parse(ctx, []string{"-policy", "does-not-exist"})
+	require.Error(t, err)
+}
+
+// A dry-run with a retention generous enough to keep everything prints a plan
+// with zero deletions.
+func TestPruneDryRunKeepsAll(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, bufOut, bufErr)
+	defer snap1.Close()
+	defer snap2.Close()
+
+	// Keep up to 10 per minute → both snapshots are kept.
+	cmd := &Prune{}
+	require.NoError(t, cmd.Parse(ctx, []string{"--per-minute=10"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	out := bufOut.String()
+	require.Contains(t, out, "prune: would keep 2 and delete 0 snapshot(s)")
+	require.NotContains(t, out, "prune: removal of")
+}
+
+// -apply with a retention that deletes nothing returns early with status 0 and
+// no removal output.
+func TestPruneApplyNoDeletions(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap1, snap2, ctx := generateRepoAndTwoSnaps(t, bufOut, bufErr)
+	defer snap1.Close()
+	defer snap2.Close()
+
+	cmd := &Prune{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-apply", "--per-minute=10"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotContains(t, bufOut.String(), "prune: removal of")
+}

--- a/subcommands/ptar/ptar_parse_test.go
+++ b/subcommands/ptar/ptar_parse_test.go
@@ -1,0 +1,158 @@
+package ptar
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-ptar/storage"
+	"github.com/PlakarKorp/plakar/config"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMissingOutput(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "/some/path"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-o option must be specified")
+}
+
+func TestParseUnknownHashingAlgo(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "-hashing", "not-a-real-algo",
+		"-o", filepath.Join(tmpDir, "x.ptar"), "/some/path"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown hashing algorithm")
+}
+
+func TestParsePassphraseFromEnv(t *testing.T) {
+	t.Setenv("PLAKAR_PASSPHRASE", "correct horse battery staple")
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-o", filepath.Join(tmpDir, "x.ptar"), "/some/path"})
+	require.NoError(t, err)
+	require.Equal(t, []byte("correct horse battery staple"), cmd.RepositorySecret)
+}
+
+func TestParseEmptyPassphraseFromEnv(t *testing.T) {
+	t.Setenv("PLAKAR_PASSPHRASE", "")
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-o", filepath.Join(tmpDir, "x.ptar"), "/some/path"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty passphrase")
+}
+
+func TestParseDefaultsToCWD(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	ctx.CWD = "/the/working/dir"
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "x.ptar")})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/the/working/dir"}, []string(cmd.BackupTargets))
+}
+
+func TestParseMultipleTargets(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "x.ptar"),
+		"/path/one", "/path/two"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/path/one", "/path/two"}, []string(cmd.BackupTargets))
+}
+
+func TestExecuteRefusesOverwrite(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpSourceDir := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+
+	tmpDir := t.TempDir()
+	out := filepath.Join(tmpDir, "test.ptar")
+
+	args := []string{"-plaintext", "-o", out, filepath.Join(tmpSourceDir, "subdir")}
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, args))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// A second run with the same output must refuse without -overwrite.
+	cmd2 := &Ptar{}
+	require.NoError(t, cmd2.Parse(ctx, args))
+	status, err = cmd2.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "already exists")
+}
+
+func TestExecuteOverwrite(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpSourceDir := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+
+	tmpDir := t.TempDir()
+	out := filepath.Join(tmpDir, "test.ptar")
+
+	require.NoError(t, os.WriteFile(out, []byte("stale archive"), 0644))
+
+	args := []string{"-plaintext", "-overwrite", "-o", out, filepath.Join(tmpSourceDir, "subdir")}
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, args))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestExecuteNoCompression(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpSourceDir := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+
+	tmpDir := t.TempDir()
+	args := []string{"-plaintext", "-no-compression", "-o",
+		filepath.Join(tmpDir, "test.ptar"), filepath.Join(tmpSourceDir, "subdir")}
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, args))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestParseSyncTargetUnknownRepository(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	ctx.Config = config.NewConfig()
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "x.ptar"),
+		"-k", "@does-not-exist"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "peer repository")
+}
+
+func TestExecuteUnresolvableSource(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	ctx.Config = config.NewConfig()
+
+	tmpDir := t.TempDir()
+	args := []string{"-plaintext", "-o", filepath.Join(tmpDir, "test.ptar"), "@nonexistent"}
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, args))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "could not resolve importer")
+}

--- a/subcommands/repair/repair_test.go
+++ b/subcommands/repair/repair_test.go
@@ -1,0 +1,108 @@
+package repair
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func simpleFiles() []ptesting.MockFile {
+	return []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/a.txt", 0644, "alpha"),
+		ptesting.NewMockFile("subdir/b.txt", 0644, "bravo"),
+	}
+}
+
+func TestParseDefault(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Repair{}
+	err := cmd.Parse(ctx, []string{})
+	require.NoError(t, err)
+	require.False(t, cmd.Apply)
+}
+
+func TestParseApplyFlag(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Repair{}
+	err := cmd.Parse(ctx, []string{"-apply"})
+	require.NoError(t, err)
+	require.True(t, cmd.Apply)
+}
+
+func TestParseCapturesSecret(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	secret := []byte("0123456789abcdef")
+	ctx.SetSecret(secret)
+
+	cmd := &Repair{}
+	err := cmd.Parse(ctx, []string{})
+	require.NoError(t, err)
+	require.Equal(t, secret, cmd.RepositorySecret)
+}
+
+func TestExecuteDryRunEmptyRepo(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "no repairs needed")
+}
+
+func TestExecuteDryRunPopulatedRepoHealthy(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	ptesting.GenerateSnapshot(t, repo, simpleFiles())
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// A healthy repository with snapshots has every packfile referenced by a
+	// known state, so nothing should be reported as missing.
+	require.Contains(t, bufOut.String(), "no repairs needed")
+}
+
+func TestExecuteApplyHealthyRepo(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	ptesting.GenerateSnapshot(t, repo, simpleFiles())
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-apply"}))
+	require.True(t, cmd.Apply)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// On a healthy repo the -apply path finds no missing states, so it neither
+	// reports "no repairs needed" nor any "repairing" lines.
+	require.NotContains(t, bufOut.String(), "repairing missing state")
+}

--- a/subcommands/rm/rm_coverage_test.go
+++ b/subcommands/rm/rm_coverage_test.go
@@ -1,0 +1,64 @@
+package rm
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Parse with neither a filter nor an explicit snapshot is rejected to avoid a
+// catastrophic "remove everything".
+func TestExecuteCmdRmParseNoFilter(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+	_ = repo
+
+	cmd := &Rm{}
+	err := cmd.Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no filter specified")
+}
+
+// A filter that matches no snapshot results in a clean no-op (status 0,
+// "no snapshots matched").
+func TestExecuteCmdRmNoMatch(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// A bogus id filter matches nothing.
+	cmd := &Rm{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-apply", "ffffffffffffffff"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "rm: no snapshots matched the selection")
+}
+
+// Dry-run plan against an explicit snapshot prints the plan with no deletions.
+func TestExecuteCmdRmDryRunExplicit(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	short := snap.Header.GetIndexShortID()
+	cmd := &Rm{}
+	require.NoError(t, cmd.Parse(ctx, []string{hex.EncodeToString(short)}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	out := bufOut.String()
+	require.Contains(t, out, "rm: would remove these 1 snapshot(s), run with -apply to proceed")
+	require.NotContains(t, out, "rm: removal of")
+}

--- a/subcommands/service/service_test.go
+++ b/subcommands/service/service_test.go
@@ -1,0 +1,312 @@
+package services
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+// newContext builds a hermetic repository + appcontext. The cookies manager
+// points at a temp dir with no auth token, and PLAKAR_TOKEN is cleared, so any
+// Execute that reaches getClient() fails with the "requires login" error
+// before any network call to api.plakar.io is attempted.
+func newContext(t *testing.T) (*repository.Repository, *appcontext.AppContext, *bytes.Buffer, *bytes.Buffer) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	return repo, ctx, bufOut, bufErr
+}
+
+// ---------------------------------------------------------------------------
+// Parse tests
+// ---------------------------------------------------------------------------
+
+func TestServiceParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	// The bare `service` command always errors (no action specified), whether
+	// or not extra args are present.
+	t.Run("no action", func(t *testing.T) {
+		cmd := &Service{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "no action specified")
+	})
+	t.Run("invalid argument", func(t *testing.T) {
+		cmd := &Service{}
+		err := cmd.Parse(ctx, []string{"bogus"})
+		require.EqualError(t, err, "invalid argument: bogus")
+	})
+}
+
+func TestServiceListParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok", func(t *testing.T) {
+		cmd := &ServiceList{}
+		err := cmd.Parse(ctx, []string{})
+		require.NoError(t, err)
+	})
+	t.Run("too many args", func(t *testing.T) {
+		cmd := &ServiceList{}
+		err := cmd.Parse(ctx, []string{"extra"})
+		require.EqualError(t, err, "invalid argument: extra")
+	})
+}
+
+func TestServiceStatusParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok", func(t *testing.T) {
+		cmd := &ServiceStatus{}
+		err := cmd.Parse(ctx, []string{"alerting"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+	})
+	t.Run("no arg", func(t *testing.T) {
+		cmd := &ServiceStatus{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 0")
+	})
+	t.Run("too many args", func(t *testing.T) {
+		cmd := &ServiceStatus{}
+		err := cmd.Parse(ctx, []string{"a", "b"})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 2")
+	})
+}
+
+func TestServiceEnableParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok", func(t *testing.T) {
+		cmd := &ServiceEnable{}
+		err := cmd.Parse(ctx, []string{"alerting"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+	})
+	t.Run("no arg", func(t *testing.T) {
+		cmd := &ServiceEnable{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 0")
+	})
+	t.Run("too many args", func(t *testing.T) {
+		cmd := &ServiceEnable{}
+		err := cmd.Parse(ctx, []string{"a", "b"})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 2")
+	})
+}
+
+func TestServiceDisableParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok", func(t *testing.T) {
+		cmd := &ServiceDisable{}
+		err := cmd.Parse(ctx, []string{"alerting"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+	})
+	t.Run("no arg", func(t *testing.T) {
+		cmd := &ServiceDisable{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 0")
+	})
+}
+
+func TestServiceShowParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok with flags", func(t *testing.T) {
+		cmd := &ServiceShow{}
+		err := cmd.Parse(ctx, []string{"-json", "-secrets", "alerting"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+		require.True(t, cmd.AsJson)
+		require.True(t, cmd.ShowSecrets)
+	})
+	t.Run("no arg", func(t *testing.T) {
+		cmd := &ServiceShow{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 0")
+	})
+	t.Run("too many args", func(t *testing.T) {
+		cmd := &ServiceShow{}
+		err := cmd.Parse(ctx, []string{"a", "b"})
+		require.EqualError(t, err, "invalid number of arguments, expected 1 but got 2")
+	})
+}
+
+func TestServiceAddParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok with kv", func(t *testing.T) {
+		cmd := &ServiceAdd{}
+		err := cmd.Parse(ctx, []string{"alerting", "email=foo@bar.io", "level=warn"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+		require.Equal(t, map[string]string{"email": "foo@bar.io", "level": "warn"}, cmd.Keys)
+	})
+	t.Run("ok empty value", func(t *testing.T) {
+		cmd := &ServiceAdd{}
+		err := cmd.Parse(ctx, []string{"alerting", "email="})
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"email": ""}, cmd.Keys)
+	})
+	t.Run("no service", func(t *testing.T) {
+		cmd := &ServiceAdd{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "no service specified")
+	})
+	t.Run("invalid kv (no =)", func(t *testing.T) {
+		cmd := &ServiceAdd{}
+		err := cmd.Parse(ctx, []string{"alerting", "noequals"})
+		require.EqualError(t, err, `invalid argument "noequals"`)
+	})
+	t.Run("invalid kv (empty key)", func(t *testing.T) {
+		cmd := &ServiceAdd{}
+		err := cmd.Parse(ctx, []string{"alerting", "=value"})
+		require.EqualError(t, err, `invalid argument "=value"`)
+	})
+}
+
+func TestServiceSetParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok with kv", func(t *testing.T) {
+		cmd := &ServiceSet{}
+		err := cmd.Parse(ctx, []string{"alerting", "email=foo@bar.io"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+		require.Equal(t, map[string]string{"email": "foo@bar.io"}, cmd.Keys)
+	})
+	t.Run("no service", func(t *testing.T) {
+		cmd := &ServiceSet{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "no service specified")
+	})
+	t.Run("invalid kv", func(t *testing.T) {
+		cmd := &ServiceSet{}
+		err := cmd.Parse(ctx, []string{"alerting", "bad"})
+		require.EqualError(t, err, `invalid argument "bad"`)
+	})
+}
+
+func TestServiceUnsetParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok with keys", func(t *testing.T) {
+		cmd := &ServiceUnset{}
+		err := cmd.Parse(ctx, []string{"alerting", "email", "level"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+		require.Equal(t, []string{"email", "level"}, cmd.Keys)
+	})
+	t.Run("no service", func(t *testing.T) {
+		cmd := &ServiceUnset{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "no service specified")
+	})
+}
+
+func TestServiceRmParse(t *testing.T) {
+	_, ctx, _, _ := newContext(t)
+
+	t.Run("ok", func(t *testing.T) {
+		cmd := &ServiceRm{}
+		err := cmd.Parse(ctx, []string{"alerting"})
+		require.NoError(t, err)
+		require.Equal(t, "alerting", cmd.Service)
+	})
+	t.Run("no service", func(t *testing.T) {
+		cmd := &ServiceRm{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "no service specified")
+	})
+	t.Run("too many args", func(t *testing.T) {
+		cmd := &ServiceRm{}
+		err := cmd.Parse(ctx, []string{"a", "b"})
+		require.EqualError(t, err, `invalid argument "b"`)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Execute tests
+//
+// The hardcoded SERVICE_ENDPOINT (https://api.plakar.io) cannot be overridden
+// without modifying source, so the only hermetic Execute path is the
+// getClient() failure: with no auth token configured, every subcommand returns
+// status 1 and the "requires login" error before any network call. The
+// network-backed success paths (GetServiceList, SetServiceStatus, etc.) are
+// deliberately not covered here.
+// ---------------------------------------------------------------------------
+
+// With no auth-token file present and PLAKAR_TOKEN unset, GetAuthToken surfaces
+// this error, which getClient propagates verbatim.
+const wantLoginErr = "no auth token found: use `plakar login` first"
+
+func TestServiceBareExecute(t *testing.T) {
+	repo, ctx, _, _ := newContext(t)
+	cmd := &Service{}
+	status, err := cmd.Execute(ctx, repo)
+	require.Equal(t, 1, status)
+	require.EqualError(t, err, "no action specified")
+}
+
+func TestExecuteRequiresLogin(t *testing.T) {
+	repo, ctx, _, _ := newContext(t)
+
+	cmds := []struct {
+		name string
+		cmd  subExecuter
+	}{
+		{"list", &ServiceList{}},
+		{"status", &ServiceStatus{Service: "alerting"}},
+		{"enable", &ServiceEnable{Service: "alerting"}},
+		{"disable", &ServiceDisable{Service: "alerting"}},
+		{"show", &ServiceShow{Service: "alerting"}},
+		{"add", &ServiceAdd{Service: "alerting", Keys: map[string]string{"k": "v"}}},
+		{"rm", &ServiceRm{Service: "alerting"}},
+		// set/unset with keys reach getClient (empty keys short-circuit to 0)
+		{"set", &ServiceSet{Service: "alerting", Keys: map[string]string{"k": "v"}}},
+		{"unset", &ServiceUnset{Service: "alerting", Keys: []string{"k"}}},
+	}
+
+	for _, tc := range cmds {
+		t.Run(tc.name, func(t *testing.T) {
+			status, err := tc.cmd.Execute(ctx, repo)
+			require.Equal(t, 1, status)
+			require.EqualError(t, err, wantLoginErr)
+		})
+	}
+}
+
+// set/unset call getClient() before the empty-keys short-circuit, so with no
+// auth token they still surface the login error regardless of keys.
+func TestSetUnsetNoKeysRequiresLogin(t *testing.T) {
+	repo, ctx, _, _ := newContext(t)
+
+	t.Run("set no keys", func(t *testing.T) {
+		cmd := &ServiceSet{Service: "alerting", Keys: map[string]string{}}
+		status, err := cmd.Execute(ctx, repo)
+		require.Equal(t, 1, status)
+		require.EqualError(t, err, wantLoginErr)
+	})
+	t.Run("unset no keys", func(t *testing.T) {
+		cmd := &ServiceUnset{Service: "alerting", Keys: nil}
+		status, err := cmd.Execute(ctx, repo)
+		require.Equal(t, 1, status)
+		require.EqualError(t, err, wantLoginErr)
+	})
+}
+
+type subExecuter interface {
+	Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error)
+}

--- a/subcommands/subcommands_test.go
+++ b/subcommands/subcommands_test.go
@@ -1,0 +1,92 @@
+package subcommands
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCmd struct {
+	SubcommandBase
+	parsed bool
+}
+
+func (c *fakeCmd) Parse(ctx *appcontext.AppContext, args []string) error {
+	c.parsed = true
+	return nil
+}
+func (c *fakeCmd) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+	return 0, nil
+}
+
+func TestRegisterAndLookupSingleToken(t *testing.T) {
+	Register(func() Subcommand { return &fakeCmd{} }, NeedRepositoryKey, "ut_register_single")
+
+	cmd, matched, rest := Lookup([]string{"ut_register_single", "arg1", "arg2"})
+	require.NotNil(t, cmd)
+	require.Equal(t, []string{"ut_register_single"}, matched)
+	require.Equal(t, []string{"arg1", "arg2"}, rest)
+
+	// flags set by setFlags via factory closure
+	require.Equal(t, NeedRepositoryKey, cmd.GetFlags())
+
+	// factory returns the right concrete type
+	fc, ok := cmd.(*fakeCmd)
+	require.True(t, ok)
+	require.False(t, fc.parsed)
+}
+
+func TestLookupMultiTokenPrefix(t *testing.T) {
+	Register(func() Subcommand { return &fakeCmd{} }, 0, "ut_multi", "sub")
+
+	// exact multi-token match consumes both tokens
+	cmd, matched, rest := Lookup([]string{"ut_multi", "sub", "tail"})
+	require.NotNil(t, cmd)
+	require.Equal(t, []string{"ut_multi", "sub"}, matched)
+	require.Equal(t, []string{"tail"}, rest)
+
+	// only first token present -> no match (nargs > provided)
+	cmd2, matched2, rest2 := Lookup([]string{"ut_multi"})
+	require.Nil(t, cmd2)
+	require.Nil(t, matched2)
+	require.Equal(t, []string{"ut_multi"}, rest2)
+}
+
+func TestLookupUnknownReturnsNil(t *testing.T) {
+	cmd, matched, rest := Lookup([]string{"ut_definitely_not_registered_xyz"})
+	require.Nil(t, cmd)
+	require.Nil(t, matched)
+	require.Equal(t, []string{"ut_definitely_not_registered_xyz"}, rest)
+}
+
+func TestLookupEmptyArgs(t *testing.T) {
+	cmd, _, rest := Lookup([]string{})
+	require.Nil(t, cmd)
+	require.Empty(t, rest)
+}
+
+func TestRegisterZeroArgsPanics(t *testing.T) {
+	require.PanicsWithValue(t, "can't register commands with zero arguments", func() {
+		Register(func() Subcommand { return &fakeCmd{} }, 0)
+	})
+}
+
+func TestListIncludesRegistered(t *testing.T) {
+	Register(func() Subcommand { return &fakeCmd{} }, 0, "ut_list_marker")
+	list := List()
+	require.NotEmpty(t, list)
+	found := slices.ContainsFunc(list, func(args []string) bool {
+		return len(args) == 1 && args[0] == "ut_list_marker"
+	})
+	require.True(t, found)
+}
+
+func TestSubcommandBaseSecret(t *testing.T) {
+	base := &SubcommandBase{RepositorySecret: []byte("topsecret")}
+	require.Equal(t, []byte("topsecret"), base.GetRepositorySecret())
+	base.setFlags(BeforeRepositoryOpen)
+	require.Equal(t, BeforeRepositoryOpen, base.GetFlags())
+}

--- a/subcommands/sync/sync_test.go
+++ b/subcommands/sync/sync_test.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/PlakarKorp/plakar/utils"
 	"github.com/stretchr/testify/require"
@@ -22,12 +22,26 @@ func init() {
 	os.Setenv("TZ", "UTC")
 }
 
+// NOTE ON Execute COVERAGE:
+// Sync.Execute calls cached.RebuildStateFromStore, which spawns a "cached"
+// daemon by re-executing os.Executable() with the "cached" argument. Under
+// `go test` the executable is the test binary, which does not implement the
+// cached subcommand, so the helper retries the connection up to 1000 times,
+// spawning a process each round, and effectively hangs. This is why the
+// repo's pre-existing Execute tests were disabled (renamed with a leading
+// underscore). The hermetic, non-daemon surface of this package is Parse,
+// which is what these tests exercise thoroughly (argument validation, the
+// snapshot/filter forms, and all three encrypted-peer passphrase-derivation
+// branches including the wrong-passphrase failures).
+
 func generateSnapshot(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) (*repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
 	stateRefresher = func(*appcontext.AppContext, *repository.Repository) func(objects.MAC, bool) error {
 		return nil
 	}
 
 	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	// sync's Parse needs a non-nil config to resolve peer repository locations.
+	ctx.Config = config.NewConfig()
 	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
 		ptesting.NewMockDir("subdir"),
 		ptesting.NewMockDir("another_subdir"),
@@ -39,97 +53,200 @@ func generateSnapshot(t *testing.T, bufOut *bytes.Buffer, bufErr *bytes.Buffer) 
 	return repo, snap, ctx
 }
 
-func _TestExecuteCmdSyncTo(t *testing.T) {
+// ---------------------------------------------------------------------------
+// Parse validation
+// ---------------------------------------------------------------------------
+
+func TestSyncParseTooManyArguments(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
 
-	localRepo, snap, lctx := generateSnapshot(t, bufOut, bufErr)
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{"a", "to", "b", "c"})
+	require.EqualError(t, err, "Too many arguments")
+}
+
+func TestSyncParseWrongArgCount(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	t.Run("zero args", func(t *testing.T) {
+		cmd := &Sync{}
+		err := cmd.Parse(ctx, []string{})
+		require.EqualError(t, err, "usage: sync [SNAPSHOT] to|from|with REPOSITORY")
+	})
+	t.Run("one arg", func(t *testing.T) {
+		cmd := &Sync{}
+		err := cmd.Parse(ctx, []string{"to"})
+		require.EqualError(t, err, "usage: sync [SNAPSHOT] to|from|with REPOSITORY")
+	})
+}
+
+func TestSyncParseInvalidDirection(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{"sideways", "somewhere"})
+	require.EqualError(t, err, "invalid direction, must be to, from or with")
+}
+
+func TestSyncParseUnknownPeer(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{"to", "@doesnotexist"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "peer store")
+	require.Contains(t, err.Error(), "could not resolve repository")
+}
+
+// Three-arg form: SNAPSHOT direction REPOSITORY, with a valid (plaintext) peer.
+func TestSyncParseSnapshotForm(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
 	defer snap.Close()
 
 	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:])), "to", peerRepo.Root()}
-
-	subcommand := &Sync{}
-	fmt.Println(args)
-	err := subcommand.Parse(lctx, args)
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{hex.EncodeToString(indexId[:]), "to", peerRepo.Root()})
 	require.NoError(t, err)
-	require.NotNil(t, subcommand)
-
-	status, err := subcommand.Execute(lctx, localRepo)
-	require.NoError(t, err)
-	require.Equal(t, 0, status)
-
-	// output should look like this
-	// 2025-03-26T21:17:28Z info: sync: synchronization from /tmp/tmp_repo1957539148/repo to /tmp/tmp_repo2470692775/repo completed: 1 snapshots synchronized
-	output := bufOut.String()
-	require.Contains(t, strings.Trim(output, "\n"), fmt.Sprintf("info: sync: synchronization from %s to %s completed: 1 snapshots synchronized", localRepo.Origin(), peerRepo.Origin()))
+	require.Equal(t, "to", cmd.Direction)
+	require.Equal(t, peerRepo.Root(), cmd.PeerRepositoryLocation)
+	require.Equal(t, []string{hex.EncodeToString(indexId[:])}, cmd.SrcLocateOptions.Filters.IDs)
 }
 
-func _TestExecuteCmdSyncWith(t *testing.T) {
+// Two-arg form: direction REPOSITORY (no snapshot, filters keep defaults).
+func TestSyncParseFilterForm(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
-
-	localRepo, snap, lctx := generateSnapshot(t, bufOut, bufErr)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
 	defer snap.Close()
 
 	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
 
-	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:])), "with", peerRepo.Root()}
-
-	subcommand := &Sync{}
-	err := subcommand.Parse(lctx, args)
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{"with", peerRepo.Root()})
 	require.NoError(t, err)
-	require.NotNil(t, subcommand)
-
-	status, err := subcommand.Execute(lctx, localRepo)
-	require.NoError(t, err)
-	require.Equal(t, 0, status)
-
-	// output should look like this
-	// 2025-03-26T21:28:23Z info: sync: synchronization between /tmp/tmp_repo3863826583/repo and /tmp/tmp_repo327669581/repo completed: 1 snapshots synchronized
-	output := bufOut.String()
-	require.Contains(t, strings.Trim(output, "\n"), fmt.Sprintf("info: sync: synchronization between %s and %s completed: 1 snapshots synchronized", localRepo.Origin(), peerRepo.Origin()))
+	require.Equal(t, "with", cmd.Direction)
+	require.Empty(t, cmd.SrcLocateOptions.Filters.IDs)
 }
 
-func _TestExecuteCmdSyncWithEncryption(t *testing.T) {
-	bufOut := bytes.NewBuffer(nil)
-	bufErr := bytes.NewBuffer(nil)
+// ---------------------------------------------------------------------------
+// Encrypted peer: passphrase derivation paths in Parse
+// ---------------------------------------------------------------------------
 
-	localRepo, snap, lctx := generateSnapshot(t, bufOut, bufErr)
-	defer snap.Close()
+// encryptedPeer creates an encrypted peer repository and registers it in the
+// caller's config under @peerRepo, then returns the config-file path so the
+// caller can tweak passphrase / passphrase_cmd before Parse.
+func encryptedPeer(t *testing.T, ctx *appcontext.AppContext, bufOut, bufErr *bytes.Buffer, passphrase string) *repository.Repository {
+	pp := []byte(passphrase)
+	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, &pp)
 
-	passphrase := []byte("aZeRtY123456$#@!@")
-	peerRepo, _ := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
-
-	// need to recreate configuration to store passphrase on peer repo
 	opt_configfile := strings.TrimPrefix(peerRepo.Root(), "fs://")
-
 	cfg, err := utils.LoadConfig(opt_configfile)
 	require.NoError(t, err)
-	lctx.Config = cfg
-	lctx.Config.Repositories["peerRepo"] = make(map[string]string)
-	lctx.Config.Repositories["peerRepo"]["passphrase"] = string(passphrase)
-	lctx.Config.Repositories["peerRepo"]["location"] = peerRepo.Root()
-	err = utils.SaveConfig(opt_configfile, lctx.Config)
+	ctx.Config = cfg
+	ctx.Config.Repositories["peerRepo"] = map[string]string{
+		"location": peerRepo.Root(),
+	}
+	err = utils.SaveConfig(opt_configfile, ctx.Config)
 	require.NoError(t, err)
+	return peerRepo
+}
+
+func TestSyncParseEncryptedPeerPassphrase(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	passphrase := "aZeRtY123456$#@!@"
+	encryptedPeer(t, ctx, bufOut, bufErr, passphrase)
+	ctx.Config.Repositories["peerRepo"]["passphrase"] = passphrase
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:])), "with", "@peerRepo"}
-
-	subcommand := &Sync{}
-	err = subcommand.Parse(lctx, args)
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{hex.EncodeToString(indexId[:]), "with", "@peerRepo"})
 	require.NoError(t, err)
-	require.NotNil(t, subcommand)
+	require.NotEmpty(t, cmd.PeerRepositorySecret)
+}
 
-	status, err := subcommand.Execute(lctx, localRepo)
+func TestSyncParseEncryptedPeerWrongPassphrase(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	encryptedPeer(t, ctx, bufOut, bufErr, "correct-horse-battery")
+	ctx.Config.Repositories["peerRepo"]["passphrase"] = "totally-wrong"
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{hex.EncodeToString(indexId[:]), "with", "@peerRepo"})
+	require.EqualError(t, err, "invalid passphrase")
+}
+
+func TestSyncParseEncryptedPeerPassphraseCmd(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	// Plain alphanumeric: the passphrase_cmd is run through /bin/sh -c, so shell
+	// metacharacters would be expanded and corrupt the value.
+	passphrase := "correcthorsebatterystaple"
+	encryptedPeer(t, ctx, bufOut, bufErr, passphrase)
+	ctx.Config.Repositories["peerRepo"]["passphrase_cmd"] = "echo " + passphrase
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{hex.EncodeToString(indexId[:]), "with", "@peerRepo"})
 	require.NoError(t, err)
-	require.Equal(t, 0, status)
+	require.NotEmpty(t, cmd.PeerRepositorySecret)
+}
 
-	// output should look like this
-	// 2025-03-26T21:28:23Z info: sync: synchronization between /tmp/tmp_repo3863826583/repo and /tmp/tmp_repo327669581/repo completed: 1 snapshots synchronized
-	output := bufOut.String()
-	require.Contains(t, strings.Trim(output, "\n"), fmt.Sprintf("info: sync: synchronization between %s and %s completed: 1 snapshots synchronized", localRepo.Origin(), peerRepo.Origin()))
+func TestSyncParseEncryptedPeerPassphraseCmdWrong(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	encryptedPeer(t, ctx, bufOut, bufErr, "therightone")
+	ctx.Config.Repositories["peerRepo"]["passphrase_cmd"] = "echo nope"
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{hex.EncodeToString(indexId[:]), "with", "@peerRepo"})
+	require.EqualError(t, err, "invalid passphrase")
+}
+
+// A passphrase_cmd that fails (non-zero exit / no output) surfaces a read error.
+func TestSyncParseEncryptedPeerPassphraseCmdFails(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	encryptedPeer(t, ctx, bufOut, bufErr, "whatever")
+	// emits zero lines -> GetPassphraseFromCommand returns "too many lines" error
+	ctx.Config.Repositories["peerRepo"]["passphrase_cmd"] = "true"
+
+	indexId := snap.Header.GetIndexID()
+	cmd := &Sync{}
+	err := cmd.Parse(ctx, []string{hex.EncodeToString(indexId[:]), "with", "@peerRepo"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read passphrase from command")
 }

--- a/subcommands/ui/ui_test.go
+++ b/subcommands/ui/ui_test.go
@@ -1,0 +1,130 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func newCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.CWD = t.TempDir()
+	return ctx
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+func TestUiParseDefaults(t *testing.T) {
+	ctx := newCtx(t)
+	cmd := &Ui{}
+	err := cmd.Parse(ctx, []string{})
+	require.NoError(t, err)
+
+	require.Equal(t, "", cmd.Addr)
+	require.False(t, cmd.Cors)
+	require.False(t, cmd.NoAuth)
+	require.False(t, cmd.NoSpawn)
+	require.False(t, cmd.NoRefresh)
+	require.Equal(t, "", cmd.Cert)
+	require.Equal(t, "", cmd.Key)
+}
+
+func TestUiParseAllFlags(t *testing.T) {
+	ctx := newCtx(t)
+	cmd := &Ui{}
+	err := cmd.Parse(ctx, []string{
+		"-addr", "127.0.0.1:8080",
+		"-cors",
+		"-no-auth",
+		"-no-spawn",
+		"-no-refresh",
+		"-cert", "/tmp/cert.pem",
+		"-key", "/tmp/key.pem",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "127.0.0.1:8080", cmd.Addr)
+	require.True(t, cmd.Cors)
+	require.True(t, cmd.NoAuth)
+	require.True(t, cmd.NoSpawn)
+	require.True(t, cmd.NoRefresh)
+	require.Equal(t, "/tmp/cert.pem", cmd.Cert)
+	require.Equal(t, "/tmp/key.pem", cmd.Key)
+}
+
+func TestUiParseTooManyArgs(t *testing.T) {
+	ctx := newCtx(t)
+	cmd := &Ui{}
+	err := cmd.Parse(ctx, []string{"unexpected"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Too many arguments")
+}
+
+func TestUiParseStoresSecret(t *testing.T) {
+	ctx := newCtx(t)
+	ctx.SetSecret([]byte("hunter2"))
+	cmd := &Ui{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.Equal(t, []byte("hunter2"), cmd.RepositorySecret)
+}
+
+// ---------------------------------------------------------------------------
+// Lookup wiring (registration)
+// ---------------------------------------------------------------------------
+
+func TestUiLookup(t *testing.T) {
+	sub, _, args := subcommands.Lookup([]string{"ui", "-no-spawn"})
+	require.NotNil(t, sub)
+	_, ok := sub.(*Ui)
+	require.True(t, ok)
+	require.Equal(t, []string{"-no-spawn"}, args)
+}
+
+// ---------------------------------------------------------------------------
+// Execute error path: an invalid listen address makes the underlying HTTP
+// server fail immediately, so Execute returns (1, err) without blocking.
+// NoSpawn avoids touching a browser; NoAuth avoids generating a token.
+// ---------------------------------------------------------------------------
+
+func TestUiExecuteInvalidAddr(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Ui{
+		Addr:    "999.999.999.999:99999", // unresolvable -> ListenAndServe errors
+		NoSpawn: true,
+		NoAuth:  true,
+	}
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, bufErr.String(), "ui:")
+}
+
+// With auth enabled and PLAKAR_UI_TOKEN set, the token is taken from the env;
+// we still feed an invalid address so Execute returns rather than blocking.
+func TestUiExecuteTokenFromEnv(t *testing.T) {
+	t.Setenv("PLAKAR_UI_TOKEN", "fixed-token")
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	cmd := &Ui{
+		Addr:    "999.999.999.999:99999",
+		NoSpawn: true,
+	}
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,108 @@
+package task
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/PlakarKorp/plakar/subcommands/check"
+	"github.com/PlakarKorp/plakar/subcommands/diag"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func generateSnapshot(t *testing.T, bufOut, bufErr *bytes.Buffer) (*repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	return repo, snap, ctx
+}
+
+// RunCommand with a known task kind (check) should run the command's Execute
+// path and finish successfully, emitting a TaskDone report.
+func TestRunCommandKnownTaskKind(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	args := []string{"check", hex.EncodeToString(indexID[:])}
+
+	subcommand, _, rest := subcommands.Lookup(args)
+	require.NotNil(t, subcommand)
+	err := subcommand.Parse(ctx, rest)
+	require.NoError(t, err)
+
+	_, ok := subcommand.(*check.Check)
+	require.True(t, ok)
+
+	status, err := RunCommand(ctx, subcommand, repo, "my-check-task")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// RunCommand with a command that is not one of the recognized task kinds
+// exercises the default branch (report.SetIgnore) while still executing the
+// command normally.
+func TestRunCommandUnknownTaskKind(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	args := []string{"diag", "snapshot", hex.EncodeToString(indexID[:])}
+
+	subcommand, _, rest := subcommands.Lookup(args)
+	require.NotNil(t, subcommand)
+	err := subcommand.Parse(ctx, rest)
+	require.NoError(t, err)
+
+	_, ok := subcommand.(*diag.DiagSnapshot)
+	require.True(t, ok)
+
+	status, err := RunCommand(ctx, subcommand, repo, "diag-task")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// diag snapshot prints the snapshot header to stdout
+	require.Contains(t, bufOut.String(), hex.EncodeToString(indexID[:]))
+}
+
+// RunCommand should tolerate a nil repository (location lookup is guarded).
+func TestRunCommandNilRepo(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+	_ = repo
+
+	// A command whose Execute fails fast without touching the repo.
+	indexID := snap.Header.GetIndexID()
+	args := []string{"check", hex.EncodeToString(indexID[:])}
+	subcommand, _, rest := subcommands.Lookup(args)
+	require.NotNil(t, subcommand)
+	require.NoError(t, subcommand.Parse(ctx, rest))
+
+	// Run against the real repo but assert the report machinery handles the
+	// repo-name/repo-attach branch.
+	status, err := RunCommand(ctx, subcommand, repo, "")
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}

--- a/term_more_test.go
+++ b/term_more_test.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTerminalDumb(t *testing.T) {
+	// TERM=dumb always reports "not a terminal".
+	t.Setenv("TERM", "dumb")
+	require.False(t, isTerminal())
+}
+
+func TestIsTerminalUnderTest(t *testing.T) {
+	// In the test harness fd 1 is not a tty, so this returns false regardless of
+	// TERM. We only assert it does not panic and returns a bool deterministically.
+	t.Setenv("TERM", "xterm-256color")
+	require.False(t, isTerminal())
+}

--- a/ui/json/json_test.go
+++ b/ui/json/json_test.go
@@ -1,0 +1,139 @@
+package json
+
+import (
+	"bytes"
+	enc "encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func newCtx() *appcontext.AppContext {
+	ctx := appcontext.NewAppContext()
+	logger := logging.NewLogger(bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+	ctx.SetLogger(logger)
+	return ctx
+}
+
+func mac(b byte) objects.MAC {
+	var m objects.MAC
+	for i := range m {
+		m[i] = b
+	}
+	return m
+}
+
+func TestNewAndAccessors(t *testing.T) {
+	ctx := newCtx()
+	defer ctx.Close()
+
+	u := New(ctx)
+	require.NotNil(t, u)
+	require.Equal(t, io.Discard, u.Stdout())
+	require.Equal(t, os.Stderr, u.Stderr())
+	u.Stop()
+	u.SetRepository(nil)
+}
+
+func TestSanitizeData(t *testing.T) {
+	in := map[string]any{
+		"err":      errors.New("boom"),
+		"duration": 2 * time.Second,
+		"str":      "hello",
+		"num":      42,
+	}
+	out := sanitizeData(in)
+	require.Equal(t, "boom", out["err"])
+	require.Equal(t, int64(2000), out["duration"])
+	require.Equal(t, "hello", out["str"])
+	require.Equal(t, 42, out["num"])
+}
+
+func TestHandleEventEncodesJSON(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	jr := &jsonRenderer{
+		ctx:     newCtx(),
+		encoder: enc.NewEncoder(buf),
+	}
+	defer jr.ctx.Close()
+
+	e := &events.Event{
+		Version:    1,
+		Timestamp:  time.Unix(0, 0).UTC(),
+		Repository: uuid.Nil,
+		Snapshot:   mac(0xab),
+		Level:      "warn",
+		Workflow:   "backup",
+		Type:       "path.error",
+		Data:       map[string]any{"path": "/x", "error": errors.New("nope")},
+	}
+	jr.handleEvent(e)
+
+	var decoded jsonEvent
+	require.NoError(t, enc.Unmarshal(buf.Bytes(), &decoded))
+	require.Equal(t, "path.error", decoded.Type)
+	require.Equal(t, "backup", decoded.Workflow)
+	require.Equal(t, "warn", decoded.Level)
+	require.Equal(t, "/x", decoded.Data["path"])
+	require.Equal(t, "nope", decoded.Data["error"])
+}
+
+func TestHandleEventEmptyData(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	jr := &jsonRenderer{ctx: newCtx(), encoder: enc.NewEncoder(buf)}
+	defer jr.ctx.Close()
+
+	jr.handleEvent(&events.Event{Type: "result", Snapshot: mac(1)})
+	require.Contains(t, buf.String(), `"type":"result"`)
+	// no data key when empty
+	require.NotContains(t, buf.String(), `"data"`)
+}
+
+func TestHandleEventSilentAndQuiet(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	ctx := newCtx()
+	ctx.Silent = true
+	jr := &jsonRenderer{ctx: ctx, encoder: enc.NewEncoder(buf)}
+	defer ctx.Close()
+	jr.handleEvent(&events.Event{Type: "path.ok", Snapshot: mac(1)})
+	require.Empty(t, buf.String())
+
+	buf2 := bytes.NewBuffer(nil)
+	ctx2 := newCtx()
+	ctx2.Quiet = true
+	jr2 := &jsonRenderer{ctx: ctx2, encoder: enc.NewEncoder(buf2)}
+	defer ctx2.Close()
+	jr2.handleEvent(&events.Event{Type: "path.ok", Level: "info", Snapshot: mac(1)})
+	require.Empty(t, buf2.String())
+}
+
+// Run/Wait drive an event through the bus.
+func TestRunAndWait(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	ctx := newCtx()
+	jr := &jsonRenderer{ctx: ctx, encoder: enc.NewEncoder(buf)}
+
+	require.NoError(t, jr.Run())
+
+	emitter := ctx.Events().NewSnapshotEmitter(uuid.Nil, mac(0xcd), "backup")
+	emitter.PathError("/served", errors.New("x"))
+
+	time.Sleep(50 * time.Millisecond)
+	ctx.Events().Close()
+
+	require.NoError(t, jr.Wait())
+	require.Contains(t, buf.String(), "/served")
+}

--- a/ui/stdio/stdio_test.go
+++ b/ui/stdio/stdio_test.go
@@ -1,0 +1,204 @@
+package stdio
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/events"
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func newCtx(bufOut, bufErr *bytes.Buffer) *appcontext.AppContext {
+	ctx := appcontext.NewAppContext()
+	logger := logging.NewLogger(bufOut, bufErr)
+	logger.EnableInfo()
+	ctx.SetLogger(logger)
+	return ctx
+}
+
+func mac(b byte) objects.MAC {
+	var m objects.MAC
+	for i := range m {
+		m[i] = b
+	}
+	return m
+}
+
+func TestNewAndAccessors(t *testing.T) {
+	ctx := newCtx(bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+	defer ctx.Close()
+
+	u := New(ctx)
+	require.NotNil(t, u)
+	require.Equal(t, os.Stdout, u.Stdout())
+	require.Equal(t, os.Stderr, u.Stderr())
+	u.Stop() // no-op, should not panic
+
+	u.SetRepository(nil) // exercises SetRepository
+}
+
+func TestHandleEventPathOK(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bufErr)
+	defer ctx.Close()
+
+	e := &events.Event{
+		Type:     "path.ok",
+		Snapshot: mac(0xab),
+		Data:     map[string]any{"path": "/etc/passwd"},
+	}
+	HandleEvent(ctx, e)
+	require.Contains(t, bufOut.String(), "/etc/passwd")
+	require.Contains(t, bufOut.String(), "OK")
+}
+
+func TestHandleEventPathError(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bufErr)
+	defer ctx.Close()
+
+	e := &events.Event{
+		Type:     "path.error",
+		Snapshot: mac(0x12),
+		Data:     map[string]any{"path": "/bad", "error": errors.New("boom")},
+	}
+	HandleEvent(ctx, e)
+	require.Contains(t, bufErr.String(), "/bad")
+	require.Contains(t, bufErr.String(), "boom")
+	require.Contains(t, bufErr.String(), "KO")
+}
+
+func TestHandleEventObjectError(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bufErr)
+	defer ctx.Close()
+
+	e := &events.Event{
+		Type:     "object.error",
+		Snapshot: mac(0x34),
+		Data:     map[string]any{"mac": mac(0x99), "error": errors.New("corrupt")},
+	}
+	HandleEvent(ctx, e)
+	require.Contains(t, bufErr.String(), "corrupt")
+	require.Contains(t, bufErr.String(), "object=")
+}
+
+func TestHandleEventResultWithErrors(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bufErr)
+	defer ctx.Close()
+
+	e := &events.Event{
+		Type:     "result",
+		Snapshot: mac(0x56),
+		Workflow: "backup",
+		Data: map[string]any{
+			"duration": 5 * time.Second,
+			"rbytes":   int64(1024),
+			"wbytes":   int64(2048),
+			"errors":   uint64(2),
+		},
+	}
+	HandleEvent(ctx, e)
+	out := bufOut.String()
+	require.Contains(t, out, "backup")
+	require.Contains(t, out, "completed")
+	require.Contains(t, out, "with 2 errors")
+}
+
+func TestHandleEventResultSingularErrorAndNoErrors(t *testing.T) {
+	// singular "error"
+	bufOut := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bytes.NewBuffer(nil))
+	defer ctx.Close()
+	HandleEvent(ctx, &events.Event{
+		Type:     "result",
+		Snapshot: mac(0x01),
+		Workflow: "check",
+		Data: map[string]any{
+			"duration": time.Second, "rbytes": int64(1), "wbytes": int64(1),
+			"errors": uint64(1),
+		},
+	})
+	require.Contains(t, bufOut.String(), "with 1 error")
+
+	// no errors path
+	bufOut2 := bytes.NewBuffer(nil)
+	ctx2 := newCtx(bufOut2, bytes.NewBuffer(nil))
+	defer ctx2.Close()
+	HandleEvent(ctx2, &events.Event{
+		Type:     "result",
+		Snapshot: mac(0x02),
+		Workflow: "restore",
+		Data: map[string]any{
+			"duration": time.Second, "rbytes": int64(1), "wbytes": int64(1),
+			"errors": uint64(0),
+		},
+	})
+	require.Contains(t, bufOut2.String(), "without errors")
+}
+
+func TestHandleEventSilentAndQuiet(t *testing.T) {
+	// Silent: nothing emitted
+	bufOut := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bytes.NewBuffer(nil))
+	ctx.Silent = true
+	defer ctx.Close()
+	HandleEvent(ctx, &events.Event{Type: "path.ok", Snapshot: mac(1), Data: map[string]any{"path": "/x"}})
+	require.Empty(t, bufOut.String())
+
+	// Quiet + info-level: suppressed
+	bufOut2 := bytes.NewBuffer(nil)
+	ctx2 := newCtx(bufOut2, bytes.NewBuffer(nil))
+	ctx2.Quiet = true
+	defer ctx2.Close()
+	HandleEvent(ctx2, &events.Event{Type: "path.ok", Level: "info", Snapshot: mac(1), Data: map[string]any{"path": "/x"}})
+	require.Empty(t, bufOut2.String())
+}
+
+func TestHandleEventIgnoredTypes(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bufErr)
+	defer ctx.Close()
+	for _, typ := range []string{"path", "directory", "file", "symlink", "object", "chunk", "object.ok", "chunk.ok", "unknown.type"} {
+		HandleEvent(ctx, &events.Event{Type: typ, Snapshot: mac(1)})
+	}
+	require.Empty(t, bufOut.String())
+	require.Empty(t, bufErr.String())
+}
+
+// Run/Wait: drive an event through the bus and ensure the listener goroutine
+// processes it then exits cleanly when the bus closes.
+func TestRunProcessesEventsAndWait(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	ctx := newCtx(bufOut, bytes.NewBuffer(nil))
+
+	u := New(ctx)
+	require.NoError(t, u.Run())
+
+	emitter := ctx.Events().NewSnapshotEmitter(uuid.Nil, mac(0xaa), "backup")
+	emitter.PathOk("/served")
+
+	// Give the goroutine a moment, then close the bus to drain Wait.
+	time.Sleep(50 * time.Millisecond)
+	ctx.Events().Close()
+
+	require.NoError(t, u.Wait())
+	require.Contains(t, bufOut.String(), "/served")
+}

--- a/ui/v2/v2_test.go
+++ b/ui/v2/v2_test.go
@@ -1,0 +1,146 @@
+package v2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/PlakarKorp/integration-fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func TestCorsMiddleware(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := corsMiddleware(next)
+
+	// Normal request passes through and gets CORS headers.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/foo", nil)
+	h.ServeHTTP(rec, req)
+	require.True(t, called)
+	require.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Preflight OPTIONS short-circuits with 204 and does not call next.
+	called = false
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodOptions, "/api/foo", nil)
+	h.ServeHTTP(rec2, req2)
+	require.False(t, called)
+	require.Equal(t, http.StatusNoContent, rec2.Code)
+}
+
+// Drive the real Ui server: it serves the embedded frontend and the api routes,
+// then shuts down when the app context is cancelled.
+func TestUiServesFrontendAndShutsDown(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	listenAddr := fmt.Sprintf("localhost:%d", 47213)
+
+	srvErr := make(chan error, 1)
+	go func() {
+		srvErr <- Ui(repo, ctx, listenAddr, &UiOptions{NoSpawn: true, Cors: true})
+	}()
+
+	base := "http://" + listenAddr
+
+	// Poll until the server is accepting connections.
+	client := &http.Client{Timeout: 2 * time.Second}
+	var ready bool
+	for i := 0; i < 100; i++ {
+		resp, err := client.Get(base + "/")
+		if err == nil {
+			resp.Body.Close()
+			ready = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.True(t, ready, "server did not come up")
+
+	// Root path -> index.html fallback (path does not exist as a real file).
+	resp, err := client.Get(base + "/some/spa/route")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, body)
+
+	// A real embedded asset is served directly.
+	resp2, err := client.Get(base + "/favicon.ico")
+	require.NoError(t, err)
+	resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	// CORS preflight handled by middleware.
+	req, _ := http.NewRequest(http.MethodOptions, base+"/api/v1/info", nil)
+	resp3, err := client.Do(req)
+	require.NoError(t, err)
+	resp3.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp3.StatusCode)
+
+	// Output mentions the launch URL.
+	require.Contains(t, bufOut.String(), "launching webUI at")
+
+	// Cancel the app context to trigger graceful shutdown.
+	ctx.Cancel(errors.New("test done"))
+
+	select {
+	case err := <-srvErr:
+		// http.ErrServerClosed is the expected return after Shutdown.
+		if err != nil {
+			require.ErrorIs(t, err, http.ErrServerClosed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down")
+	}
+}
+
+// With a token configured, the launch URL embeds the token query param.
+func TestUiTokenURL(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	listenAddr := "localhost:47214"
+	srvErr := make(chan error, 1)
+	go func() {
+		srvErr <- Ui(repo, ctx, listenAddr, &UiOptions{NoSpawn: true, Token: "sekret"})
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	for i := 0; i < 100; i++ {
+		resp, err := client.Get("http://" + listenAddr + "/")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	require.Contains(t, bufOut.String(), "plakar_token=sekret")
+
+	ctx.Cancel(errors.New("done"))
+	select {
+	case <-srvErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down")
+	}
+}

--- a/utils/config_handler_test.go
+++ b/utils/config_handler_test.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveAndLoadConfigRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	cfg.DefaultRepository = "main"
+	cfg.Repositories["main"] = map[string]string{"location": "/var/backups"}
+	cfg.Sources["laptop"] = map[string]string{"location": "fs:///home"}
+	cfg.Destinations["restore"] = map[string]string{"location": "fs:///restore"}
+
+	require.NoError(t, SaveConfig(dir, cfg))
+
+	// Files were written in the new format.
+	for _, f := range []string{"sources.yml", "destinations.yml", "stores.yml"} {
+		_, err := os.Stat(filepath.Join(dir, f))
+		require.NoError(t, err, "expected %s to exist", f)
+	}
+
+	loaded, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "main", loaded.DefaultRepository)
+	require.Equal(t, "/var/backups", loaded.Repositories["main"]["location"])
+	require.Equal(t, "fs:///home", loaded.Sources["laptop"]["location"])
+	require.Equal(t, "fs:///restore", loaded.Destinations["restore"]["location"])
+}
+
+func TestLoadConfigFallbackFromOldFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// No new-format files exist, but an old plakar.yml does.
+	old := `default-repo: main
+repositories:
+  main:
+    location: /var/backups
+remotes:
+  src:
+    location: fs:///home
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plakar.yml"), []byte(old), 0600))
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "main", cfg.DefaultRepository)
+	require.Equal(t, "/var/backups", cfg.Repositories["main"]["location"])
+	require.Equal(t, "fs:///home", cfg.Sources["src"]["location"])
+
+	// The fallback path migrates the config to the new format on disk.
+	_, err = os.Stat(filepath.Join(dir, "stores.yml"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "sources.yml"))
+	require.NoError(t, err)
+}
+
+func TestLoadConfigEmptyDirGivesEmptyConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "", cfg.DefaultRepository)
+	require.Empty(t, cfg.Repositories)
+}
+
+func TestLoadConfigLegacyKlosetsFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// New-format sources/destinations present...
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\nsources: {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "destinations.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\ndestinations: {}\n"), 0600))
+	// ...but the stores live in the legacy klosets.yml file.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "klosets.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\ndefault: main\nstores:\n  main:\n    location: /repo\n"), 0600))
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "main", cfg.DefaultRepository)
+	require.Equal(t, "/repo", cfg.Repositories["main"]["location"])
+}
+
+func TestLoadConfigOldFormatStoresWithDefaultMarker(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\nsources: {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "destinations.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\ndestinations: {}\n"), 0600))
+
+	// Old-format stores file (no version, top-level is the store map, with
+	// a .isDefault marker). This exercises the fallback decode path.
+	stores := `main:
+  location: /repo
+  .isDefault: "true"
+backup:
+  location: /backup
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stores.yml"), []byte(stores), 0600))
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "main", cfg.DefaultRepository)
+	require.Equal(t, "/repo", cfg.Repositories["main"]["location"])
+	require.Equal(t, "/backup", cfg.Repositories["backup"]["location"])
+	// The marker key is stripped out.
+	_, ok := cfg.Repositories["main"][".isDefault"]
+	require.False(t, ok)
+}
+
+func TestLoadConfigOldFormatMultipleDefaultsErrors(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\nsources: {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "destinations.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\ndestinations: {}\n"), 0600))
+
+	stores := `main:
+  location: /repo
+  .isDefault: "true"
+backup:
+  location: /backup
+  .isDefault: "true"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stores.yml"), []byte(stores), 0600))
+
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple default store")
+}

--- a/utils/config_loaders_test.go
+++ b/utils/config_loaders_test.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadINI(t *testing.T) {
+	data := `[remote]
+location = s3://bucket
+key = value
+
+[other]
+foo = bar
+`
+	res, err := LoadINI(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket", res["remote"]["location"])
+	require.Equal(t, "value", res["remote"]["key"])
+	require.Equal(t, "bar", res["other"]["foo"])
+}
+
+func TestLoadINIInvalid(t *testing.T) {
+	// A line with no section and malformed content -> ini parse error.
+	_, err := LoadINI(strings.NewReader("=no-key\n[unterminated"))
+	require.Error(t, err)
+}
+
+func TestLoadYAML(t *testing.T) {
+	data := `remote:
+  location: s3://bucket
+  count: 3
+  enabled: true
+scalar: ignored
+`
+	res, err := LoadYAML(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket", res["remote"]["location"])
+	// non-string scalars are stringified by toString
+	require.Equal(t, "3", res["remote"]["count"])
+	require.Equal(t, "true", res["remote"]["enabled"])
+	// non-object top-level keys are skipped
+	_, ok := res["scalar"]
+	require.False(t, ok)
+}
+
+func TestLoadYAMLInvalid(t *testing.T) {
+	_, err := LoadYAML(strings.NewReader("foo: [bar"))
+	require.Error(t, err)
+}
+
+func TestLoadJSON(t *testing.T) {
+	data := `{"remote": {"location": "s3://bucket", "key": "value"}}`
+	res, err := LoadJSON(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket", res["remote"]["location"])
+	require.Equal(t, "value", res["remote"]["key"])
+}
+
+func TestLoadJSONInvalid(t *testing.T) {
+	_, err := LoadJSON(strings.NewReader("{not json"))
+	require.Error(t, err)
+}
+
+func TestGetConfYAML(t *testing.T) {
+	data := `remote:
+  location: s3://bucket
+  empty:
+  key: value
+`
+	res, err := GetConf(strings.NewReader(data), "")
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket", res["remote"]["location"])
+	require.Equal(t, "value", res["remote"]["key"])
+	// empty values are stripped
+	_, ok := res["remote"]["empty"]
+	require.False(t, ok)
+}
+
+func TestGetConfMissingLocation(t *testing.T) {
+	data := `remote:
+  key: value
+`
+	_, err := GetConf(strings.NewReader(data), "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing 'location' key")
+}
+
+func TestGetConfThirdParty(t *testing.T) {
+	// With a thirdParty set, keys are prefixed and a synthetic location added.
+	data := `remote:
+  host: example.com
+  user: bob
+`
+	res, err := GetConf(strings.NewReader(data), "rclone")
+	require.NoError(t, err)
+	require.Equal(t, "rclone://", res["remote"]["location"])
+	require.Equal(t, "example.com", res["remote"]["rclone_host"])
+	require.Equal(t, "bob", res["remote"]["rclone_user"])
+	// original (unprefixed) keys are gone
+	_, ok := res["remote"]["host"]
+	require.False(t, ok)
+}
+
+func TestGetConfINI(t *testing.T) {
+	// INI parsing is the last fallback after YAML and JSON both fail to
+	// produce a usable structure.
+	data := "[remote]\nlocation = s3://bucket\nkey = value\n"
+	res, err := GetConf(strings.NewReader(data), "")
+	require.NoError(t, err)
+	require.Equal(t, "s3://bucket", res["remote"]["location"])
+	require.Equal(t, "value", res["remote"]["key"])
+}

--- a/utils/config_policy_test.go
+++ b/utils/config_policy_test.go
@@ -1,0 +1,272 @@
+package utils
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/locate"
+	"github.com/stretchr/testify/require"
+)
+
+func newPolicies() *policiesConfig {
+	return &policiesConfig{
+		Version:  "v1.0.0",
+		Policies: map[string]*locate.LocateOptions{},
+	}
+}
+
+func TestPolicyHasAddRemove(t *testing.T) {
+	c := newPolicies()
+	require.False(t, c.Has("daily"))
+	c.Add("daily")
+	require.True(t, c.Has("daily"))
+	require.NotNil(t, c.Policies["daily"])
+	c.Remove("daily")
+	require.False(t, c.Has("daily"))
+}
+
+func TestPolicySetInt(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+
+	require.NoError(t, c.Set("p", "days", "7"))
+	require.Equal(t, 7, c.Policies["p"].Periods.Day.Keep)
+
+	require.NoError(t, c.Set("p", "per-hour", "3"))
+	require.Equal(t, 3, c.Policies["p"].Periods.Hour.Cap)
+
+	// non-numeric
+	err := c.Set("p", "days", "abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid value")
+
+	// negative
+	err = c.Set("p", "days", "-1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "negative value")
+}
+
+func TestPolicySetString(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "name", "myname"))
+	require.Equal(t, "myname", c.Policies["p"].Filters.Name)
+
+	require.NoError(t, c.Set("p", "category", "cat"))
+	require.Equal(t, "cat", c.Policies["p"].Filters.Category)
+}
+
+func TestPolicySetStringList(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "tags", "a,b,c"))
+	require.Equal(t, []string{"a", "b", "c"}, c.Policies["p"].Filters.Tags)
+}
+
+func TestPolicySetTime(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "before", "2025-04-15"))
+	require.False(t, c.Policies["p"].Filters.Before.IsZero())
+
+	err := c.Set("p", "before", "not-a-date")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid value")
+}
+
+func TestPolicySetBool(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "latest", "true"))
+	require.True(t, c.Policies["p"].Filters.Latest)
+
+	err := c.Set("p", "latest", "notbool")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid value")
+}
+
+func TestPolicySetUnknownKeyOrEntry(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+
+	err := c.Set("p", "nope", "x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid key")
+
+	err = c.Set("missing", "days", "1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "entry not found")
+}
+
+func TestPolicyUnset(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+
+	require.NoError(t, c.Set("p", "days", "7"))
+	require.NoError(t, c.Set("p", "name", "foo"))
+	require.NoError(t, c.Set("p", "tags", "a,b"))
+	require.NoError(t, c.Set("p", "before", "2025-04-15"))
+	require.NoError(t, c.Set("p", "latest", "true"))
+
+	require.NoError(t, c.Unset("p", "days"))
+	require.Equal(t, 0, c.Policies["p"].Periods.Day.Keep)
+
+	require.NoError(t, c.Unset("p", "name"))
+	require.Equal(t, "", c.Policies["p"].Filters.Name)
+
+	require.NoError(t, c.Unset("p", "tags"))
+	require.Nil(t, c.Policies["p"].Filters.Tags)
+
+	require.NoError(t, c.Unset("p", "before"))
+	require.True(t, c.Policies["p"].Filters.Before.IsZero())
+
+	require.NoError(t, c.Unset("p", "latest"))
+	require.False(t, c.Policies["p"].Filters.Latest)
+
+	err := c.Unset("p", "nope")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid key")
+}
+
+func TestPolicyAllLocateFields(t *testing.T) {
+	// Exercise every key understood by locateField via Set, so the big
+	// switch is fully covered.
+	intKeys := []string{
+		"minutes", "hours", "days", "weeks", "months", "years",
+		"mondays", "tuesdays", "wednesdays", "thursdays", "fridays", "saturdays", "sundays",
+		"per-minute", "per-hour", "per-day", "per-week", "per-month", "per-year",
+		"per-monday", "per-tuesday", "per-wednesday", "per-thursday", "per-friday",
+		"per-saturday", "per-sunday",
+	}
+	stringKeys := []string{
+		"name", "category", "environment", "perimeter", "job",
+	}
+	listKeys := []string{"tags", "ids", "roots"}
+	timeKeys := []string{"before", "since"}
+
+	c := newPolicies()
+	c.Add("p")
+
+	for _, k := range intKeys {
+		require.NoError(t, c.Set("p", k, "1"), "int key %s", k)
+	}
+	for _, k := range stringKeys {
+		require.NoError(t, c.Set("p", k, "v"), "string key %s", k)
+	}
+	for _, k := range listKeys {
+		require.NoError(t, c.Set("p", k, "a,b"), "list key %s", k)
+	}
+	for _, k := range timeKeys {
+		require.NoError(t, c.Set("p", k, "2025-04-15"), "time key %s", k)
+	}
+	require.NoError(t, c.Set("p", "latest", "true"))
+
+	require.Equal(t, "v", c.Policies["p"].Filters.Environment)
+	require.Equal(t, "v", c.Policies["p"].Filters.Perimeter)
+	require.Equal(t, "v", c.Policies["p"].Filters.Job)
+	require.Equal(t, []string{"a", "b"}, c.Policies["p"].Filters.IDs)
+	require.Equal(t, []string{"a", "b"}, c.Policies["p"].Filters.Roots)
+	require.False(t, c.Policies["p"].Filters.Since.IsZero())
+	require.Equal(t, 1, c.Policies["p"].Periods.Minute.Keep)
+	require.Equal(t, 1, c.Policies["p"].Periods.Month.Cap)
+}
+
+func TestPolicyWeekdayKeys(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "mondays", "2"))
+	require.Equal(t, 2, c.Policies["p"].Periods.Monday.Keep)
+	require.NoError(t, c.Set("p", "per-sunday", "5"))
+	require.Equal(t, 5, c.Policies["p"].Periods.Sunday.Cap)
+	require.NoError(t, c.Set("p", "weeks", "4"))
+	require.Equal(t, 4, c.Policies["p"].Periods.Week.Keep)
+	require.NoError(t, c.Set("p", "per-year", "1"))
+	require.Equal(t, 1, c.Policies["p"].Periods.Year.Cap)
+}
+
+func TestPolicyDumpJSONAndYAML(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "days", "7"))
+
+	var jsonBuf bytes.Buffer
+	require.NoError(t, c.Dump(&jsonBuf, "json", []string{"p"}))
+	require.Contains(t, jsonBuf.String(), "\"p\"")
+
+	var yamlBuf bytes.Buffer
+	require.NoError(t, c.Dump(&yamlBuf, "yaml", nil))
+	require.Contains(t, yamlBuf.String(), "p:")
+
+	// unknown format
+	var b bytes.Buffer
+	err := c.Dump(&b, "xml", []string{"p"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown format")
+
+	// unknown entry
+	err = c.Dump(&b, "json", []string{"missing"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestPolicySaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "policies.yml")
+
+	c := newPolicies()
+	c.Add("daily")
+	require.NoError(t, c.Set("daily", "days", "7"))
+	require.NoError(t, c.Set("daily", "name", "nightly"))
+
+	require.NoError(t, c.SaveToFile(file))
+	_, err := os.Stat(file)
+	require.NoError(t, err)
+
+	loaded, err := LoadPolicyConfigFile(file)
+	require.NoError(t, err)
+	require.True(t, loaded.Has("daily"))
+	require.Equal(t, 7, loaded.Policies["daily"].Periods.Day.Keep)
+	require.Equal(t, "nightly", loaded.Policies["daily"].Filters.Name)
+}
+
+func TestLoadPolicyConfigFileMissing(t *testing.T) {
+	// Missing file returns an initialized, empty config.
+	c, err := LoadPolicyConfigFile(filepath.Join(t.TempDir(), "nope.yml"))
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	require.Empty(t, c.Policies)
+	require.Equal(t, "v1.0.0", c.Version)
+}
+
+func TestLoadPolicyConfigFileInvalid(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "bad.yml")
+	require.NoError(t, os.WriteFile(file, []byte("policies: [unterminated"), 0600))
+	_, err := LoadPolicyConfigFile(file)
+	require.Error(t, err)
+}
+
+func TestPolicyLoadFromReader(t *testing.T) {
+	c := newPolicies()
+	data := "version: v1.0.0\npolicies:\n  weekly:\n    Filters:\n      Name: w\n"
+	require.NoError(t, c.Load(strings.NewReader(data)))
+	require.True(t, c.Has("weekly"))
+}
+
+func TestPolicyApplyConfig(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "days", "9"))
+
+	var po locate.LocateOptions
+	c.ApplyConfig("p", &po)
+	require.Equal(t, 9, po.Periods.Day.Keep)
+
+	// Applying a missing entry leaves the target untouched.
+	var po2 locate.LocateOptions
+	c.ApplyConfig("missing", &po2)
+	require.Equal(t, 0, po2.Periods.Day.Keep)
+}

--- a/utils/oldconfig_test.go
+++ b/utils/oldconfig_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOldConfigIfExistsMissing(t *testing.T) {
+	// Non-existent file returns a fresh, empty config without error.
+	cfg, err := LoadOldConfigIfExists(filepath.Join(t.TempDir(), "does-not-exist.yml"))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Empty(t, cfg.Repositories)
+	require.Empty(t, cfg.Sources)
+}
+
+func TestLoadOldConfigIfExistsValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plakar.yml")
+	content := `default-repo: main
+repositories:
+  main:
+    location: /var/backups
+remotes:
+  laptop:
+    location: fs:///home/user
+    foo: bar
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	cfg, err := LoadOldConfigIfExists(path)
+	require.NoError(t, err)
+	require.Equal(t, "main", cfg.DefaultRepository)
+	require.Equal(t, "/var/backups", cfg.Repositories["main"]["location"])
+
+	// Remotes become Sources.
+	require.Equal(t, "fs:///home/user", cfg.Sources["laptop"]["location"])
+	require.Equal(t, "bar", cfg.Sources["laptop"]["foo"])
+
+	// Destinations are derived (copied) from the sources.
+	require.Equal(t, "fs:///home/user", cfg.Destinations["laptop"]["location"])
+	require.Equal(t, "bar", cfg.Destinations["laptop"]["foo"])
+
+	// The destination copy is independent of the source map.
+	cfg.Destinations["laptop"]["foo"] = "changed"
+	require.Equal(t, "bar", cfg.Sources["laptop"]["foo"])
+}
+
+func TestLoadOldConfigIfExistsInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plakar.yml")
+	require.NoError(t, os.WriteFile(path, []byte("default-repo: [unterminated"), 0600))
+
+	_, err := LoadOldConfigIfExists(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse old config file")
+}

--- a/utils/opts_test.go
+++ b/utils/opts_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptsFlagStringNil(t *testing.T) {
+	o := NewOptsFlag(nil)
+	require.Equal(t, "", o.String())
+}
+
+func TestOptsFlagSetAndString(t *testing.T) {
+	o := NewOptsFlag(map[string]string{})
+
+	// key=value form
+	require.NoError(t, o.Set("foo=bar"))
+	// key without '=' defaults to "true"
+	require.NoError(t, o.Set("flag"))
+	// value containing '=' keeps everything after the first '='
+	require.NoError(t, o.Set("kv=a=b"))
+
+	s := o.String()
+	// Map iteration order is non-deterministic; assert on the parts.
+	require.Contains(t, s, "foo=bar")
+	require.Contains(t, s, "flag=true")
+	require.Contains(t, s, "kv=a=b")
+
+	// Entries are space-separated; with 3 entries we expect 2 spaces.
+	require.Equal(t, 2, strings.Count(s, " "))
+}
+
+func TestOptsFlagSetOverwrites(t *testing.T) {
+	m := map[string]string{}
+	o := NewOptsFlag(m)
+	require.NoError(t, o.Set("k=1"))
+	require.NoError(t, o.Set("k=2"))
+	require.Equal(t, "2", m["k"])
+	require.Equal(t, "k=2", o.String())
+}

--- a/utils/time_extra_test.go
+++ b/utils/time_extra_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimeFlagDateTimeNoSeconds(t *testing.T) {
+	// Covers the "2006-01-02 15:04" layout branch.
+	expected, _ := time.Parse("2006-01-02 15:04", "2025-04-15 10:30")
+	got, err := ParseTimeFlag("2025-04-15 10:30")
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}
+
+func TestTimeFlagStringZero(t *testing.T) {
+	// nil dest -> empty
+	tf := NewTimeFlag(nil)
+	require.Equal(t, "", tf.String())
+
+	// zero time -> empty
+	var z time.Time
+	tf = NewTimeFlag(&z)
+	require.Equal(t, "", tf.String())
+}
+
+func TestTimeFlagStringNonZero(t *testing.T) {
+	tm := time.Date(2025, 4, 15, 10, 0, 0, 0, time.UTC)
+	tf := NewTimeFlag(&tm)
+	require.Equal(t, tm.String(), tf.String())
+}
+
+func TestTimeFlagSetValid(t *testing.T) {
+	var dest time.Time
+	tf := NewTimeFlag(&dest)
+	require.NoError(t, tf.Set("2025-04-15"))
+	expected, _ := time.Parse("2006-01-02", "2025-04-15")
+	require.Equal(t, expected, dest)
+	require.Equal(t, expected, *tf.dest)
+}
+
+func TestTimeFlagSetInvalid(t *testing.T) {
+	var dest time.Time
+	tf := NewTimeFlag(&dest)
+	err := tf.Set("not-a-time")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid time format")
+	// dest left untouched (zero)
+	require.True(t, dest.IsZero())
+}
+
+func TestTimeFlagSetDuration(t *testing.T) {
+	var dest time.Time
+	tf := NewTimeFlag(&dest)
+	now := time.Now()
+	require.NoError(t, tf.Set("1h"))
+	require.WithinDuration(t, now.Add(-time.Hour), dest, 2*time.Second)
+}

--- a/utils/utils_extra_test.go
+++ b/utils/utils_extra_test.go
@@ -1,0 +1,127 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEmail(t *testing.T) {
+	addr, err := ValidateEmail("user@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "user@example.com", addr)
+
+	_, err = ValidateEmail("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be empty")
+
+	_, err = ValidateEmail("not-an-email")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid email address")
+
+	// Address with display name: ParseAddress succeeds but the parsed
+	// address won't equal the raw input, so it is rejected.
+	_, err = ValidateEmail("Bob <bob@example.com>")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid email address")
+}
+
+func TestGetPassphraseFromCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+
+	pass, err := GetPassphraseFromCommand("echo hunter2")
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", pass)
+}
+
+func TestGetPassphraseFromCommandTooManyLines(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	_, err := GetPassphraseFromCommand("printf 'a\\nb\\n'")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many lines")
+}
+
+func TestGetPassphraseFromCommandFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	// Command exits non-zero -> Wait returns an error.
+	_, err := GetPassphraseFromCommand("echo x; exit 1")
+	require.Error(t, err)
+}
+
+func TestGetDataDirWithEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	dataEnv := "XDG_DATA_HOME"
+	if runtime.GOOS == "windows" {
+		dataEnv = "LocalAppData"
+	}
+	t.Setenv(dataEnv, tempDir)
+
+	dataDir, err := GetDataDir("testapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(tempDir, "testapp"), dataDir)
+	require.True(t, filepath.IsAbs(dataDir))
+}
+
+func TestGetDataDirDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("default path differs on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	dataDir, err := GetDataDir("testapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, ".local", "share", "testapp"), dataDir)
+}
+
+func TestGetCacheDirDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("default path differs on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	cacheDir, err := GetCacheDir("testapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, ".cache", "testapp"), cacheDir)
+}
+
+func TestGetConfigDirDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("default path differs on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	configDir, err := GetConfigDir("testapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, ".config", "testapp"), configDir)
+}
+
+func TestShouldCheckUpdateDevelVersion(t *testing.T) {
+	// VERSION in this build contains "devel", so update checks are skipped
+	// and no cookie is created.
+	dir := t.TempDir()
+	require.False(t, shouldCheckUpdate(dir))
+	_, err := os.Stat(filepath.Join(dir, "last-update-check"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestSanitizeTextRoundTripPrintable(t *testing.T) {
+	// Sanity check that unicode printable runes are preserved.
+	in := "héllo wörld"
+	require.Equal(t, in, SanitizeText(in))
+	require.True(t, issafe(in))
+}

--- a/utils/utils_more2_test.go
+++ b/utils/utils_more2_test.go
@@ -1,0 +1,151 @@
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/config"
+	"github.com/stretchr/testify/require"
+)
+
+// failWriter always fails on Write, to exercise encoder error paths.
+type failWriter struct{}
+
+func (failWriter) Write(p []byte) (int, error) { return 0, errors.New("boom") }
+
+func TestLoadConfigMalformedSourcesReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	// A malformed sources.yml that is neither valid new nor old format makes
+	// load() return a non-IsNotExist error, which Load() propagates.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("sources: [unterminated"), 0600))
+
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse config file")
+}
+
+func TestLoadConfigMalformedDestinationsReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\nsources: {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "destinations.yml"),
+		[]byte("destinations: [unterminated"), 0600))
+
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+}
+
+func TestLoadConfigMalformedStoresReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\nsources: {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "destinations.yml"),
+		[]byte("version: "+CONFIG_VERSION+"\ndestinations: {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stores.yml"),
+		[]byte("stores: [unterminated"), 0600))
+
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+}
+
+func TestLoadConfigEmptyFilesAreTreatedAsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// Zero-length files exercise the info.Size()==0 early-return in load().
+	for _, f := range []string{"sources.yml", "destinations.yml", "stores.yml"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f), nil, 0600))
+	}
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Repositories)
+	require.Empty(t, cfg.Sources)
+}
+
+func TestLoadFallbackInvalidOldConfig(t *testing.T) {
+	dir := t.TempDir()
+	// No new-format files; the old plakar.yml is malformed, so LoadFallback
+	// surfaces the read error.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plakar.yml"),
+		[]byte("default-repo: [unterminated"), 0600))
+
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error reading file")
+}
+
+func TestSaveConfigMkdirFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission checks")
+	}
+	parent := t.TempDir()
+	// Make the parent unwritable so MkdirAll of a child fails.
+	require.NoError(t, os.Chmod(parent, 0500))
+	t.Cleanup(func() { os.Chmod(parent, 0700) })
+
+	cfg := config.NewConfig()
+	err := SaveConfig(filepath.Join(parent, "sub", "cfg"), cfg)
+	require.Error(t, err)
+}
+
+func TestGetConfReadError(t *testing.T) {
+	_, err := GetConf(failReader{}, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read config data")
+}
+
+type failReader struct{}
+
+func (failReader) Read(p []byte) (int, error) { return 0, errors.New("read boom") }
+
+func TestGetConfUnparseable(t *testing.T) {
+	// Content that fails YAML, JSON and INI parsing.
+	_, err := GetConf(bytes.NewReader([]byte("\x00\x01\x02not valid anything\x00")), "")
+	require.Error(t, err)
+}
+
+func TestPolicySetTimeUnsetKeepsZero(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	require.NoError(t, c.Set("p", "since", "2025-01-02"))
+	require.False(t, c.Policies["p"].Filters.Since.IsZero())
+	require.NoError(t, c.Unset("p", "since"))
+	require.True(t, c.Policies["p"].Filters.Since.IsZero())
+}
+
+func TestPolicyDumpEncodeError(t *testing.T) {
+	c := newPolicies()
+	c.Add("p")
+	err := c.Dump(failWriter{}, "json", []string{"p"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to encode")
+}
+
+func TestPolicySaveToFileBadDir(t *testing.T) {
+	// A filename whose directory does not exist makes CreateTemp fail.
+	err := newPolicies().SaveToFile(filepath.Join(t.TempDir(), "no-such-dir", "p.yml"))
+	require.Error(t, err)
+}
+
+func TestPolicyUnsetMissingEntry(t *testing.T) {
+	c := newPolicies()
+	err := c.Unset("missing", "days")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "entry not found")
+}
+
+func TestToStringViaLoadYAML(t *testing.T) {
+	// Exercises the default branch of toString (a nested object value gets
+	// stringified to "").
+	data := "remote:\n  nested:\n    a: b\n  ok: value\n"
+	res, err := LoadYAML(bytes.NewReader([]byte(data)))
+	require.NoError(t, err)
+	require.Equal(t, "value", res["remote"]["ok"])
+	require.Equal(t, "", res["remote"]["nested"])
+}


### PR DESCRIPTION
The test suite sat around 24% statement coverage. This brings it to ~61% without touching any non-test code.

Most of it is the obvious gaps: the api handlers now run against a real fs-backed repository over httptest, the subcommand packages (diag, diff, config, pkg, cached, sync, service, backup, ptar, repair, login, info, cat, check, rm, prune, dup, ui, mount/http) get their Parse and Execute paths exercised through the usual Lookup/Parse/Execute harness, and the services, server/httpd, plugins, reporting, cached, login, task and ui packages plus the root command dispatcher all gain their first real coverage.

Paths that need a live cached daemon, a real network call to api.plakar.io, a TTY for passphrase entry, or an actual OS mount are left alone — they can't run hermetically under `go test`, and forcing them would mean reshaping the code just to test it. The FUSE filesystem and the bubbletea TUI are untouched for the same reason.

(Tests largely generated with help from our friend.)
