### PR TITLE
test: raise overall coverage past 60%

### DIFF
--- a/api/api_coverage_test.go
+++ b/api/api_coverage_test.go
@@ -1,0 +1,381 @@
+package api
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// covServer builds a real repository with a richer snapshot than newAPIServer
+// (nested dirs, multiple files) and wires SetupRoutes with norefresh=true.
+// Distinct name to avoid clashing with the team's newAPIServer helper.
+func covServer(t *testing.T) (*http.ServeMux, *repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
+	t.Helper()
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("subdir/foo.txt", 0644, "hello foo"),
+		ptesting.NewMockFile("subdir/baz.txt", 0644, "hello baz"),
+		ptesting.NewMockDir("subdir/nested"),
+		ptesting.NewMockFile("subdir/nested/deep.txt", 0644, "deep content"),
+		ptesting.NewMockFile("top.txt", 0644, "top level"),
+	})
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, "", true /* norefresh */)
+	return mux, repo, snap, ctx
+}
+
+func covGET(t *testing.T, mux *http.ServeMux, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func covSnapID(snap *snapshot.Snapshot) string {
+	id := snap.Header.GetIndexID()
+	return hex.EncodeToString(id[:])
+}
+
+// --- Auth middleware with a non-empty token --------------------------------
+
+func TestCovAuthTokenRequired(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "a"),
+	})
+	defer snap.Close()
+
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, "secret-token", true)
+
+	// Missing Authorization header -> 401.
+	w := covGET(t, mux, "/api/info")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Wrong token -> 401.
+	req, _ := http.NewRequest("GET", "/api/info", nil)
+	req.Header.Set("Authorization", "Bearer nope")
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Correct token -> 200.
+	req, _ = http.NewRequest("GET", "/api/info", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Contains(t, resp, "repository_id")
+	require.Contains(t, resp, "version")
+}
+
+// --- Snapshot header / not-found branches ----------------------------------
+
+func TestCovSnapshotHeaderNotFound(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+
+	// Valid hex, valid length, but no such snapshot -> 404.
+	w := covGET(t, mux, "/api/snapshot/7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c")
+	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCovSnapshotHeaderBadParam(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+
+	w := covGET(t, mux, "/api/snapshot/zz")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- VFS browse / children paging edges ------------------------------------
+
+func TestCovVFSBrowseRootAndFile(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	// Root directory (path empty -> "/").
+	w := covGET(t, mux, "/api/snapshot/vfs/"+id+":/")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// A regular file entry.
+	w = covGET(t, mux, "/api/snapshot/vfs/"+id+":/top.txt")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// Non-existent path -> error (not 200).
+	w = covGET(t, mux, "/api/snapshot/vfs/"+id+":/does/not/exist")
+	require.NotEqual(t, http.StatusOK, w.Code)
+}
+
+func TestCovVFSChildrenPaging(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	// Default listing of a directory with several entries.
+	w := covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var items Items[json.RawMessage]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.Greater(t, len(items.Items), 0)
+
+	// offset>0 path: exercises the ".." offset-decrement branch.
+	w = covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=2")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// Explicit sort key.
+	w = covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=Name")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCovVFSChildrenErrors(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	// children of a regular file -> 400 "not a directory".
+	w := covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/top.txt")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// invalid sort key -> 400.
+	w = covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=Bogus")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// invalid offset -> error.
+	w = covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=abc")
+	require.NotEqual(t, http.StatusOK, w.Code)
+}
+
+// --- VFS chunks paging -----------------------------------------------------
+
+func TestCovVFSChunksPaging(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	w := covGET(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?offset=0&limit=10")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "total")
+
+	// bad limit -> error.
+	w = covGET(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?limit=abc")
+	require.NotEqual(t, http.StatusOK, w.Code)
+}
+
+// --- VFS errors handler ----------------------------------------------------
+
+func TestCovVFSErrorsHandler(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	// happy path on a dir.
+	w := covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=10")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// invalid sort key -> 400.
+	w = covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=Bogus")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// -Name sort key is accepted.
+	w = covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=-Name")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// errors of a regular file -> 400 not a directory.
+	w = covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/top.txt")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- VFS search paging / mime edges ----------------------------------------
+
+func TestCovVFSSearchVariants(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	// recursive search with offset/limit and a name pattern.
+	w := covGET(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&offset=0&limit=1&pattern=txt")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "has_next")
+
+	// bad offset -> 400.
+	w = covGET(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?offset=abc")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// bad limit -> 400.
+	w = covGET(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=abc")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- Snapshot reader render error branch -----------------------------------
+
+func TestCovReaderInvalidRender(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=invalid")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// code render path.
+	w = covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=code")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// reader for a non-existent file -> error.
+	w = covGET(t, mux, "/api/snapshot/reader/"+id+":/nope.txt")
+	require.NotEqual(t, http.StatusOK, w.Code)
+}
+
+// --- Downloader: signed-url error flows ------------------------------------
+
+func TestCovDownloaderSignedNotFound(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+
+	// Unknown download id -> 404.
+	w := covGET(t, mux, "/api/snapshot/vfs/downloader-sign-url/does-not-exist?format=zip")
+	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCovDownloaderFormats(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	post := func() string {
+		body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
+		req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var resp struct {
+			Id string `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.NotEmpty(t, resp.Id)
+		return resp.Id
+	}
+
+	// tar format.
+	w := covGET(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+post()+"?format=tar")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Header().Get("Content-Type"), "tar")
+
+	// tarball format.
+	w = covGET(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+post()+"?format=tarball")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// unknown format -> 400.
+	w = covGET(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+post()+"?format=bogus")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCovDownloaderBadBody(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+	id := covSnapID(snap)
+
+	// malformed JSON body -> 400.
+	req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString("{not-json"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- Repository snapshots: filters, sort, offset/limit edges ---------------
+
+func TestCovRepositorySnapshotsFilters(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+
+	// importer filter that matches nothing -> total counts only matching ones.
+	w := covGET(t, mux, "/api/repository/snapshots?importer=nonexistent")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// since in the future -> no matching snapshots but still 200.
+	w = covGET(t, mux, "/api/repository/snapshots?since=2999-01-01T00:00:00Z")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// descending sort.
+	w = covGET(t, mux, "/api/repository/snapshots?sort=-Timestamp")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// offset beyond the number of headers -> empty items.
+	w = covGET(t, mux, "/api/repository/snapshots?offset=1000")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// invalid sort key -> 400.
+	w = covGET(t, mux, "/api/repository/snapshots?sort=Bogus")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// invalid offset -> error.
+	w = covGET(t, mux, "/api/repository/snapshots?offset=abc")
+	require.NotEqual(t, http.StatusOK, w.Code)
+}
+
+// --- Repository locate-pathname: filters and sort --------------------------
+
+func TestCovLocatePathnameFilters(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+
+	// Resource that exists in the snapshot.
+	w := covGET(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=-Timestamp")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "total")
+
+	// importerType filter that matches nothing.
+	w = covGET(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerType=nope")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// importerOrigin filter that matches nothing.
+	w = covGET(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerOrigin=nope")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// importerDirectory filter that matches nothing.
+	w = covGET(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerDirectory=nope")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// Resource that does not resolve in any snapshot -> empty result, 200.
+	w = covGET(t, mux, "/api/repository/locate-pathname?resource=/no/such/file")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// invalid sort key -> 400.
+	w = covGET(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=Bogus")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+	// offset beyond results.
+	w = covGET(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&offset=1000")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+// --- Importer types --------------------------------------------------------
+
+func TestCovImporterTypes(t *testing.T) {
+	mux, _, snap, _ := covServer(t)
+	defer snap.Close()
+
+	w := covGET(t, mux, "/api/repository/importer-types")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var items Items[map[string]string]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.Equal(t, items.Total, len(items.Items))
+}

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// runEntryPoint drives the global entryPoint() dispatcher in a hermetic
+// environment. It saves and restores all the global state entryPoint touches
+// (os.Args, os.Stdout, os.Stderr, flag.CommandLine) and points the config /
+// cache / data directories at per-test temp dirs via the XDG_* / HOME
+// environment variables. TERM=dumb forces the stdio renderer instead of the
+// TUI, and stdout/stderr are redirected through pipes because entryPoint
+// writes to os.Stdout / os.Stderr directly in several branches.
+//
+// It returns the process status code together with everything written to the
+// captured stdout and stderr.
+func runEntryPoint(t *testing.T, args ...string) (status int, stdout, stderr string) {
+	t.Helper()
+
+	// Hermetic directories.
+	base := t.TempDir()
+	for _, kv := range [][2]string{
+		{"HOME", base},
+		{"XDG_CONFIG_HOME", filepath.Join(base, "config")},
+		{"XDG_CACHE_HOME", filepath.Join(base, "cache")},
+		{"XDG_DATA_HOME", filepath.Join(base, "data")},
+		{"TERM", "dumb"},        // force stdio renderer, no TUI
+		{"PLAKAR_REPOSITORY", ""}, // don't inherit a real repo
+		{"PLAKAR_PASSPHRASE", ""}, // don't inherit a real passphrase
+	} {
+		t.Setenv(kv[0], kv[1])
+	}
+
+	// Save and restore global process state.
+	oldArgs := os.Args
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	oldFlag := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+		flag.CommandLine = oldFlag
+	})
+
+	// Fresh flag set so re-defining the same flags across calls doesn't panic.
+	flag.CommandLine = flag.NewFlagSet("plakar", flag.ContinueOnError)
+
+	// Redirect os.Stdout / os.Stderr through pipes.
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	outCh := make(chan string)
+	errCh := make(chan string)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, e := rOut.Read(buf)
+			if n > 0 {
+				b.Write(buf[:n])
+			}
+			if e != nil {
+				break
+			}
+		}
+		outCh <- b.String()
+	}()
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, e := rErr.Read(buf)
+			if n > 0 {
+				b.Write(buf[:n])
+			}
+			if e != nil {
+				break
+			}
+		}
+		errCh <- b.String()
+	}()
+
+	os.Args = append([]string{"plakar"}, args...)
+	status = entryPoint()
+
+	// Close the write ends so the reader goroutines terminate, then restore.
+	_ = wOut.Close()
+	_ = wErr.Close()
+	stdout = <-outCh
+	stderr = <-errCh
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	return status, stdout, stderr
+}
+
+// ---------- entryPoint: simple dispatch branches ----------
+
+func TestEntryPoint_Version(t *testing.T) {
+	status, stdout, _ := runEntryPoint(t, "version")
+	require.Equal(t, 0, status)
+	// The version subcommand prints the version string to stdout.
+	require.NotEmpty(t, strings.TrimSpace(stdout))
+}
+
+func TestEntryPoint_NoArgs(t *testing.T) {
+	status, _, stderr := runEntryPoint(t)
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "a subcommand must be provided")
+}
+
+func TestEntryPoint_BadCPUValue(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-cpu", "0", "version")
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "invalid -cpu value")
+}
+
+func TestEntryPoint_BadConcurrencyValue(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-concurrency", "0", "version")
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "invalid -concurrency value")
+}
+
+func TestEntryPoint_UnknownCommand(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "this-command-does-not-exist")
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "command not found")
+}
+
+// ---------- entryPoint: security-check toggle branches ----------
+
+func TestEntryPoint_DisableSecurityCheck(t *testing.T) {
+	status, stdout, _ := runEntryPoint(t, "-disable-security-check", "version")
+	require.Equal(t, 0, status)
+	require.Contains(t, stdout, "security check disabled")
+}
+
+func TestEntryPoint_EnableSecurityCheck(t *testing.T) {
+	// First disable, then enable, reusing the same temp HOME so the cookie
+	// state carries over within the single entryPoint call's lifecycle.
+	status, stdout, _ := runEntryPoint(t, "-enable-security-check", "version")
+	require.Equal(t, 0, status)
+	require.Contains(t, stdout, "security check enabled")
+}
+
+// ---------- entryPoint: keyfile error branch ----------
+
+func TestEntryPoint_MissingKeyfile(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-keyfile", "/no/such/keyfile", "version")
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "could not read key file")
+}
+
+// ---------- entryPoint: full create + info flow over a real fs repo ----------
+
+func TestEntryPoint_CreateThenInfo(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "repo")
+
+	// Create a plaintext repository at an explicit location.
+	status, _, stderr := runEntryPoint(t, "at", repoDir, "create", "-plaintext")
+	require.Equalf(t, 0, status, "create stderr: %s", stderr)
+
+	// The repository must now exist on disk.
+	_, err := os.Stat(repoDir)
+	require.NoError(t, err)
+
+	// Now run `info` against it: this exercises storage.Open,
+	// setupEncryption (nil path on a plaintext repo),
+	// repository.NewNoRebuild, cached.RebuildStateFromStore and
+	// task.RunCommand.
+	status, stdout, stderr := runEntryPoint(t, "at", repoDir, "info")
+	require.Equalf(t, 0, status, "info stderr: %s", stderr)
+	require.NotEmpty(t, stdout+stderr)
+}
+
+func TestEntryPoint_AtMissingCommand(t *testing.T) {
+	// `at <loc>` with no following command currently calls log.Fatalf, which
+	// would exit the test process. We only drive the parse branch that does
+	// NOT terminate: `at` with a location and a real (but failing) command.
+	// Opening a non-existent repo location yields the RepoNotFound exit code.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	status, _, stderr := runEntryPoint(t, "at", missing, "info")
+	require.NotEqual(t, 0, status)
+	require.Contains(t, stderr, "failed to open the repository")
+}
+
+// ---------- entryPoint: keyfile + plaintext repo unlock (nil secret) ----------
+
+func TestEntryPoint_KeyfileWithPlaintextRepo(t *testing.T) {
+	// A keyfile is supplied but the repo is plaintext: setupEncryption sees a
+	// nil Encryption config and the keyfile secret is simply ignored.
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	status, _, stderr := runEntryPoint(t, "at", repoDir, "create", "-plaintext")
+	require.Equalf(t, 0, status, "create stderr: %s", stderr)
+
+	keyfile := filepath.Join(t.TempDir(), "key")
+	require.NoError(t, os.WriteFile(keyfile, []byte("ignored-passphrase\n"), 0600))
+
+	status, _, stderr = runEntryPoint(t, "-keyfile", keyfile, "at", repoDir, "info")
+	require.Equalf(t, 0, status, "info stderr: %s", stderr)
+}
+
+// keep the ptesting import referenced even if future edits drop direct uses.
+var _ = ptesting.NewMockDir

--- a/subcommands/cached/cached_test.go
+++ b/subcommands/cached/cached_test.go
@@ -1,0 +1,210 @@
+package cached
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/encryption"
+	"github.com/PlakarKorp/kloset/hashing"
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/kloset/resources"
+	"github.com/PlakarKorp/kloset/versioning"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+func newCachedCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.Stdout = bytes.NewBuffer(nil)
+	ctx.Stderr = bytes.NewBuffer(nil)
+	// Use a short temp path: macOS sun_path is limited to 104 bytes.
+	dir, err := os.MkdirTemp("", "cd")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	ctx.CacheDir = dir
+	ctx.SetLogger(logging.NewLogger(ctx.Stdout, ctx.Stderr))
+	return ctx
+}
+
+// ---------------------------------------------------------------------------
+// Cached.Parse
+// ---------------------------------------------------------------------------
+
+func TestCachedParseForeground(t *testing.T) {
+	ctx := newCachedCtx(t)
+	cmd := &Cached{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-foreground"}))
+	require.Equal(t, filepath.Join(ctx.CacheDir, "cached.sock"), cmd.socketPath)
+	require.NotNil(t, cmd.jobQueue)
+	require.NotNil(t, cmd.runningJobs)
+	// default teardown is 5s
+	require.Equal(t, 5*time.Second, cmd.teardown)
+}
+
+func TestCachedParseTeardownFlag(t *testing.T) {
+	ctx := newCachedCtx(t)
+	cmd := &Cached{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-foreground", "-teardown", "250ms"}))
+	require.Equal(t, 250*time.Millisecond, cmd.teardown)
+}
+
+func TestCachedParseReexec(t *testing.T) {
+	ctx := newCachedCtx(t)
+	t.Setenv("REEXEC", "1")
+	// With REEXEC set, Parse does not daemonize even without -foreground.
+	// syslog setup may fail in CI; that path falls back to io.Discard and
+	// still returns nil.
+	cmd := &Cached{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.Equal(t, filepath.Join(ctx.CacheDir, "cached.sock"), cmd.socketPath)
+}
+
+func TestCachedParseLogfile(t *testing.T) {
+	ctx := newCachedCtx(t)
+	logfile := filepath.Join(ctx.CacheDir, "cached.log")
+	cmd := &Cached{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-foreground", "-log", logfile}))
+	_, err := os.Stat(logfile)
+	require.NoError(t, err)
+}
+
+func TestCachedParseLogfileError(t *testing.T) {
+	ctx := newCachedCtx(t)
+	// Point -log at a path whose parent does not exist -> open fails.
+	bad := filepath.Join(ctx.CacheDir, "missing-dir", "cached.log")
+	cmd := &Cached{}
+	err := cmd.Parse(ctx, []string{"-foreground", "-log", bad})
+	require.Error(t, err)
+}
+
+func TestCachedParseTooManyArgs(t *testing.T) {
+	ctx := newCachedCtx(t)
+	err := (&Cached{}).Parse(ctx, []string{"-foreground", "extra"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+// ---------------------------------------------------------------------------
+// Cached.Close
+// ---------------------------------------------------------------------------
+
+func TestCachedCloseMissingSocket(t *testing.T) {
+	ctx := newCachedCtx(t)
+	cmd := &Cached{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-foreground"}))
+	// No socket file exists yet; Close should tolerate ENOENT.
+	require.NoError(t, cmd.Close())
+}
+
+func TestCachedClosePresentSocket(t *testing.T) {
+	ctx := newCachedCtx(t)
+	cmd := &Cached{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-foreground"}))
+
+	// Create a real listening unix socket at socketPath, store the listener.
+	ln, err := net.Listen("unix", cmd.socketPath)
+	require.NoError(t, err)
+	cmd.listener = ln
+
+	require.NoError(t, cmd.Close())
+	// Close removes the socket file.
+	_, statErr := os.Stat(cmd.socketPath)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+// ---------------------------------------------------------------------------
+// isDisconnectError
+// ---------------------------------------------------------------------------
+
+type timeoutErr struct{ to bool }
+
+func (e timeoutErr) Error() string   { return "timeout" }
+func (e timeoutErr) Timeout() bool   { return e.to }
+func (e timeoutErr) Temporary() bool { return false }
+
+func TestIsDisconnectError(t *testing.T) {
+	require.True(t, isDisconnectError(io.EOF))
+	require.True(t, isDisconnectError(io.ErrUnexpectedEOF))
+	require.True(t, isDisconnectError(timeoutErr{to: true}))
+
+	require.False(t, isDisconnectError(nil))
+	require.False(t, isDisconnectError(io.ErrClosedPipe))
+	require.False(t, isDisconnectError(timeoutErr{to: false}))
+}
+
+// ---------------------------------------------------------------------------
+// getSecret
+// ---------------------------------------------------------------------------
+
+// wrapConfig serializes + wraps a storage.Configuration the same way the
+// repository does, producing the bytes getSecret expects.
+func wrapConfig(t *testing.T, config *storage.Configuration, key []byte) []byte {
+	t.Helper()
+	serialized, err := config.ToBytes()
+	require.NoError(t, err)
+
+	var hasher = hashing.GetHasher(storage.DEFAULT_HASHING_ALGORITHM)
+	if key != nil {
+		hasher = hashing.GetMACHasher(storage.DEFAULT_HASHING_ALGORITHM, key)
+	}
+	rd, err := storage.Serialize(hasher, resources.RT_CONFIG, versioning.GetCurrentVersion(resources.RT_CONFIG), bytes.NewReader(serialized))
+	require.NoError(t, err)
+	wrapped, err := io.ReadAll(rd)
+	require.NoError(t, err)
+	return wrapped
+}
+
+func TestGetSecretNoEncryption(t *testing.T) {
+	ctx := newCachedCtx(t)
+	config := storage.NewConfiguration()
+	config.Encryption = nil
+
+	wrapped := wrapConfig(t, config, nil)
+	key, err := getSecret(ctx, nil, wrapped)
+	require.NoError(t, err)
+	require.Nil(t, key)
+}
+
+func TestGetSecretMalformedConfig(t *testing.T) {
+	ctx := newCachedCtx(t)
+	_, err := getSecret(ctx, nil, []byte("not a wrapped config"))
+	require.Error(t, err)
+}
+
+func TestGetSecretCorrectAndWrongKey(t *testing.T) {
+	ctx := newCachedCtx(t)
+	config := storage.NewConfiguration()
+
+	passphrase := []byte("correct horse battery staple")
+	key, err := encryption.DeriveKey(config.Encryption.KDFParams, passphrase)
+	require.NoError(t, err)
+	canary, err := encryption.DeriveCanary(config.Encryption, key)
+	require.NoError(t, err)
+	config.Encryption.Canary = canary
+
+	wrapped := wrapConfig(t, config, key)
+
+	// Correct key verifies the canary and is returned unchanged.
+	got, err := getSecret(ctx, key, wrapped)
+	require.NoError(t, err)
+	require.Equal(t, key, got)
+
+	// Wrong key fails canary verification.
+	wrongKey := make([]byte, len(key))
+	copy(wrongKey, key)
+	wrongKey[0] ^= 0xff
+	_, err = getSecret(ctx, wrongKey, wrapped)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to verify key")
+}

--- a/subcommands/config/config_coverage_test.go
+++ b/subcommands/config/config_coverage_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	_ "github.com/PlakarKorp/integrations/fs/importer"
+	_ "github.com/PlakarKorp/integrations/fs/storage"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// covCtx builds an AppContext backed by an empty on-disk config in a temp dir.
+func covCtx(t *testing.T) (*appcontext.AppContext, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	cfg, err := utils.LoadOldConfigIfExists(filepath.Join(tmpDir, "config.yaml"))
+	require.NoError(t, err)
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := appcontext.NewAppContext()
+	ctx.Config = cfg
+	ctx.ConfigDir = tmpDir
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	return ctx, bufOut, bufErr
+}
+
+// fsLoc returns an absolute fs:/// location pointing at a fresh temp dir.
+func fsLoc(t *testing.T) string {
+	t.Helper()
+	return "fs://" + t.TempDir()
+}
+
+// ---------- check success (store / source / destination) ----------
+
+func TestCovCheckStoreSuccess(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	loc := fsLoc(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"r", loc}))
+	// fs storage backend opens cleanly even when uninitialized.
+	require.NoError(t, dispatchSubcommand(ctx, "store", "check", []string{"r"}))
+}
+
+func TestCovCheckSourceSuccess(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	loc := fsLoc(t)
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"s", loc}))
+	require.NoError(t, dispatchSubcommand(ctx, "source", "check", []string{"s"}))
+}
+
+func TestCovCheckDestinationSuccess(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	loc := fsLoc(t)
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"d", loc}))
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "check", []string{"d"}))
+}
+
+// ---------- ping success (store / source / destination) ----------
+
+func TestCovPingStoreSuccess(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	loc := fsLoc(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"r", loc}))
+	require.NoError(t, dispatchSubcommand(ctx, "store", "ping", []string{"r"}))
+}
+
+func TestCovPingSourceSuccess(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	loc := fsLoc(t)
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"s", loc}))
+	require.NoError(t, dispatchSubcommand(ctx, "source", "ping", []string{"s"}))
+}
+
+func TestCovPingDestinationSuccess(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	loc := fsLoc(t)
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"d", loc}))
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "ping", []string{"d"}))
+}
+
+// ---------- source add/set/unset/rm/show lifecycle ----------
+
+func TestCovSourceLifecycle(t *testing.T) {
+	ctx, bufOut, _ := covCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"s", "fs:/tmp/s", "k=v"}))
+	require.True(t, ctx.Config.HasSource("s"))
+	require.Equal(t, "v", ctx.Config.Sources["s"]["k"])
+
+	require.NoError(t, dispatchSubcommand(ctx, "source", "set", []string{"s", "k2=v2"}))
+	require.Equal(t, "v2", ctx.Config.Sources["s"]["k2"])
+
+	require.NoError(t, dispatchSubcommand(ctx, "source", "unset", []string{"s", "k2"}))
+	_, ok := ctx.Config.Sources["s"]["k2"]
+	require.False(t, ok)
+
+	bufOut.Reset()
+	require.NoError(t, dispatchSubcommand(ctx, "source", "show", []string{"s"}))
+	require.Contains(t, bufOut.String(), "s")
+
+	require.NoError(t, dispatchSubcommand(ctx, "source", "rm", []string{"s"}))
+	require.False(t, ctx.Config.HasSource("s"))
+}
+
+// ---------- destination add/set/unset/rm/show lifecycle ----------
+
+func TestCovDestinationLifecycle(t *testing.T) {
+	ctx, bufOut, _ := covCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"d", "fs:/tmp/d", "k=v"}))
+	require.True(t, ctx.Config.HasDestination("d"))
+
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "set", []string{"d", "k2=v2"}))
+	require.Equal(t, "v2", ctx.Config.Destinations["d"]["k2"])
+
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "unset", []string{"d", "k2"}))
+	_, ok := ctx.Config.Destinations["d"]["k2"]
+	require.False(t, ok)
+
+	bufOut.Reset()
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "show", []string{"-yaml", "d"}))
+	require.Contains(t, bufOut.String(), "d")
+
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "rm", []string{"d"}))
+	require.False(t, ctx.Config.HasDestination("d"))
+}
+
+// ---------- check/ping failure for unconfigured source & destination ----------
+
+func TestCovCheckSourceUnknownGetFails(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	// name exists in the map but with a bogus protocol -> NewImporter fails.
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"s", "bogus://x"}))
+	require.Error(t, dispatchSubcommand(ctx, "source", "check", []string{"s"}))
+}
+
+func TestCovCheckDestinationUnknownGetFails(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"d", "bogus://x"}))
+	require.Error(t, dispatchSubcommand(ctx, "destination", "check", []string{"d"}))
+}
+
+func TestCovPingSourceBadProto(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"s", "bogus://x"}))
+	require.Error(t, dispatchSubcommand(ctx, "source", "ping", []string{"s"}))
+}
+
+func TestCovPingDestinationBadProto(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "destination", "add", []string{"d", "bogus://x"}))
+	require.Error(t, dispatchSubcommand(ctx, "destination", "ping", []string{"d"}))
+}
+
+// ---------- source/destination check/ping on unknown name ----------
+
+func TestCovCheckPingMissingName(t *testing.T) {
+	ctx, _, _ := covCtx(t)
+	require.Error(t, dispatchSubcommand(ctx, "source", "check", []string{"ghost"}))
+	require.Error(t, dispatchSubcommand(ctx, "destination", "check", []string{"ghost"}))
+	require.Error(t, dispatchSubcommand(ctx, "source", "ping", []string{"ghost"}))
+	require.Error(t, dispatchSubcommand(ctx, "destination", "ping", []string{"ghost"}))
+}
+
+// ---------- policy lifecycle via dispatchPolicy (set/unset/show formats) ----------
+
+func TestCovPolicyShowFormatsAndUnset(t *testing.T) {
+	ctx, bufOut, _ := covCtx(t)
+	require.NoError(t, dispatchPolicy(ctx, "policy", "add", []string{"daily", "days=7"}))
+
+	// set a value, then show default (yaml), then json.
+	require.NoError(t, dispatchPolicy(ctx, "policy", "set", []string{"daily", "tags=auto,nightly"}))
+
+	bufOut.Reset()
+	require.NoError(t, dispatchPolicy(ctx, "policy", "show", []string{"daily"}))
+	require.Contains(t, bufOut.String(), "daily")
+
+	bufOut.Reset()
+	require.NoError(t, dispatchPolicy(ctx, "policy", "show", []string{"-json", "daily"}))
+	require.Contains(t, bufOut.String(), "{")
+
+	// unset a real key.
+	require.NoError(t, dispatchPolicy(ctx, "policy", "unset", []string{"daily", "tags"}))
+
+	// rm it.
+	require.NoError(t, dispatchPolicy(ctx, "policy", "rm", []string{"daily"}))
+}

--- a/subcommands/diag/diag_coverage_test.go
+++ b/subcommands/diag/diag_coverage_test.go
@@ -1,0 +1,413 @@
+package diag
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// covGenSnapshot builds a small repo+snapshot for the coverage tests. Distinct
+// name from the package's existing generateSnapshot helper.
+func covGenSnapshot(t *testing.T) (*repository.Repository, *snapshot.Snapshot, *appcontext.AppContext, *bytes.Buffer) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("subdir/foo.txt", 0644, "hello foo"),
+	})
+	return repo, snap, ctx, bufOut
+}
+
+// runDiag is a small helper that drives a diag subcommand end-to-end.
+func runDiag(t *testing.T, ctx *appcontext.AppContext, repo *repository.Repository, args []string) (int, error) {
+	t.Helper()
+	subcommand, _, rest := subcommands.Lookup(args)
+	require.NotNil(t, subcommand)
+	if err := subcommand.Parse(ctx, rest); err != nil {
+		return -1, err
+	}
+	return subcommand.Execute(ctx, repo)
+}
+
+// stateLines runs `diag state <serial>` and returns the per-blob index lines.
+func stateLines(t *testing.T, ctx *appcontext.AppContext, repo *repository.Repository, bufOut *bytes.Buffer) []string {
+	t.Helper()
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "state"})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	serial := strings.Trim(bufOut.String(), "\n")
+
+	bufOut.Reset()
+	status, err = runDiag(t, ctx, repo, []string{"diag", "state", serial})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	return strings.Split(strings.Trim(bufOut.String(), "\n"), "\n")
+}
+
+// --- diag repository (default subcommand) ----------------------------------
+
+func TestCovDiagRepositoryDefault(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag"})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.Contains(t, out, "Version:")
+	require.Contains(t, out, "RepositoryID:")
+	require.Contains(t, out, "Chunking:")
+	require.Contains(t, out, "Hashing:")
+	require.Contains(t, out, "Snapshots:")
+	require.Contains(t, out, "Size:")
+}
+
+func TestCovDiagRepositoryEncrypted(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	passphrase := []byte("correct horse battery staple")
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("secret.txt", 0644, "top secret"),
+	})
+	defer snap.Close()
+
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag"})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.Contains(t, out, "Encryption:")
+	require.Contains(t, out, "KDF:")
+	require.Contains(t, out, "Canary:")
+}
+
+// --- diag blob (success + error paths) -------------------------------------
+
+func TestCovDiagBlobSuccess(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	lines := stateLines(t, ctx, repo, bufOut)
+
+	// For each blob-type we know how to deserialize, find one index line and
+	// run `diag blob <type> <mac>`. We skip RT_CHUNK success (won't
+	// deserialize from a raw blob, per the brief) and only assert the ones
+	// that decode cleanly.
+	wantTypes := map[string]bool{
+		"snapshot":  true,
+		"object":    true,
+		"vfs-entry": true,
+	}
+
+	tested := map[string]bool{}
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		typ := fields[0]
+		if !wantTypes[typ] || tested[typ] {
+			continue
+		}
+		mac := fields[1]
+		if len(mac) != 64 {
+			continue
+		}
+		bufOut.Reset()
+		status, err := runDiag(t, ctx, repo, []string{"diag", "blob", typ, mac})
+		if err != nil {
+			// Type string may not round-trip through resources.FromString for
+			// every label printed by `diag state`; only assert on the ones
+			// that succeed.
+			continue
+		}
+		require.Equal(t, 0, status)
+		require.NotEmpty(t, strings.TrimSpace(bufOut.String()))
+		tested[typ] = true
+	}
+
+	require.NotEmpty(t, tested, "expected at least one blob type to be diagnosable")
+}
+
+func TestCovDiagBlobErrors(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Unknown blob type.
+	status, err := runDiag(t, ctx, repo, []string{"diag", "blob", "not-a-type", strings.Repeat("ab", 32)})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Non-hex mac.
+	status, err = runDiag(t, ctx, repo, []string{"diag", "blob", "object", "zzzz"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Wrong mac length (valid hex, but not 32 bytes).
+	status, err = runDiag(t, ctx, repo, []string{"diag", "blob", "object", "abcd"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Valid-looking mac but no such blob.
+	status, err = runDiag(t, ctx, repo, []string{"diag", "blob", "object", strings.Repeat("00", 32)})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCovDiagBlobChunkErrorPath(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	lines := stateLines(t, ctx, repo, bufOut)
+
+	var chunkMac string
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "chunk" && len(fields[1]) == 64 {
+			chunkMac = fields[1]
+			break
+		}
+	}
+	require.NotEmpty(t, chunkMac, "expected a chunk index line")
+
+	// Per the brief, RT_CHUNK won't deserialize from GetBlobBytes; this drives
+	// the error branch of the RT_CHUNK case (or the GetBlobBytes failure).
+	status, err := runDiag(t, ctx, repo, []string{"diag", "blob", "chunk", chunkMac})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCovDiagBlobParseError(t *testing.T) {
+	_, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Only one positional arg -> Parse usage error.
+	subcommand, _, rest := subcommands.Lookup([]string{"diag", "blob", "object"})
+	require.NotNil(t, subcommand)
+	err := subcommand.Parse(ctx, rest)
+	require.Error(t, err)
+}
+
+// --- diag blobsearch -------------------------------------------------------
+
+func TestCovDiagBlobSearch(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	lines := stateLines(t, ctx, repo, bufOut)
+
+	var objMac string
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "object" && len(fields[1]) == 64 {
+			objMac = fields[1]
+			break
+		}
+	}
+	require.NotEmpty(t, objMac, "expected an object index line")
+
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "blobsearch", objMac})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	out := bufOut.String()
+	require.Contains(t, out, "Warning this command is slow")
+	require.Contains(t, out, "Found candidate")
+}
+
+func TestCovDiagBlobSearchErrors(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Hash of wrong length -> Execute returns error.
+	status, err := runDiag(t, ctx, repo, []string{"diag", "blobsearch", "deadbeef"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// 64 chars but not valid hex.
+	status, err = runDiag(t, ctx, repo, []string{"diag", "blobsearch", strings.Repeat("z", 64)})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// No arg -> Parse error.
+	subcommand, _, rest := subcommands.Lookup([]string{"diag", "blobsearch"})
+	require.NotNil(t, subcommand)
+	err = subcommand.Parse(ctx, rest)
+	require.Error(t, err)
+}
+
+// --- diag dirpack ----------------------------------------------------------
+
+func TestCovDiagDirPack(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "dirpack", hex.EncodeToString(indexID[:])})
+	// dirpack may or may not have an index depending on snapshot; accept both
+	// success and the explicit "no dirpack index" error, but exercise the path.
+	if err != nil {
+		require.Equal(t, 1, status)
+		require.Contains(t, err.Error(), "dirpack")
+		return
+	}
+	require.Equal(t, 0, status)
+}
+
+func TestCovDiagDirPackParseError(t *testing.T) {
+	_, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	subcommand, _, rest := subcommands.Lookup([]string{"diag", "dirpack"})
+	require.NotNil(t, subcommand)
+	err := subcommand.Parse(ctx, rest)
+	require.Error(t, err)
+}
+
+func TestCovDiagDirPackBadSnapshot(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Non-existent snapshot id -> Execute error.
+	status, err := runDiag(t, ctx, repo, []string{"diag", "dirpack", strings.Repeat("00", 32)})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// --- diag chunks -----------------------------------------------------------
+
+func TestCovDiagChunks(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{
+		"diag", "chunks",
+		fmt.Sprintf("%s:subdir/dummy.txt", hex.EncodeToString(indexID[:])),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, bufOut.String(), "Chunk[0]:")
+}
+
+func TestCovDiagChunksErrors(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+
+	// Path that points at a directory (no resolved object) -> error.
+	status, err := runDiag(t, ctx, repo, []string{
+		"diag", "chunks",
+		fmt.Sprintf("%s:subdir", hex.EncodeToString(indexID[:])),
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Non-existent path -> error.
+	status, err = runDiag(t, ctx, repo, []string{
+		"diag", "chunks",
+		fmt.Sprintf("%s:does/not/exist", hex.EncodeToString(indexID[:])),
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// No arg -> Parse error.
+	subcommand, _, rest := subcommands.Lookup([]string{"diag", "chunks"})
+	require.NotNil(t, subcommand)
+	err = subcommand.Parse(ctx, rest)
+	require.Error(t, err)
+}
+
+// --- Parse error paths for the path-taking subcommands ---------------------
+
+func TestCovDiagParseErrors(t *testing.T) {
+	_, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	for _, name := range []string{"snapshot", "vfs", "xattr", "contenttype", "object"} {
+		t.Run(name, func(t *testing.T) {
+			subcommand, _, rest := subcommands.Lookup([]string{"diag", name})
+			require.NotNil(t, subcommand)
+			err := subcommand.Parse(ctx, rest)
+			require.Error(t, err, "expected usage error for diag %s with no args", name)
+		})
+	}
+}
+
+// --- Execute error paths for object / vfs / search -------------------------
+
+func TestCovDiagObjectErrors(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Wrong-length object hash.
+	status, err := runDiag(t, ctx, repo, []string{"diag", "object", "abcd"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Right length, non-hex.
+	status, err = runDiag(t, ctx, repo, []string{"diag", "object", strings.Repeat("z", 64)})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+
+	// Right length hex, no such object.
+	status, err = runDiag(t, ctx, repo, []string{"diag", "object", strings.Repeat("00", 32)})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCovDiagVFSNotFound(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	status, err := runDiag(t, ctx, repo, []string{
+		"diag", "vfs",
+		fmt.Sprintf("%s:/no/such/path", hex.EncodeToString(indexID[:])),
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCovDiagSearchWithMime(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+
+	// Two-arg form: path + mime filter (exercises the case 2 branch in Parse).
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{
+		"diag", "search",
+		fmt.Sprintf("%s:subdir/", hex.EncodeToString(indexID[:])),
+		"text/plain",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// No-arg form -> Parse usage error.
+	subcommand, _, rest := subcommands.Lookup([]string{"diag", "search"})
+	require.NotNil(t, subcommand)
+	err = subcommand.Parse(ctx, rest)
+	require.Error(t, err)
+}

--- a/subcommands/pkg/pkg_coverage_test.go
+++ b/subcommands/pkg/pkg_coverage_test.go
@@ -1,0 +1,401 @@
+package pkg
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/location"
+	ppkg "github.com/PlakarKorp/pkg"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Parse argument validation
+// ---------------------------------------------------------------------------
+
+func TestPkgParseNoAction(t *testing.T) {
+	ctx := newCtx(t)
+	// Pkg.Parse always reports "no action specified" for no args.
+	err := (&Pkg{}).Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no action specified")
+
+	// With a positional arg it reports "invalid argument".
+	err = (&Pkg{}).Parse(ctx, []string{"bogus"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid argument")
+}
+
+func TestPkgAddParseVariants(t *testing.T) {
+	ctx := newCtx(t)
+
+	// -u (upgrade) with no positional args is allowed.
+	cmd := &PkgAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-u"}))
+	require.True(t, cmd.upgrade)
+	require.Empty(t, cmd.Args)
+
+	// A relative name pointing to a real file gets absolutified.
+	f := filepath.Join(ctx.CWD, "plugin.ptar")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0644))
+	cmd = &PkgAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"plugin.ptar"}))
+	require.Equal(t, []string{f}, cmd.Args)
+
+	// A relative name that does not exist is kept as-is (treated as a recipe).
+	cmd = &PkgAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"imap"}))
+	require.Equal(t, []string{"imap"}, cmd.Args)
+
+	// An absolute path that does not exist is an error.
+	cmd = &PkgAdd{}
+	missing := filepath.Join(ctx.CWD, "does-not-exist.ptar")
+	err := cmd.Parse(ctx, []string{missing})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file not found")
+}
+
+func TestPkgRmParseEmpty(t *testing.T) {
+	ctx := newCtx(t)
+	cmd := &PkgRm{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.Empty(t, cmd.Args)
+}
+
+func TestPkgListParseTooMany(t *testing.T) {
+	ctx := newCtx(t)
+	err := (&PkgList{}).Parse(ctx, []string{"a", "b"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many arguments")
+}
+
+func TestPkgBuildParseErrors(t *testing.T) {
+	ctx := newCtx(t)
+
+	// wrong number of args
+	err := (&PkgBuild{}).Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong usage")
+
+	// recipe file that does not exist (path contains separator -> file branch)
+	bad := filepath.Join(ctx.CWD, "nope.yaml")
+	err = (&PkgBuild{}).Parse(ctx, []string{bad})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse")
+
+	// valid recipe but invalid plugin name
+	recipe := filepath.Join(ctx.CWD, "recipe.yaml")
+	require.NoError(t, os.WriteFile(recipe, []byte("name: \"bad name!\"\nversion: v1.0.0\nrepository: https://example.com/x\n"), 0644))
+	err = (&PkgBuild{}).Parse(ctx, []string{recipe})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a valid plugin name")
+
+	// valid name but invalid semver
+	recipe2 := filepath.Join(ctx.CWD, "recipe2.yaml")
+	require.NoError(t, os.WriteFile(recipe2, []byte("name: imap\nversion: not-semver\nrepository: https://example.com/x\n"), 0644))
+	err = (&PkgBuild{}).Parse(ctx, []string{recipe2})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a valid version string")
+
+	// fully valid recipe parses without error
+	recipe3 := filepath.Join(ctx.CWD, "recipe3.yaml")
+	require.NoError(t, os.WriteFile(recipe3, []byte("name: imap\nversion: v1.2.3\nrepository: https://example.com/x\n"), 0644))
+	cmd := &PkgBuild{}
+	require.NoError(t, cmd.Parse(ctx, []string{recipe3}))
+	require.Equal(t, "imap", cmd.Recipe.Name)
+	require.Equal(t, "v1.2.3", cmd.Recipe.Version)
+}
+
+func TestPkgCreateParseOk(t *testing.T) {
+	ctx := newCtx(t)
+	manifest := filepath.Join(ctx.CWD, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\n"), 0644))
+
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"manifest.yaml", "v1.2.3"}))
+	require.Equal(t, "myplugin", cmd.Manifest.Name)
+	require.Equal(t, ctx.CWD, cmd.Base)
+	require.Equal(t, manifest, cmd.ManifestPath)
+	// Default output name is derived from the manifest name and version.
+	require.True(t, strings.HasSuffix(cmd.Out, ".ptar"))
+	require.Contains(t, filepath.Base(cmd.Out), "myplugin_v1.2.3_")
+
+	// Explicit -out overrides the derived name.
+	cmd = &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-out", "custom.ptar", "manifest.yaml", "v1.2.3"}))
+	require.Equal(t, "custom.ptar", cmd.Out)
+}
+
+func TestPkgCreateParseBadManifestContent(t *testing.T) {
+	ctx := newCtx(t)
+	manifest := filepath.Join(ctx.CWD, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("\t this : is : not : valid : yaml\n"), 0644))
+	err := (&PkgCreate{}).Parse(ctx, []string{"manifest.yaml", "v1.2.3"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse the manifest")
+}
+
+// ---------------------------------------------------------------------------
+// getRecipe: file and http branches
+// ---------------------------------------------------------------------------
+
+func TestGetRecipeFile(t *testing.T) {
+	ctx := newCtx(t)
+	p := filepath.Join(ctx.CWD, "recipe.yaml")
+	require.NoError(t, os.WriteFile(p, []byte("name: imap\nversion: v1.0.0\nrepository: https://example.com/r\n"), 0644))
+
+	var r ppkg.Recipe
+	require.NoError(t, getRecipe(ctx, p, &r))
+	require.Equal(t, "imap", r.Name)
+	require.Equal(t, "v1.0.0", r.Version)
+
+	// non-existent file with a path separator -> open error
+	var r2 ppkg.Recipe
+	err := getRecipe(ctx, filepath.Join(ctx.CWD, "missing.yaml"), &r2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couldn't open")
+}
+
+func TestGetRecipeHTTP(t *testing.T) {
+	ctx := newCtx(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("name: s3\nversion: v2.0.0\nrepository: https://example.com/s3\n"))
+	}))
+	defer srv.Close()
+
+	var r ppkg.Recipe
+	require.NoError(t, getRecipe(ctx, srv.URL, &r))
+	require.Equal(t, "s3", r.Name)
+	require.Equal(t, "v2.0.0", r.Version)
+}
+
+func TestGetRecipeHTTPNotFound(t *testing.T) {
+	ctx := newCtx(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var r ppkg.Recipe
+	err := getRecipe(ctx, srv.URL, &r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couldn't fetch recipe")
+}
+
+// ---------------------------------------------------------------------------
+// absolutify
+// ---------------------------------------------------------------------------
+
+func TestAbsolutify(t *testing.T) {
+	abs := "/already/abs/../abs/path"
+	require.Equal(t, filepath.Clean(abs), absolutify("/base", abs))
+
+	require.Equal(t, filepath.Join("/base", "rel", "file"), absolutify("/base", "rel/file"))
+}
+
+// ---------------------------------------------------------------------------
+// pkgerImporter: metadata, Ping, Close, mkstruct, dofile, scan
+// ---------------------------------------------------------------------------
+
+func TestPkgerImporterMetadata(t *testing.T) {
+	imp := &pkgerImporter{}
+	require.Equal(t, "", imp.Origin())
+	require.Equal(t, "pkger", imp.Type())
+	require.Equal(t, "/", imp.Root())
+	require.Equal(t, location.Flags(0), imp.Flags())
+	require.NoError(t, imp.Ping(t.Context()))
+	require.NoError(t, imp.Close(t.Context()))
+}
+
+func drain(ch <-chan *connectors.Record) []*connectors.Record {
+	var recs []*connectors.Record
+	for r := range ch {
+		recs = append(recs, r)
+	}
+	return recs
+}
+
+func TestMkstruct(t *testing.T) {
+	ch := make(chan *connectors.Record, 16)
+	mkstruct("/a/b/c/file.txt", ch)
+	close(ch)
+	recs := drain(ch)
+	// directories: /a/b/c, /a/b, /a (stops at /)
+	var paths []string
+	for _, r := range recs {
+		paths = append(paths, r.Pathname)
+		require.True(t, r.FileInfo.Lmode.IsDir())
+	}
+	require.Equal(t, []string{"/a/b/c", "/a/b", "/a"}, paths)
+}
+
+func TestDofileExecutableOk(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "plugin")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+
+	imp := &pkgerImporter{cwd: dir}
+	ch := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(exe, ch, itexe))
+	close(ch)
+	recs := drain(ch)
+
+	var fileRec *connectors.Record
+	for _, r := range recs {
+		if r.Pathname == "/plugin" {
+			fileRec = r
+		}
+		require.Nil(t, r.Err, "no record should carry an error")
+	}
+	require.NotNil(t, fileRec)
+	require.NotNil(t, fileRec.Reader)
+}
+
+func TestDofileNotExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit semantics differ on windows")
+	}
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "data")
+	require.NoError(t, os.WriteFile(plain, []byte("nope"), 0644))
+
+	imp := &pkgerImporter{cwd: dir}
+	ch := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(plain, ch, itexe))
+	close(ch)
+	recs := drain(ch)
+	require.Len(t, recs, 1)
+	require.NotNil(t, recs[0].Err)
+	require.Contains(t, recs[0].Err.Error(), "Not executable")
+}
+
+func TestDofileJSONValidAndInvalid(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.json")
+	require.NoError(t, os.WriteFile(good, []byte(`{"k":"v"}`), 0644))
+	bad := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(bad, []byte(`{not json`), 0644))
+
+	imp := &pkgerImporter{cwd: dir}
+
+	ch := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(good, ch, itjson))
+	close(ch)
+	for _, r := range drain(ch) {
+		require.Nil(t, r.Err)
+	}
+
+	ch2 := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(bad, ch2, itjson))
+	close(ch2)
+	recs := drain(ch2)
+	require.Len(t, recs, 1)
+	require.NotNil(t, recs[0].Err)
+	require.Contains(t, recs[0].Err.Error(), "invalid json")
+}
+
+func TestDofileMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	imp := &pkgerImporter{cwd: dir}
+	ch := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(filepath.Join(dir, "ghost"), ch, itextra))
+	close(ch)
+	recs := drain(ch)
+	require.Len(t, recs, 1)
+	require.NotNil(t, recs[0].Err)
+	require.Contains(t, recs[0].Err.Error(), "Failed to open file")
+}
+
+func TestDofileNotBelowManifest(t *testing.T) {
+	dir := t.TempDir()
+	imp := &pkgerImporter{cwd: filepath.Join(dir, "sub")}
+	require.NoError(t, os.MkdirAll(imp.cwd, 0755))
+	outside := filepath.Join(dir, "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("x"), 0644))
+
+	ch := make(chan *connectors.Record, 32)
+	err := imp.dofile(outside, ch, itextra)
+	close(ch)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not below the manifest")
+}
+
+func TestPkgerImporterScan(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\n"), 0644))
+	exe := filepath.Join(dir, "myplugin")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\n"), 0755))
+	validator := filepath.Join(dir, "validator.json")
+	require.NoError(t, os.WriteFile(validator, []byte(`{"ok":true}`), 0644))
+	extra := filepath.Join(dir, "extra.dat")
+	require.NoError(t, os.WriteFile(extra, []byte("data"), 0644))
+
+	m := &ppkg.Manifest{
+		Name: "myplugin",
+		Connectors: []ppkg.ManifestConnector{{
+			Executable: "myplugin",
+			Validator:  "validator.json",
+			ExtraFiles: []string{"extra.dat"},
+		}},
+	}
+	imp := &pkgerImporter{cwd: dir, manifest: m, manifestPath: manifest}
+
+	ch := make(chan *connectors.Record, 128)
+	require.NoError(t, imp.scan(ch))
+	close(ch)
+	recs := drain(ch)
+
+	seen := map[string]bool{}
+	for _, r := range recs {
+		require.Nil(t, r.Err, "scan record %q carries error", r.Pathname)
+		seen[r.Pathname] = true
+	}
+	require.True(t, seen["/"])
+	require.True(t, seen["/manifest.yaml"])
+	require.True(t, seen["/myplugin"])
+	require.True(t, seen["/validator.json"])
+	require.True(t, seen["/extra.dat"])
+}
+
+// ---------------------------------------------------------------------------
+// Full PkgCreate.Parse + Execute: build a real .ptar
+// ---------------------------------------------------------------------------
+
+func TestPkgCreateExecuteBuildsPtar(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	work := t.TempDir()
+	ctx.CWD = work
+
+	manifest := filepath.Join(work, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\nconnectors:\n  - type: importer\n    executable: myplugin\n"), 0644))
+	exe := filepath.Join(work, "myplugin")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\necho hi\n"), 0755))
+
+	out := filepath.Join(work, "out.ptar")
+
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-out", out, "manifest.yaml", "v1.2.3"}))
+
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	info, err := os.Stat(out)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0))
+	require.Contains(t, bufOut.String(), "Plugin created successfully")
+}

--- a/subcommands/ptar/ptar_coverage_test.go
+++ b/subcommands/ptar/ptar_coverage_test.go
@@ -1,0 +1,179 @@
+package ptar
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/importer"
+	_ "github.com/PlakarKorp/integrations/ptar/storage"
+	"github.com/PlakarKorp/plakar/config"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- Parse ----------
+
+func TestPtarParseMissingOutput(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-plaintext", "/some/path"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-o option must be specified")
+}
+
+func TestPtarParseUnknownHashing(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{
+		"-plaintext",
+		"-hashing", "NOSUCHALGO",
+		"-o", filepath.Join(tmpDir, "a.ptar"),
+		tmpDir,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown hashing algorithm")
+}
+
+func TestPtarParsePassphraseFromEnvNonEmpty(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	t.Setenv("PLAKAR_PASSPHRASE", "correct horse battery staple")
+
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-o", filepath.Join(tmpDir, "a.ptar"), tmpDir})
+	require.NoError(t, err)
+	require.Equal(t, []byte("correct horse battery staple"), cmd.GetRepositorySecret())
+}
+
+func TestPtarParsePassphraseFromEnvEmpty(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	t.Setenv("PLAKAR_PASSPHRASE", "")
+
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-o", filepath.Join(tmpDir, "a.ptar"), tmpDir})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty passphrase")
+}
+
+func TestPtarParseDefaultsToCWD(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	ctx.CWD = "/the/current/dir"
+
+	cmd := &Ptar{}
+	// -plaintext avoids the passphrase prompt; no targets -> defaults to CWD.
+	err := cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "a.ptar")})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/the/current/dir"}, []string(cmd.BackupTargets))
+}
+
+func TestPtarParseMultipleTargets(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{
+		"-plaintext",
+		"-o", filepath.Join(tmpDir, "a.ptar"),
+		"/path/one", "/path/two", "/path/three",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/path/one", "/path/two", "/path/three"}, []string(cmd.BackupTargets))
+}
+
+func TestPtarParseUnknownPeer(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	ctx.Config = config.NewConfig()
+	tmpDir := t.TempDir()
+
+	cmd := &Ptar{}
+	// -k references a peer that is not configured; opening it as a bare
+	// location fails before any backup happens.
+	err := cmd.Parse(ctx, []string{
+		"-plaintext",
+		"-o", filepath.Join(tmpDir, "a.ptar"),
+		"-k", "does-not-exist",
+	})
+	require.Error(t, err)
+}
+
+// ---------- Execute ----------
+
+func TestPtarExecuteRefuseOverwrite(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+
+	tmpDir := t.TempDir()
+	out := filepath.Join(tmpDir, "exists.ptar")
+	require.NoError(t, os.WriteFile(out, []byte("preexisting"), 0644))
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", out, filepath.Join(src, "subdir")}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "already exists")
+}
+
+func TestPtarExecuteOverwrite(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+
+	tmpDir := t.TempDir()
+	out := filepath.Join(tmpDir, "exists.ptar")
+	require.NoError(t, os.WriteFile(out, []byte("preexisting"), 0644))
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-overwrite", "-o", out, filepath.Join(src, "subdir")}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestPtarExecuteNoCompression(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+
+	tmpDir := t.TempDir()
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-plaintext", "-no-compression",
+		"-o", filepath.Join(tmpDir, "nc.ptar"),
+		filepath.Join(src, "subdir"),
+	}))
+	require.True(t, cmd.NoCompression)
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestPtarExecuteUnresolvableSource(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+
+	// GenerateRepositoryWithoutConfig leaves ctx.Config nil; the @source
+	// resolution path dereferences it, so install an empty config.
+	ctx.Config = config.NewConfig()
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "u.ptar")}))
+	// Force a backup target that uses the @source syntax pointing at an
+	// undefined source; backup() must fail to resolve the importer.
+	cmd.BackupTargets = listFlag{"@nonexistent-source"}
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "could not resolve importer")
+}

--- a/subcommands/repair/repair_coverage_test.go
+++ b/subcommands/repair/repair_coverage_test.go
@@ -1,0 +1,74 @@
+package repair
+
+import (
+	"bytes"
+	"testing"
+
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRepairParseCapturesSecret verifies that Parse copies the secret set on the
+// AppContext into the command's RepositorySecret field.
+func TestRepairParseCapturesSecret(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+
+	secret := []byte("hunter2-top-secret")
+	ctx.SetSecret(secret)
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.Equal(t, secret, cmd.GetRepositorySecret())
+}
+
+// TestRepairExecuteDryRunEmptyRepo drives a dry-run on a freshly created
+// repository with no snapshots. No repairs are needed and the command succeeds.
+func TestRepairExecuteDryRunEmptyRepo(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// TestRepairExecuteDryRunPopulatedHealthy drives a dry-run on a healthy
+// repository that already contains a snapshot. All packfiles belong to known
+// remote states, so no missing-state repairs are reported.
+func TestRepairExecuteDryRunPopulatedHealthy(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/a.txt", 0644, "hello world"),
+		ptesting.NewMockFile("subdir/b.txt", 0644, "more content here"),
+	})
+	defer snap.Close()
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// TestRepairExecuteApplyHealthy drives repair with -apply against a healthy
+// repository. This exercises the exclusive Lock/Unlock path. Because the
+// repository is healthy there are no missing states to repair, so the
+// orphaned-packfile loop is skipped.
+func TestRepairExecuteApplyHealthy(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("d"),
+		ptesting.NewMockFile("d/f.txt", 0644, "payload"),
+	})
+	defer snap.Close()
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-apply"}))
+	require.True(t, cmd.Apply)
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}

--- a/subcommands/service/service_coverage_test.go
+++ b/subcommands/service/service_coverage_test.go
@@ -1,0 +1,222 @@
+package services
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// newCoverageCtx builds a hermetic AppContext: a fresh empty cookies.Manager
+// rooted in a temp dir and no PLAKAR_TOKEN, so getClient always fails with a
+// login error before any network access.
+func newCoverageCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx := appcontext.NewAppContext()
+	ctx.Stdout = bytes.NewBuffer(nil)
+	ctx.Stderr = bytes.NewBuffer(nil)
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	return ctx
+}
+
+func TestCoverageServiceLookupAndTrailingArgs(t *testing.T) {
+	// Lookup must strip the matched command tokens and return the trailing args.
+	cmd, _, rest := subcommands.Lookup([]string{"service", "show", "alerting", "-json"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &ServiceShow{}, cmd)
+	require.Equal(t, []string{"alerting", "-json"}, rest)
+
+	// Bare "service" resolves to the top-level Service command with no trailing args.
+	cmd, _, rest = subcommands.Lookup([]string{"service"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Service{}, cmd)
+	require.Empty(t, rest)
+}
+
+func TestCoverageServiceParseGood(t *testing.T) {
+	ctx := newCoverageCtx(t)
+
+	// Subcommands taking exactly one <name>.
+	for _, name := range []string{"status", "enable", "disable", "show", "rm"} {
+		cmd, _, rest := subcommands.Lookup([]string{"service", name, "alerting"})
+		require.NotNil(t, cmd, "name=%s", name)
+		require.NoError(t, cmd.Parse(ctx, rest), "name=%s", name)
+	}
+
+	// list takes no args.
+	require.NoError(t, (&ServiceList{}).Parse(ctx, []string{}))
+}
+
+func TestCoverageServiceParseBadNoAction(t *testing.T) {
+	ctx := newCoverageCtx(t)
+
+	// Top-level service: no action specified.
+	err := (&Service{}).Parse(ctx, []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no action specified")
+
+	// Top-level service: stray positional argument.
+	err = (&Service{}).Parse(ctx, []string{"bogus"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid argument")
+}
+
+func TestCoverageServiceParseWrongArgCounts(t *testing.T) {
+	ctx := newCoverageCtx(t)
+
+	// Commands that require exactly one argument: zero args -> error.
+	for _, name := range []string{"status", "enable", "disable", "show"} {
+		cmd, _, rest := subcommands.Lookup([]string{"service", name})
+		require.NotNil(t, cmd, "name=%s", name)
+		require.Error(t, cmd.Parse(ctx, rest), "name=%s zero args", name)
+	}
+
+	// Same commands: too many args -> error.
+	for _, name := range []string{"status", "enable", "disable", "show"} {
+		cmd, _, rest := subcommands.Lookup([]string{"service", name, "a", "b"})
+		require.NotNil(t, cmd, "name=%s", name)
+		require.Error(t, cmd.Parse(ctx, rest), "name=%s two args", name)
+	}
+
+	// rm: zero args -> error; too many args -> error.
+	require.Error(t, (&ServiceRm{}).Parse(ctx, []string{}))
+	require.Error(t, (&ServiceRm{}).Parse(ctx, []string{"a", "b"}))
+
+	// list: any positional arg -> error.
+	require.Error(t, (&ServiceList{}).Parse(ctx, []string{"extra"}))
+
+	// add/set/unset: zero args -> "no service specified".
+	require.Error(t, (&ServiceAdd{}).Parse(ctx, []string{}))
+	require.Error(t, (&ServiceSet{}).Parse(ctx, []string{}))
+	require.Error(t, (&ServiceUnset{}).Parse(ctx, []string{}))
+}
+
+func TestCoverageServiceAddSetKeyValueParsing(t *testing.T) {
+	ctx := newCoverageCtx(t)
+
+	// Valid key=value pairs populate the Keys map.
+	add := &ServiceAdd{}
+	require.NoError(t, add.Parse(ctx, []string{"alerting", "email=foo@bar", "level=high"}))
+	require.Equal(t, "alerting", add.Service)
+	require.Equal(t, map[string]string{"email": "foo@bar", "level": "high"}, add.Keys)
+
+	// Empty value is allowed (key= -> "").
+	add2 := &ServiceAdd{}
+	require.NoError(t, add2.Parse(ctx, []string{"alerting", "key="}))
+	require.Equal(t, map[string]string{"key": ""}, add2.Keys)
+
+	// Missing '=' is rejected.
+	require.Error(t, (&ServiceAdd{}).Parse(ctx, []string{"alerting", "noequals"}))
+	// Empty key (=value) is rejected.
+	require.Error(t, (&ServiceAdd{}).Parse(ctx, []string{"alerting", "=value"}))
+
+	// Same rules for set.
+	set := &ServiceSet{}
+	require.NoError(t, set.Parse(ctx, []string{"alerting", "a=1", "b=2"}))
+	require.Equal(t, map[string]string{"a": "1", "b": "2"}, set.Keys)
+	require.Error(t, (&ServiceSet{}).Parse(ctx, []string{"alerting", "noequals"}))
+	require.Error(t, (&ServiceSet{}).Parse(ctx, []string{"alerting", "=value"}))
+
+	// add/set with only a name and no pairs -> empty map, no error.
+	addName := &ServiceAdd{}
+	require.NoError(t, addName.Parse(ctx, []string{"alerting"}))
+	require.Empty(t, addName.Keys)
+}
+
+func TestCoverageServiceUnsetKeySlice(t *testing.T) {
+	ctx := newCoverageCtx(t)
+
+	// unset populates the Keys slice from the trailing positional args.
+	unset := &ServiceUnset{}
+	require.NoError(t, unset.Parse(ctx, []string{"alerting", "email", "level"}))
+	require.Equal(t, "alerting", unset.Service)
+	require.Equal(t, []string{"email", "level"}, unset.Keys)
+
+	// Name only -> empty key slice.
+	unsetName := &ServiceUnset{}
+	require.NoError(t, unsetName.Parse(ctx, []string{"alerting"}))
+	require.Empty(t, unsetName.Keys)
+}
+
+func TestCoverageServiceShowParseFlags(t *testing.T) {
+	ctx := newCoverageCtx(t)
+
+	show := &ServiceShow{}
+	require.NoError(t, show.Parse(ctx, []string{"-json", "-secrets", "alerting"}))
+	require.True(t, show.AsJson)
+	require.True(t, show.ShowSecrets)
+	require.False(t, show.AsYaml)
+	require.Equal(t, "alerting", show.Service)
+
+	showYaml := &ServiceShow{}
+	require.NoError(t, showYaml.Parse(ctx, []string{"-yaml", "alerting"}))
+	require.True(t, showYaml.AsYaml)
+	require.False(t, showYaml.AsJson)
+
+	// show with no name -> error.
+	require.Error(t, (&ServiceShow{}).Parse(ctx, []string{"-json"}))
+	// show with too many names -> error.
+	require.Error(t, (&ServiceShow{}).Parse(ctx, []string{"a", "b"}))
+}
+
+// TestCoverageServiceExecuteRequiresLogin drives Execute for every subcommand
+// through the hermetic getClient-failure path: with no auth token, getClient
+// returns a login error and Execute returns status 1 before any network call.
+// The repository is a real ptesting-generated repo so the ctx is fully wired.
+func TestCoverageServiceExecuteRequiresLogin(t *testing.T) {
+	t.Setenv("PLAKAR_TOKEN", "")
+	var out, errb bytes.Buffer
+	repo, ctx := ptesting.GenerateRepository(t, &out, &errb, nil)
+	// Ensure a fresh empty cookies manager (no token on disk).
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+
+	cmds := []struct {
+		name string
+		cmd  subcommands.Subcommand
+		args []string
+	}{
+		{"list", &ServiceList{}, []string{}},
+		{"status", &ServiceStatus{}, []string{"alerting"}},
+		{"enable", &ServiceEnable{}, []string{"alerting"}},
+		{"disable", &ServiceDisable{}, []string{"alerting"}},
+		{"show", &ServiceShow{}, []string{"alerting"}},
+		{"add", &ServiceAdd{}, []string{"alerting", "k=v"}},
+		{"set", &ServiceSet{}, []string{"alerting", "k=v"}},
+		{"unset", &ServiceUnset{}, []string{"alerting", "k"}},
+		{"rm", &ServiceRm{}, []string{"alerting"}},
+		{"service", &Service{}, []string{}},
+	}
+
+	for _, c := range cmds {
+		// Parse may legitimately error for the bare "service" command; ignore
+		// that here since we only care about the Execute login path.
+		_ = c.cmd.Parse(ctx, c.args)
+		status, err := c.cmd.Execute(ctx, repo)
+		require.Error(t, err, "subcommand=%s", c.name)
+		require.Equal(t, 1, status, "subcommand=%s", c.name)
+		if c.name != "service" {
+			require.True(t, strings.Contains(err.Error(), "login") ||
+				strings.Contains(err.Error(), "auth token"),
+				"subcommand=%s expected login/auth error, got: %v", c.name, err)
+		}
+	}
+}
+
+// TestCoverageServiceExecuteRequiresLoginEmptyRepo runs the same login-failure
+// path against a zero-value &repository.Repository{} to exercise that branch
+// without a generated repo.
+func TestCoverageServiceExecuteRequiresLoginEmptyRepo(t *testing.T) {
+	ctx := newCoverageCtx(t)
+	cmd := &ServiceShow{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}

--- a/utils/utils_coverage_test.go
+++ b/utils/utils_coverage_test.go
@@ -1,0 +1,135 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- GetPassphraseFromCommand ----------
+
+func TestGetPassphraseFromCommandSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh syntax")
+	}
+	pass, err := GetPassphraseFromCommand("printf 'sekret'")
+	require.NoError(t, err)
+	require.Equal(t, "sekret", pass)
+}
+
+func TestGetPassphraseFromCommandSingleLineEcho(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh syntax")
+	}
+	pass, err := GetPassphraseFromCommand("echo hunter2")
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", pass)
+}
+
+func TestGetPassphraseFromCommandMultilineError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh syntax")
+	}
+	// Two output lines must be rejected.
+	_, err := GetPassphraseFromCommand("printf 'a\\nb\\n'")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many lines")
+}
+
+func TestGetPassphraseFromCommandEmptyOutputError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh syntax")
+	}
+	// No output -> zero lines -> "too many lines" (lines != 1).
+	_, err := GetPassphraseFromCommand("true")
+	require.Error(t, err)
+}
+
+func TestGetPassphraseFromCommandFailingCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh syntax")
+	}
+	// A command that prints one line but exits non-zero -> Wait() errors.
+	_, err := GetPassphraseFromCommand("echo oops; exit 3")
+	require.Error(t, err)
+}
+
+// ---------- LoadOldConfigIfExists additional paths ----------
+
+func TestLoadOldConfigIfExistsMissingDistinct(t *testing.T) {
+	cfg, err := LoadOldConfigIfExists(filepath.Join(t.TempDir(), "nope.yml"))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Empty(t, cfg.Repositories)
+}
+
+func TestLoadOldConfigIfExistsDecodeErrorDistinct(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plakar.yml")
+	require.NoError(t, os.WriteFile(path, []byte("default-repo: [unterminated"), 0o600))
+	_, err := LoadOldConfigIfExists(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse old config file")
+}
+
+// ---------- config.go load() previous-format fallback for sources/destinations ----------
+
+func TestLoadConfigPreviousFormatSourcesAndDestinations(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(name, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600))
+	}
+	// No version field -> falls through to the previous (top-level map) format.
+	mustWrite("sources.yml", "s1:\n  location: fs:///s1\n")
+	mustWrite("destinations.yml", "d1:\n  location: fs:///d1\n")
+	mustWrite("stores.yml", "version: v1.0.0\nstores:\n  r1:\n    location: fs:///r1\n")
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "fs:///s1", cfg.Sources["s1"]["location"])
+	require.Equal(t, "fs:///d1", cfg.Destinations["d1"]["location"])
+}
+
+// ---------- config.go load() parse error path ----------
+
+func TestLoadConfigSourcesParseError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sources.yml"),
+		[]byte("not: [valid: yaml"), 0o600))
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+}
+
+// ---------- SaveConfig error path: ConfigDir is a regular file ----------
+
+func TestSaveConfigMkdirFails(t *testing.T) {
+	// Point ConfigDir at a path whose parent is a regular file -> MkdirAll fails.
+	f := filepath.Join(t.TempDir(), "afile")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+
+	cfg, err := LoadOldConfigIfExists(filepath.Join(t.TempDir(), "missing.yml"))
+	require.NoError(t, err)
+
+	err = SaveConfig(filepath.Join(f, "subdir"), cfg)
+	require.Error(t, err)
+}
+
+// ---------- LoadConfig empty-file branch in load() ----------
+
+func TestLoadConfigEmptySourcesFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(name, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600))
+	}
+	// Empty sources.yml (size 0) returns nil early; the rest are valid.
+	mustWrite("sources.yml", "")
+	mustWrite("destinations.yml", "version: v1.0.0\ndestinations:\n  d:\n    location: fs:///d\n")
+	mustWrite("stores.yml", "version: v1.0.0\nstores:\n  r:\n    location: fs:///r\n")
+
+	cfg, err := LoadConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "fs:///r", cfg.Repositories["r"]["location"])
+}


### PR DESCRIPTION
Picks up where the recent coverage push left off. The suite was around 53%; this takes it to ~63%.

It fills the packages that were still thin rather than touching anything already covered: the root command dispatcher (`entryPoint` driven end-to-end), the subcommands pkg/cached/service/repair/ptar/config, more of the api handlers (error and paging branches over a real httptest repo), the remaining diag subcommands, and a few more utils paths. Every test lives in a new `*_coverage_test.go` file, so nothing existing is modified.

Paths that can't run hermetically under `go test` are left alone — a live cached daemon, the plugins/services backend over the network, a TTY for passphrase entry, an actual OS mount. Forcing those would mean reshaping the code just to test it.

(Tests largely generated with help from our friend.)
