### PR TITLE
test: push coverage past 70% (and stop CI timeout truncation)

### DIFF
--- a/api/api_coverage2_test.go
+++ b/api/api_coverage2_test.go
@@ -1,0 +1,325 @@
+package api
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// cov2Server is a fresh real-fs server like covServer but lets the caller pick
+// the auth token so signed-URL flows can be exercised end to end.
+func cov2Server(t *testing.T, token string) (*http.ServeMux, *repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
+	t.Helper()
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("noext", 0644, "plain text no extension"),
+		ptesting.NewMockFile("top.txt", 0644, "top level"),
+	})
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, token, true /* norefresh */)
+	return mux, repo, snap, ctx
+}
+
+func cov2SnapID(snap *snapshot.Snapshot) string {
+	id := snap.Header.GetIndexID()
+	return hex.EncodeToString(id[:])
+}
+
+// --- apiInfo: authenticated branch -----------------------------------------
+
+func TestCov2ApiInfoAuthenticated(t *testing.T) {
+	mux, _, snap, ctx := cov2Server(t, "")
+	defer snap.Close()
+
+	// Drop an auth token into the cookie jar so apiInfo reports authenticated.
+	require.NoError(t, ctx.GetCookies().PutAuthToken("some-auth-token"))
+
+	w := covGET(t, mux, "/api/info")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp struct {
+		Authenticated bool   `json:"authenticated"`
+		RepositoryId  string `json:"repository_id"`
+		Version       string `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.True(t, resp.Authenticated)
+	require.NotEmpty(t, resp.RepositoryId)
+}
+
+// --- Signed-URL reader: full JWT verification flow -------------------------
+
+// signReader posts to the sign endpoint (auth via Bearer token) and returns the
+// JWT signature for a snapshot path.
+func signReader(t *testing.T, mux *http.ServeMux, token, snapPath string) string {
+	t.Helper()
+	req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+snapPath, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp struct {
+		Item struct {
+			Signature string `json:"signature"`
+		} `json:"item"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Item.Signature)
+	return resp.Item.Signature
+}
+
+func TestCov2SignedReaderValid(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	sig := signReader(t, mux, token, id+":/subdir/dummy.txt")
+
+	// A valid signature lets the (otherwise token-protected) reader through.
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "hello dummy")
+}
+
+func TestCov2SignedReaderTamperedPathAndSnapshot(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	sig := signReader(t, mux, token, id+":/subdir/dummy.txt")
+
+	// Same valid signature but requesting a different path -> rejected.
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/top.txt?signature="+sig)
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCov2SignedReaderBadSignature(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// Garbage signature -> JWT parse failure -> 401.
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature=not-a-jwt")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCov2SignedReaderExpired(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// Hand-craft an already-expired token signed with the right key.
+	now := time.Now().Add(-3 * time.Hour)
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, SnapshotSignedURLClaims{
+		SnapshotID: id,
+		Path:       "/subdir/dummy.txt",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(1 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			Issuer:    "plakar-api",
+		},
+	})
+	sig, err := jwtToken.SignedString([]byte(token))
+	require.NoError(t, err)
+
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "expired")
+}
+
+func TestCov2SignedReaderWrongSigningMethod(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// A token with the "none" alg should be rejected by the method check.
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodNone, SnapshotSignedURLClaims{
+		SnapshotID: id,
+		Path:       "/subdir/dummy.txt",
+	})
+	sig, err := jwtToken.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+}
+
+// --- Reader middleware fallthrough to token auth ---------------------------
+
+func TestCov2ReaderNoSignatureRequiresToken(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// No signature and no Authorization header -> token middleware rejects.
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+
+	// With the correct Bearer token it succeeds.
+	req, _ := http.NewRequest("GET", "/api/snapshot/reader/"+id+":/subdir/dummy.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+// --- Sign endpoint error branches ------------------------------------------
+
+func TestCov2SignReaderNonexistentPath(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// Signing a path that does not exist in the snapshot returns an error.
+	req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+id+":/no/such/file", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCov2SignReaderBadSnapshotID(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := cov2Server(t, token)
+	defer snap.Close()
+
+	// Empty snapshot id segment -> SnapshotPathParam missing-arg error.
+	req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/:/subdir/dummy.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- renderCode: content-type lexer fallback (no extension) ----------------
+
+func TestCov2RenderCodeNoExtension(t *testing.T) {
+	mux, _, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// "noext" has no filename extension, so lexers.Match returns nil and the
+	// handler falls back to the resolved content type / fallback lexer.
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/noext?render=code")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "<!DOCTYPE html>")
+}
+
+// --- handleError: not-found mapping via reader on missing file -------------
+
+func TestCov2ReaderMissingFileNotFound(t *testing.T) {
+	mux, _, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// GetEntry on a missing path bubbles up an fs.ErrNotExist which handleError
+	// maps to a 404.
+	w := covGET(t, mux, "/api/snapshot/reader/"+id+":/missing.txt")
+	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+// --- SnapshotPathParam: invalid id prefix ----------------------------------
+
+func TestCov2VFSBrowseUnknownPrefix(t *testing.T) {
+	mux, _, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+
+	// A well-formed but unmatched snapshot prefix -> LocateSnapshotByPrefix
+	// error surfaced as a 400 invalid_params.
+	w := covGET(t, mux, "/api/snapshot/vfs/deadbeef:/subdir")
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- VFS children: ".." parent paging on offset>0 page ---------------------
+
+func TestCov2VFSChildrenSecondPage(t *testing.T) {
+	mux, _, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// offset>0 takes the branch that decrements offset for the implicit "..".
+	w := covGET(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=5")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var items Items[json.RawMessage]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+}
+
+// --- VFS errors: offset/limit windowing ------------------------------------
+
+func TestCov2VFSErrorsPaging(t *testing.T) {
+	mux, _, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	// Exercise the offset/limit window arithmetic on a clean (no-error) dir.
+	w := covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// bad offset -> error from QueryParamToInt64.
+	w = covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=-1")
+	require.NotEqual(t, http.StatusOK, w.Code)
+
+	// errors on a missing dir -> 404.
+	w = covGET(t, mux, "/api/snapshot/vfs/errors/"+id+":/no-such-dir")
+	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+}
+
+// --- Downloader signed: custom name keeps extension behavior ---------------
+
+func TestCov2DownloaderSignedCustomName(t *testing.T) {
+	mux, _, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+	id := cov2SnapID(snap)
+
+	body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
+	req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp struct {
+		Id string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// name already carries an extension -> the ext-appending branch is skipped.
+	w = covGET(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+resp.Id+"?format=zip&name=custom.zip")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Header().Get("Content-Disposition"), "custom.zip")
+}
+
+// --- SnapshotPathParam unit: missing id ------------------------------------
+
+func TestCov2SnapshotPathParamMissingID(t *testing.T) {
+	mux, repo, snap, _ := cov2Server(t, "")
+	defer snap.Close()
+	_ = mux
+
+	req, _ := http.NewRequest("GET", "/x/{snapshot_path}", nil)
+	req.SetPathValue("snapshot_path", "")
+	_, _, err := SnapshotPathParam(req, repo, "snapshot_path")
+	require.Error(t, err)
+	apierr, ok := err.(*ApiError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, apierr.HttpCode)
+}

--- a/api/api_coverage3_test.go
+++ b/api/api_coverage3_test.go
@@ -1,0 +1,361 @@
+package api
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// cov3Server mirrors covServer but with a unique helper name. It builds a real
+// fs-backed repository with a single snapshot and wires SetupRoutes with
+// norefresh=true so handlers never reach the cached daemon.
+func cov3Server(t *testing.T) (*http.ServeMux, *repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
+	t.Helper()
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("dir"),
+		ptesting.NewMockFile("dir/a.txt", 0644, "alpha"),
+		ptesting.NewMockFile("dir/b.txt", 0644, "bravo"),
+		ptesting.NewMockFile("root.txt", 0644, "root level content"),
+	})
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, "", true /* norefresh */)
+	return mux, repo, snap, ctx
+}
+
+func cov3GET(t *testing.T, mux *http.ServeMux, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func cov3SnapID(snap *snapshot.Snapshot) string {
+	id := snap.Header.GetIndexID()
+	return hex.EncodeToString(id[:])
+}
+
+// --- handleError: error -> HTTP status mapping (direct unit test) -----------
+
+func TestCov3HandleErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"not-readable -> 400", repository.ErrNotReadable, http.StatusBadRequest},
+		{"blob-not-found -> 404", repository.ErrBlobNotFound, http.StatusNotFound},
+		{"packfile-not-found -> 404", repository.ErrPackfileNotFound, http.StatusNotFound},
+		{"fs-not-exist -> 404", fs.ErrNotExist, http.StatusNotFound},
+		{"snapshot-not-found -> 404", snapshot.ErrNotFound, http.StatusNotFound},
+		{"wrapped fs-not-exist -> 404", errors.New("boom: " + fs.ErrNotExist.Error()), http.StatusInternalServerError},
+		{"unknown -> 500", errors.New("some random failure"), http.StatusInternalServerError},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/whatever", nil)
+			w := httptest.NewRecorder()
+			handleError(w, req, c.err)
+			require.Equal(t, c.want, w.Code)
+
+			var body ApiErrorRes
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			require.NotNil(t, body.Error)
+		})
+	}
+}
+
+// TestCov3HandleErrorPassesApiError verifies an existing *ApiError is forwarded
+// verbatim (its HttpCode and ErrCode preserved) rather than remapped.
+func TestCov3HandleErrorPassesApiError(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/x", nil)
+	w := httptest.NewRecorder()
+	handleError(w, req, &ApiError{HttpCode: http.StatusTeapot, ErrCode: "teapot", Message: "short and stout"})
+	require.Equal(t, http.StatusTeapot, w.Code)
+
+	var body ApiErrorRes
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, "teapot", body.Error.ErrCode)
+}
+
+// --- repositoryInfo: efficiency == -1 (empty repo, zero logical size) -------
+
+func TestCov3RepositoryInfoEmptyEfficiency(t *testing.T) {
+	// A repository with no snapshots has logicalSize == 0, which drives the
+	// efficiency = -1 branch in repositoryInfo.
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	mux := http.NewServeMux()
+	SetupRoutes(mux, repo, ctx, "", true)
+
+	w := cov3GET(t, mux, "/api/repository/info")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp Item[RepositoryInfoResponse]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, float64(-1), resp.Item.Snapshots.Efficiency)
+	require.Equal(t, 0, resp.Item.Snapshots.Total)
+	require.Len(t, resp.Item.Snapshots.SnapshotsPerDay, 30)
+}
+
+// TestCov3RepositoryInfoWithSnapshot exercises the populated-efficiency branch
+// (logicalSize > 0) and asserts the response shape.
+func TestCov3RepositoryInfoWithSnapshot(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+
+	w := cov3GET(t, mux, "/api/repository/info")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp Item[RepositoryInfoResponse]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.GreaterOrEqual(t, resp.Item.Snapshots.Total, 1)
+	require.NotEmpty(t, resp.Item.OS)
+	require.NotEmpty(t, resp.Item.Arch)
+	require.True(t, resp.Item.Browsable)
+}
+
+// --- IntegrationsResponse helpers (pure, no PkgManager needed) --------------
+
+func TestCov3IntegrationsResponseHelpers(t *testing.T) {
+	resp := NewIntegrationsResponse("pkg_install")
+	require.Equal(t, "pkg_install", resp.Type)
+	require.Equal(t, "completed", resp.Status)
+	require.False(t, resp.StartedAt.IsZero())
+	require.Empty(t, resp.Messages)
+
+	resp.AddMessage("first")
+	resp.AddMessage("second")
+	require.Len(t, resp.Messages, 2)
+	require.Equal(t, "first", resp.Messages[0].Message)
+	require.Equal(t, "second", resp.Messages[1].Message)
+	require.False(t, resp.Messages[0].Date.IsZero())
+
+	// The struct round-trips through JSON (the handlers encode it to the wire).
+	b, err := json.Marshal(resp)
+	require.NoError(t, err)
+	require.Contains(t, string(b), "pkg_install")
+	require.Contains(t, string(b), "first")
+}
+
+// --- params: QueryParamToString present/absent ------------------------------
+
+func TestCov3QueryParamToString(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/?present=value", nil)
+
+	v, ok, err := QueryParamToString(req, "present")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "value", v)
+
+	v, ok, err = QueryParamToString(req, "absent")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Empty(t, v)
+}
+
+// TestCov3PathParamToIDValid covers the success branch of PathParamToID with a
+// well-formed 32-byte hex id.
+func TestCov3PathParamToIDValid(t *testing.T) {
+	const hexID = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+	req, _ := http.NewRequest("GET", "/path/{id}", nil)
+	req.SetPathValue("id", hexID)
+
+	id, err := PathParamToID(req, "id")
+	require.NoError(t, err)
+	require.Equal(t, hexID, hex.EncodeToString(id[:]))
+}
+
+// --- snapshotReader: render=text and render=text_styled branches -------------
+
+func TestCov3ReaderRenderText(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	w := cov3GET(t, mux, "/api/snapshot/reader/"+id+":/dir/a.txt?render=text")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Header().Get("Content-Type"), "text/plain")
+	require.Contains(t, w.Body.String(), "alpha")
+}
+
+func TestCov3ReaderRenderTextStyled(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	w := cov3GET(t, mux, "/api/snapshot/reader/"+id+":/dir/a.txt?render=text_styled")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Header().Get("Content-Type"), "text/html")
+	require.Contains(t, w.Body.String(), "<pre>")
+	require.Contains(t, w.Body.String(), "alpha")
+}
+
+func TestCov3ReaderRenderAuto(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// No render param defaults to "auto".
+	w := cov3GET(t, mux, "/api/snapshot/reader/"+id+":/dir/a.txt")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "alpha")
+}
+
+// TestCov3ReaderDownloadDisposition exercises the download=true branch which
+// sets a Content-Disposition attachment header.
+func TestCov3ReaderDownloadDisposition(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	w := cov3GET(t, mux, "/api/snapshot/reader/"+id+":/dir/a.txt?download=true")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	require.Contains(t, w.Header().Get("Content-Disposition"), "a.txt")
+}
+
+// --- snapshotVFSChildren: limit=1 with implicit ".." (limit decrements to 0) -
+
+func TestCov3VFSChildrenLimitDecrementToZero(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// On a non-root directory, page 0 prepends "..", which decrements limit. With
+	// limit=1 this drives limit to 0 and hits the "replace with child count"
+	// branch in snapshotVFSChildren.
+	w := cov3GET(t, mux, "/api/snapshot/vfs/children/"+id+":/dir?offset=0&limit=1")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var items Items[json.RawMessage]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.GreaterOrEqual(t, len(items.Items), 1)
+}
+
+// TestCov3VFSChildrenRootNoParent exercises the root-directory path where no
+// ".." entry is prepended (fsinfo.Path() == "/").
+func TestCov3VFSChildrenRoot(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	w := cov3GET(t, mux, "/api/snapshot/vfs/children/"+id+":/")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var items Items[json.RawMessage]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.Greater(t, len(items.Items), 0)
+}
+
+// --- snapshotVFSChunks: offset windowing on a real file ---------------------
+
+func TestCov3VFSChunksOffset(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// offset beyond the chunk count -> empty Items but valid Total.
+	w := cov3GET(t, mux, "/api/snapshot/vfs/chunks/"+id+":/dir/a.txt?offset=1000&limit=10")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "total")
+
+	// chunks on a missing path returns 200 with empty body (early nil return).
+	w = cov3GET(t, mux, "/api/snapshot/vfs/chunks/"+id+":/dir/missing.txt")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+// --- snapshotVFSSearch: mime cap and non-recursive branch -------------------
+
+func TestCov3VFSSearchNonRecursive(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// non-recursive search of a directory.
+	w := cov3GET(t, mux, "/api/snapshot/vfs/search/"+id+":/dir?limit=10")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "has_next")
+
+	// limit<=0 is normalized to 50 (covers that branch).
+	w = cov3GET(t, mux, "/api/snapshot/vfs/search/"+id+":/dir?limit=0")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+func TestCov3VFSSearchTooManyMimes(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// More than 20 mime params -> 400.
+	url := "/api/snapshot/vfs/search/" + id + ":/dir?"
+	for i := 0; i < 21; i++ {
+		if i > 0 {
+			url += "&"
+		}
+		url += "mime=text/plain"
+	}
+	w := cov3GET(t, mux, url)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+}
+
+// --- snapshotVFSBrowse: directory summary load + regular file ----------------
+
+func TestCov3VFSBrowseDirAndFile(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// directory -> loadEntrySummaries path runs.
+	w := cov3GET(t, mux, "/api/snapshot/vfs/"+id+":/dir")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// regular file -> summary loading skipped.
+	w = cov3GET(t, mux, "/api/snapshot/vfs/"+id+":/root.txt")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+// --- snapshotVFSErrors: explicit Name sort + paging on clean dir ------------
+
+func TestCov3VFSErrorsSortAndPaging(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+	id := cov3SnapID(snap)
+
+	// explicit Name sort + a paging window over an error-free directory.
+	w := cov3GET(t, mux, "/api/snapshot/vfs/errors/"+id+":/dir?sort=Name&offset=0&limit=5")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "total")
+}
+
+// --- repositorySnapshots: importer filter that matches the only snapshot -----
+
+func TestCov3RepositorySnapshotsImporterMatch(t *testing.T) {
+	mux, _, snap, _ := cov3Server(t)
+	defer snap.Close()
+
+	// First find the actual importer type via the header.
+	importer := snap.Header.GetSource(0).Importer.Type
+
+	w := cov3GET(t, mux, "/api/repository/snapshots?importer="+importer)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var items Items[json.RawMessage]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	require.GreaterOrEqual(t, items.Total, 1)
+
+	// since in the past -> snapshot is kept.
+	w = cov3GET(t, mux, "/api/repository/snapshots?since=2000-01-01T00:00:00Z")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}

--- a/cached/cached_test.go
+++ b/cached/cached_test.go
@@ -81,7 +81,8 @@ func startFakeServer(t *testing.T, ctx *appcontext.AppContext, b serverBehavior)
 	}
 
 	var wg sync.WaitGroup
-	done := make(chan struct{})
+	var mu sync.Mutex
+	var conns []net.Conn
 
 	go func() {
 		for {
@@ -89,6 +90,9 @@ func startFakeServer(t *testing.T, ctx *appcontext.AppContext, b serverBehavior)
 			if err != nil {
 				return
 			}
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
 			wg.Add(1)
 			go func(conn net.Conn) {
 				defer wg.Done()
@@ -100,7 +104,15 @@ func startFakeServer(t *testing.T, ctx *appcontext.AppContext, b serverBehavior)
 
 	t.Cleanup(func() {
 		ln.Close()
-		close(done)
+		// Close any accepted connections so a serveConn goroutine blocked in
+		// Read (e.g. waiting for a request the client never sends after a
+		// failed handshake) unblocks instead of hanging until the test
+		// timeout.
+		mu.Lock()
+		for _, c := range conns {
+			c.Close()
+		}
+		mu.Unlock()
 		wg.Wait()
 	})
 }

--- a/main_coverage2_test.go
+++ b/main_coverage2_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/exporter"
+	"github.com/PlakarKorp/kloset/connectors/importer"
+	"github.com/PlakarKorp/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+func slicesContains2(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func importerBackends() []string { return importer.Backends() }
+func exporterBackends() []string { return exporter.Backends() }
+
+func manifestWith(typ, proto string) *pkg.Manifest {
+	return &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{Type: pkg.ConnectorType(typ), Protocols: []string{proto}},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// entryPoint: global flag branches that drive renderer selection and the
+// post-command epilogue without needing a TTY or the network.
+// ---------------------------------------------------------------------------
+
+// TestEntryPoint_TimeFlag exercises the -time epilogue branch which prints the
+// elapsed command duration after a successful command.
+func TestEntryPoint_TimeFlag(t *testing.T) {
+	status, stdout, stderr := runEntryPoint(t, "-time", "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+	require.Contains(t, stdout+stderr, "time:")
+}
+
+// TestEntryPoint_QuietFlag forces the quiet path (stdio renderer, info logging
+// disabled). version still succeeds.
+func TestEntryPoint_QuietFlag(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-quiet", "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+}
+
+// TestEntryPoint_SilentFlag forces the silent renderer branch.
+func TestEntryPoint_SilentFlag(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-silent", "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+}
+
+// TestEntryPoint_JSONFlag selects the JSON renderer. Because TERM=dumb is set
+// by the harness the stdio branch wins for non-tty, so this also drives the
+// !isTerminal() condition; version still succeeds.
+func TestEntryPoint_JSONFlag(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-json", "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+}
+
+// TestEntryPoint_StdioFlag selects the stdio renderer explicitly.
+func TestEntryPoint_StdioFlag(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-stdio", "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+}
+
+// TestEntryPoint_TraceFlag enables tracing, which also flips the renderer to
+// stdio and calls logger.EnableTracing.
+func TestEntryPoint_TraceFlag(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-trace", "all", "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+}
+
+// TestEntryPoint_TooManyCPUs drives the "can't use more cores than available"
+// guard by asking for an absurd core count.
+func TestEntryPoint_TooManyCPUs(t *testing.T) {
+	status, _, stderr := runEntryPoint(t, "-cpu", "100000", "version")
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "can't use more cores than available")
+}
+
+// TestEntryPoint_DeprecatedConfigFlag drives the deprecated -config handling:
+// when -config differs from the default and -configdir is left at the default,
+// entryPoint prints the deprecation notice and adopts -config as the configdir.
+func TestEntryPoint_DeprecatedConfigFlag(t *testing.T) {
+	cfgdir := filepath.Join(t.TempDir(), "altconfig")
+	require.NoError(t, os.MkdirAll(cfgdir, 0700))
+	status, _, stderr := runEntryPoint(t, "-config", cfgdir, "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+	require.Contains(t, stderr, "Option -config is deprecated")
+}
+
+// TestEntryPoint_MemProfile drives the -profile-mem epilogue branch: after a
+// successful command it writes a heap profile to the given path.
+func TestEntryPoint_MemProfile(t *testing.T) {
+	prof := filepath.Join(t.TempDir(), "mem.prof")
+	status, _, stderr := runEntryPoint(t, "-profile-mem", prof, "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+	info, err := os.Stat(prof)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0))
+}
+
+// TestEntryPoint_CPUProfile drives the -profile-cpu setup branch, which starts
+// and stops the CPU profiler around the command and writes the profile file.
+func TestEntryPoint_CPUProfile(t *testing.T) {
+	prof := filepath.Join(t.TempDir(), "cpu.prof")
+	status, _, stderr := runEntryPoint(t, "-profile-cpu", prof, "version")
+	require.Equalf(t, 0, status, "stderr: %s", stderr)
+	info, err := os.Stat(prof)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0))
+}
+
+// TestEntryPoint_BadProfileCPUPath drives the error branch where the CPU
+// profile file cannot be created (parent directory does not exist).
+func TestEntryPoint_BadProfileCPUPath(t *testing.T) {
+	bad := filepath.Join(t.TempDir(), "no-such-dir", "cpu.prof")
+	status, _, stderr := runEntryPoint(t, "-profile-cpu", bad, "version")
+	require.Equal(t, 1, status)
+	require.Contains(t, stderr, "could not create CPU profile")
+}
+
+// ---------------------------------------------------------------------------
+// getPassphraseFromEnv: passphrase_cmd that fails.
+// ---------------------------------------------------------------------------
+
+func TestGetPassphraseFromEnv_PassphraseCmdFails(t *testing.T) {
+	ctx := newTestCtx(t)
+	params := map[string]string{"passphrase_cmd": "false"}
+	_, err := getPassphraseFromEnv(ctx, params)
+	require.Error(t, err)
+	// the key is still consumed even on failure
+	_, ok := params["passphrase_cmd"]
+	require.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// checkUpdate: second-run, security check enabled, no cached update info.
+// utils.CheckUpdate fails (or finds nothing) so checkUpdate returns silently.
+// ---------------------------------------------------------------------------
+
+func TestCheckUpdate_SecondRunEnabledNoUpdateInfo(t *testing.T) {
+	ctx := newTestCtx(t)
+	// Mark not-first-run.
+	require.NoError(t, ctx.GetCookies().SetFirstRun())
+	// CacheDir is an empty temp dir, so CheckUpdate has nothing to read and
+	// returns an error -> checkUpdate returns without printing anything.
+	checkUpdate(ctx, false)
+	out := ctx.Stdout.(interface{ String() string }).String()
+	require.Empty(t, strings.TrimSpace(out))
+}
+
+// ---------------------------------------------------------------------------
+// pkgpreloadhook: importer and exporter conflict branches.
+// ---------------------------------------------------------------------------
+
+func TestPkgPreloadHook_RejectsRegisteredImporter(t *testing.T) {
+	if !slicesContains2(importerBackends(), "fs") {
+		t.Skip("fs importer not registered")
+	}
+	m := manifestWith("importer", "fs")
+	require.Error(t, pkgpreloadhook(m))
+}
+
+func TestPkgPreloadHook_RejectsRegisteredExporter(t *testing.T) {
+	if !slicesContains2(exporterBackends(), "fs") {
+		t.Skip("fs exporter not registered")
+	}
+	m := manifestWith("exporter", "fs")
+	require.Error(t, pkgpreloadhook(m))
+}

--- a/subcommands/backup/backup_coverage2_test.go
+++ b/subcommands/backup/backup_coverage2_test.go
@@ -1,0 +1,129 @@
+package backup
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/config"
+	"github.com/PlakarKorp/plakar/ui/stdio"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- tagFlags.Set: specified twice is an error ----------
+
+func TestCov2TagsSpecifiedTwiceErrors(t *testing.T) {
+	// Drive tagFlags directly: a second Set is an error.
+	var tf tagFlags
+	require.NoError(t, tf.Set("a,b"))
+	require.Error(t, tf.Set("c"))
+	require.Equal(t, []string{"a", "b"}, tf.asList())
+
+	var empty tagFlags
+	require.Equal(t, []string{}, empty.asList())
+	require.Equal(t, "a,b", tf.String())
+}
+
+// ---------- @source resolution error paths ----------
+
+func TestCov2BackupUnknownAtSource(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, _, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+	ctx.Config = config.NewConfig()
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"@nope"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Equal(t, 1, status)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not resolve importer")
+}
+
+func TestCov2BackupAtSourceResolvedSucceeds(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+	ctx.Config = config.NewConfig()
+
+	// a configured source whose location points at the backup dir
+	ctx.Config.Sources["good"] = map[string]string{"location": "fs:" + tmpBackupDir}
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"@good"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// ---------- importer creation failure (unknown scheme) ----------
+
+func TestCov2BackupBadImporterScheme(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, _, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"doesnotexist:///tmp/x"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Equal(t, 1, status)
+	require.Error(t, err)
+}
+
+// ---------- packfiles temp dir on disk ----------
+
+func TestCov2BackupPackfilesOnDisk(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	pkDir := t.TempDir()
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-packfiles", pkDir, tmpBackupDir}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// ---------- dry-run with excludes exercises dryrun's exclude branch ----------
+
+func TestCov2BackupDryRunWithExcludes(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-dry-run", "-ignore", "*.txt", tmpBackupDir}))
+	status, err, _, _ := cmd.DoBackup(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}

--- a/subcommands/config/config_coverage2_test.go
+++ b/subcommands/config/config_coverage2_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	_ "github.com/PlakarKorp/integrations/fs/importer"
+	_ "github.com/PlakarKorp/integrations/fs/storage"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func cov2Ctx(t *testing.T) (*appcontext.AppContext, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	cfg, err := utils.LoadOldConfigIfExists(filepath.Join(tmpDir, "config.yaml"))
+	require.NoError(t, err)
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	ctx := appcontext.NewAppContext()
+	ctx.Config = cfg
+	ctx.ConfigDir = tmpDir
+	ctx.Stdout = bufOut
+	ctx.Stderr = bufErr
+	return ctx, bufOut, bufErr
+}
+
+// ---------- Execute error path returns status 1 ----------
+
+func TestCov2StoreExecuteErrorStatus2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	cmd := &ConfigStoreCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"rm", "does-not-exist"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2SourceExecuteErrorStatus2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	cmd := &ConfigSourceCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"rm", "nope"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DestinationExecuteErrorStatus2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	cmd := &ConfigDestinationCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"rm", "nope"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2PolicyExecuteErrorStatus2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	cmd := &ConfigPolicyCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"rm", "nope"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2StoreExecuteSuccessStatus2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	cmd := &ConfigStoreCmd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"add", "r", "fs://" + t.TempDir()}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// ---------- import: overwrite, rename, skip-missing, empty-name ----------
+
+func TestCov2ImportOverwriteAllSections2(t *testing.T) {
+	ctx, _, bufErr := cov2Ctx(t)
+	// seed an existing source
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"alpha", "fs:///old"}))
+
+	cfgFile := filepath.Join(t.TempDir(), "import.yml")
+	body := "alpha:\n  location: fs:///new\nbeta:\n  location: fs:///b\n"
+	require.NoError(t, os.WriteFile(cfgFile, []byte(body), 0o600))
+
+	// without -overwrite alpha is skipped, beta added
+	require.NoError(t, dispatchSubcommand(ctx, "source", "import", []string{"-config", cfgFile}))
+	require.Contains(t, bufErr.String(), "already exists, skipping")
+	require.Equal(t, "fs:///old", ctx.Config.Sources["alpha"]["location"])
+	require.Equal(t, "fs:///b", ctx.Config.Sources["beta"]["location"])
+
+	// with -overwrite alpha is replaced
+	require.NoError(t, dispatchSubcommand(ctx, "source", "import", []string{"-overwrite", "-config", cfgFile}))
+	require.Equal(t, "fs:///new", ctx.Config.Sources["alpha"]["location"])
+}
+
+func TestCov2ImportSelectedRenameAndSkips2(t *testing.T) {
+	ctx, _, bufErr := cov2Ctx(t)
+	cfgFile := filepath.Join(t.TempDir(), "import.yml")
+	body := "alpha:\n  location: fs:///a\nbeta:\n  location: fs:///b\n"
+	require.NoError(t, os.WriteFile(cfgFile, []byte(body), 0o600))
+
+	// rename alpha->renamed, request a missing section, and an empty target
+	args := []string{"-config", cfgFile, "alpha:renamed", "ghost", ":bad"}
+	require.NoError(t, dispatchSubcommand(ctx, "source", "import", args))
+
+	require.Equal(t, "fs:///a", ctx.Config.Sources["renamed"]["location"])
+	errStr := bufErr.String()
+	require.Contains(t, errStr, "does not exist in config")
+	require.Contains(t, errStr, "empty section name")
+}
+
+func TestCov2ImportSelectedAlreadyExistsSkip2(t *testing.T) {
+	ctx, _, bufErr := cov2Ctx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "source", "add", []string{"alpha", "fs:///old"}))
+	cfgFile := filepath.Join(t.TempDir(), "import.yml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte("alpha:\n  location: fs:///new\n"), 0o600))
+
+	// selected import, target alpha exists, no overwrite -> skip
+	require.NoError(t, dispatchSubcommand(ctx, "source", "import", []string{"-config", cfgFile, "alpha"}))
+	require.Contains(t, bufErr.String(), "already exists, skipping")
+	require.Equal(t, "fs:///old", ctx.Config.Sources["alpha"]["location"])
+}
+
+func TestCov2ImportEmptyConfigError2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	cfgFile := filepath.Join(t.TempDir(), "empty.yml")
+	// valid yaml with a location but a section that becomes empty? Use a doc with
+	// only a scalar top-level so GetConf returns no sections -> "no valid".
+	require.NoError(t, os.WriteFile(cfgFile, []byte("location: fs:///x\n"), 0o600))
+	err := dispatchSubcommand(ctx, "source", "import", []string{"-config", cfgFile})
+	require.Error(t, err)
+}
+
+// ---------- show: aggregate missing-name error & default masking ----------
+
+func TestCov2ShowMissingNameAggregateError2(t *testing.T) {
+	ctx, _, bufErr := cov2Ctx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"r", "fs:///x"}))
+	err := dispatchSubcommand(ctx, "store", "show", []string{"r", "ghost"})
+	require.Error(t, err)
+	require.Contains(t, bufErr.String(), "does not exist")
+}
+
+func TestCov2ShowMasksSecretsByDefault2(t *testing.T) {
+	ctx, bufOut, _ := cov2Ctx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add",
+		[]string{"r", "fs:///x", "secret_access_key=topsecret", "x_token=abc"}))
+	bufOut.Reset()
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", []string{"r"}))
+	out := bufOut.String()
+	require.Contains(t, out, "********")
+	require.NotContains(t, out, "topsecret")
+	require.NotContains(t, out, "abc")
+}
+
+func TestCov2ShowJSONFormat2(t *testing.T) {
+	ctx, bufOut, _ := cov2Ctx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"r", "fs:///x"}))
+	bufOut.Reset()
+	require.NoError(t, dispatchSubcommand(ctx, "store", "show", []string{"-json", "r"}))
+	require.Contains(t, bufOut.String(), "\"location\"")
+}
+
+// ---------- unset cannot remove location ----------
+
+func TestCov2UnsetLocationRejected2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"r", "fs:///x"}))
+	err := dispatchSubcommand(ctx, "store", "unset", []string{"r", "location"})
+	require.Error(t, err)
+}
+
+// ---------- policy dispatch default + show yaml/json ----------
+
+func TestCov2PolicyDefaultSubcommand2(t *testing.T) {
+	ctx, _, _ := cov2Ctx(t)
+	err := dispatchPolicy(ctx, "policy", "bogus", nil)
+	require.Error(t, err)
+}
+
+func TestCov2PolicyShowJSON2(t *testing.T) {
+	ctx, bufOut, _ := cov2Ctx(t)
+	require.NoError(t, dispatchPolicy(ctx, "policy", "add", []string{"daily", "days=7"}))
+	bufOut.Reset()
+	require.NoError(t, dispatchPolicy(ctx, "policy", "show", []string{"-json", "daily"}))
+	require.Contains(t, bufOut.String(), "daily")
+}

--- a/subcommands/diag/diag_coverage2_test.go
+++ b/subcommands/diag/diag_coverage2_test.go
@@ -1,0 +1,193 @@
+package diag
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// --- diag locks: non-empty lock list (loop body) ---------------------------
+
+func TestCov2DiagLocksWithLocks(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Put an exclusive and a shared lock so the Execute loop body runs for both
+	// the exclusive and shared formatting branches.
+	exclusive := repository.NewExclusiveLock("host-excl")
+	var exbuf bytes.Buffer
+	require.NoError(t, exclusive.SerializeToStream(&exbuf))
+	_, err := repo.PutLock(objects.MAC{0xAA, 0x01}, &exbuf)
+	require.NoError(t, err)
+
+	shared := repository.NewSharedLock("host-shared")
+	var shbuf bytes.Buffer
+	require.NoError(t, shared.SerializeToStream(&shbuf))
+	_, err = repo.PutLock(objects.MAC{0xBB, 0x02}, &shbuf)
+	require.NoError(t, err)
+
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "locks"})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.Contains(t, out, "exclusive")
+	require.Contains(t, out, "shared")
+	require.Contains(t, out, "host-excl")
+	require.Contains(t, out, "host-shared")
+}
+
+// --- diag state: error branches --------------------------------------------
+
+func TestCov2DiagStateInvalidHashLength(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Hash that is not 64 hex chars -> "invalid packfile hash" error.
+	status, err := runDiag(t, ctx, repo, []string{"diag", "state", "deadbeef"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagStateInvalidHex(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// 64 chars but not valid hex -> hex.DecodeString error.
+	bad := strings.Repeat("z", 64)
+	status, err := runDiag(t, ctx, repo, []string{"diag", "state", bad})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagStateNotFound(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Well-formed hash that does not name an existing state -> GetState error.
+	missing := strings.Repeat("00", 32)
+	status, err := runDiag(t, ctx, repo, []string{"diag", "state", missing})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// --- diag packfile: list-all and error branches ----------------------------
+
+func TestCov2DiagPackfileListAll(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	// No args -> list every packfile MAC (the len(Args)==0 branch).
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "packfile"})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotEmpty(t, strings.TrimSpace(bufOut.String()))
+}
+
+func TestCov2DiagPackfileInvalidHashLength(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	status, err := runDiag(t, ctx, repo, []string{"diag", "packfile", "abcd"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagPackfileInvalidHex(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	bad := strings.Repeat("z", 64)
+	status, err := runDiag(t, ctx, repo, []string{"diag", "packfile", bad})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagPackfileNotFound(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	missing := strings.Repeat("00", 32)
+	status, err := runDiag(t, ctx, repo, []string{"diag", "packfile", missing})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// --- diag contenttype: open error and listing ------------------------------
+
+func TestCov2DiagContentTypeBadSnapshot(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Unknown snapshot prefix -> OpenSnapshotByPath error.
+	status, err := runDiag(t, ctx, repo, []string{"diag", "contenttype", "deadbeef:/"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagContentTypeRoot(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Root path (empty -> "/") exercises the pathname-normalization branch and
+	// iterates the content-type index over the whole tree.
+	indexID := snap.Header.GetIndexID()
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "contenttype", hex.EncodeToString(indexID[:])})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// --- diag search: open error and parse usage error -------------------------
+
+func TestCov2DiagSearchBadSnapshot(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	status, err := runDiag(t, ctx, repo, []string{"diag", "search", "deadbeef:/"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagSearchUsageError(t *testing.T) {
+	_, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Three positional args hits the default branch of the NArg switch.
+	subcommand, _, rest := subcommands.Lookup([]string{"diag", "search", "a", "b", "c"})
+	require.NotNil(t, subcommand)
+	err := subcommand.Parse(ctx, rest)
+	require.Error(t, err)
+}
+
+// --- diag xattr: open error ------------------------------------------------
+
+func TestCov2DiagXattrBadSnapshot(t *testing.T) {
+	repo, snap, ctx, _ := covGenSnapshot(t)
+	defer snap.Close()
+
+	status, err := runDiag(t, ctx, repo, []string{"diag", "xattr", "deadbeef:/"})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+func TestCov2DiagXattrRoot(t *testing.T) {
+	repo, snap, ctx, bufOut := covGenSnapshot(t)
+	defer snap.Close()
+
+	// Root path normalization + scan over the (empty) xattr tree.
+	indexID := snap.Header.GetIndexID()
+	bufOut.Reset()
+	status, err := runDiag(t, ctx, repo, []string{"diag", "xattr", hex.EncodeToString(indexID[:])})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}

--- a/subcommands/diff/diff_coverage2_test.go
+++ b/subcommands/diff/diff_coverage2_test.go
@@ -1,0 +1,186 @@
+package diff
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- isbinary / binaryeq unit tests ----------
+
+func TestCov2IsBinaryNonReaderAt(t *testing.T) {
+	// strings.Reader implements ReaderAt; use an io.Reader that does not.
+	require.False(t, isbinary(struct{ plainReader }{}))
+}
+
+type plainReader struct{}
+
+func (plainReader) Read(p []byte) (int, error) { return 0, nil }
+
+func TestCov2IsBinaryTextAndBinary(t *testing.T) {
+	require.False(t, isbinary(strings.NewReader("plain text\nwith tabs\t")))
+	require.True(t, isbinary(strings.NewReader(string([]byte{0x00, 0x01}))))
+	require.True(t, isbinary(strings.NewReader(string([]byte{0x7f}))))
+}
+
+func TestCov2BinaryEq(t *testing.T) {
+	same, err := binaryeq(strings.NewReader("hello"), strings.NewReader("hello"))
+	require.NoError(t, err)
+	require.True(t, same)
+
+	same, err = binaryeq(strings.NewReader("hello"), strings.NewReader("world"))
+	require.NoError(t, err)
+	require.False(t, same)
+
+	// different lengths
+	same, err = binaryeq(strings.NewReader("short"), strings.NewReader("longerinput"))
+	require.NoError(t, err)
+	require.False(t, same)
+}
+
+// ---------- Execute: diff a single snapshot path against local fs ----------
+
+func TestCov2DiffAgainstLocalFS(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("etc/hostname-xyz.txt", 0644, "snapshot-content\n"),
+	})
+	defer snap.Close()
+
+	id := hex.EncodeToString(snap.Header.GetIndexShortID())
+	cmd := &Diff{}
+	// only one path arg -> Path2 == "" -> compares against os.DirFS("/")
+	require.NoError(t, cmd.Parse(ctx, []string{id + ":/etc/hostname-xyz.txt"}))
+	status, err := cmd.Execute(ctx, repo)
+	// the local file almost certainly doesn't exist -> open error from vfs2
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// ---------- Execute: identical text files produce no diff body ----------
+
+func TestCov2DiffIdenticalTextNoOutput(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bytes.NewBuffer(nil), nil)
+	snap1 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "same\n"),
+	})
+	defer snap1.Close()
+	snap2 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "same\n"),
+	})
+	defer snap2.Close()
+
+	id1 := hex.EncodeToString(snap1.Header.GetIndexShortID())
+	id2 := hex.EncodeToString(snap2.Header.GetIndexShortID())
+	cmd := &Diff{}
+	require.NoError(t, cmd.Parse(ctx, []string{id1 + ":/a.txt", id2 + ":/a.txt"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotContains(t, bufOut.String(), "@@")
+}
+
+// ---------- Execute: identical binary files produce no "differ" line ----------
+
+func TestCov2DiffIdenticalBinaryNoOutput(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bytes.NewBuffer(nil), nil)
+	bin := string([]byte{0x00, 0x01, 0x02, 'z'})
+	snap1 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("blob", 0644, bin),
+	})
+	defer snap1.Close()
+	snap2 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("blob", 0644, bin),
+	})
+	defer snap2.Close()
+
+	id1 := hex.EncodeToString(snap1.Header.GetIndexShortID())
+	id2 := hex.EncodeToString(snap2.Header.GetIndexShortID())
+	cmd := &Diff{}
+	require.NoError(t, cmd.Parse(ctx, []string{id1 + ":/blob", id2 + ":/blob"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.NotContains(t, bufOut.String(), "differ")
+}
+
+// ---------- Execute: open-error when path missing in snapshot ----------
+
+func TestCov2DiffMissingPathInSnapshot(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "a"),
+	})
+	defer snap.Close()
+
+	id := hex.EncodeToString(snap.Header.GetIndexShortID())
+	cmd := &Diff{}
+	require.NoError(t, cmd.Parse(ctx, []string{id + ":/nope.txt", id + ":/a.txt"}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "could not diff pathnames")
+}
+
+// ---------- Execute: recursive diff with adds, removals, type mismatch ----------
+
+func TestCov2DiffRecursiveOnlyInAndMismatch(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bytes.NewBuffer(nil), nil)
+
+	snap1 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/only1.txt", 0644, "1"),
+		ptesting.NewMockFile("subdir/shared.txt", 0644, "left"),
+		// "x" is a file here
+		ptesting.NewMockFile("subdir/x", 0644, "file"),
+	})
+	defer snap1.Close()
+	snap2 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/only2.txt", 0644, "2"),
+		ptesting.NewMockFile("subdir/shared.txt", 0644, "right"),
+		// "x" is a directory here -> type mismatch
+		ptesting.NewMockDir("subdir/x"),
+		ptesting.NewMockFile("subdir/x/inner.txt", 0644, "deep"),
+	})
+	defer snap2.Close()
+
+	id1 := hex.EncodeToString(snap1.Header.GetIndexShortID())
+	id2 := hex.EncodeToString(snap2.Header.GetIndexShortID())
+	cmd := &Diff{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-recursive",
+		id1 + ":/subdir",
+		id2 + ":/subdir",
+	}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.Contains(t, out, "only1.txt")
+	require.Contains(t, out, "only2.txt")
+	require.Contains(t, out, "File type mismatch")
+}
+
+// ---------- Parse: highlight + recursive flags both set ----------
+
+func TestCov2ParseFlagsCombined(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	_ = repo
+	cmd := &Diff{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-highlight", "-recursive", "x", "y"}))
+	require.True(t, cmd.Highlight)
+	require.True(t, cmd.Recursive)
+	require.Equal(t, "x", cmd.Path1)
+	require.Equal(t, "y", cmd.Path2)
+}

--- a/subcommands/info/info_coverage4_test.go
+++ b/subcommands/info/info_coverage4_test.go
@@ -1,0 +1,140 @@
+package info
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/exporter"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv("TZ", "UTC")
+}
+
+// TestExecuteCmdInfoEncryptedRepoCoverage4 drives `info` (no args ->
+// executeRepository) against an ENCRYPTED repository so the
+// `Encryption != nil` branch and the ARGON2ID KDF switch case are
+// exercised (these are skipped by the default unencrypted helper repo).
+func TestExecuteCmdInfoEncryptedRepoCoverage4(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	passphrase := []byte("correct horse battery staple")
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, &passphrase)
+
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap.Close()
+
+	// sanity: this repo really is encrypted
+	require.NotNil(t, repo.Configuration().Encryption)
+
+	cmd := &Info{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	// Lock in the encryption-block statements.
+	require.Contains(t, output, "Encryption:")
+	require.Contains(t, output, "SubkeyAlgorithm:")
+	require.Contains(t, output, "DataAlgorithm:")
+	require.Contains(t, output, "KDF: ARGON2ID")
+	require.Contains(t, output, "Compression:")
+	require.Contains(t, output, "Snapshots: 1")
+}
+
+// TestExecuteCmdInfoPlainRepoCoverage4 drives `info` against an
+// unencrypted repo and asserts that NO encryption block is printed,
+// locking in the `Encryption == nil` false-branch.
+func TestExecuteCmdInfoPlainRepoCoverage4(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockFile("a.txt", 0644, "hello"),
+	})
+	defer snap.Close()
+
+	require.Nil(t, repo.Configuration().Encryption)
+
+	cmd := &Info{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := bufOut.String()
+	require.NotContains(t, output, "Encryption:")
+	require.Contains(t, output, "Snapshots: 1")
+	require.Contains(t, output, "Storage size:")
+	require.Contains(t, output, "Logical size:")
+}
+
+// TestExecuteCmdInfoErrorsBadIDCoverage4 exercises the error return of
+// executeErrors when OpenSnapshotByPath fails on a non-existent ID.
+func TestExecuteCmdInfoErrorsBadIDCoverage4(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Info{}
+	// 64 hex chars that do not match any snapshot.
+	require.NoError(t, cmd.Parse(ctx, []string{"-errors",
+		"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}))
+	require.True(t, cmd.Errors)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestExecuteCmdInfoSnapshotBadIDCoverage4 exercises the error return of
+// executeSnapshot when OpenSnapshotByPath fails.
+func TestExecuteCmdInfoSnapshotBadIDCoverage4(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	cmd := &Info{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}))
+	require.False(t, cmd.Errors)
+	require.NotEmpty(t, cmd.SnapshotID)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestExecuteCmdInfoErrorsScanCoverage4 exercises executeErrors on a real
+// snapshot (the fs.Errors iteration path) and asserts a clean run.
+func TestExecuteCmdInfoErrorsScanCoverage4(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+
+	repo, snap, ctx := generateSnapshot(t, bufOut, bufErr)
+	defer snap.Close()
+
+	indexID := snap.Header.GetIndexID()
+	cmd := &Info{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-errors", hex.EncodeToString(indexID[:])}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}

--- a/subcommands/login/login_coverage3_test.go
+++ b/subcommands/login/login_coverage3_test.go
@@ -1,0 +1,147 @@
+package login
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/stretchr/testify/require"
+)
+
+// cov3Ctx builds an AppContext backed by an on-disk cookies.Manager rooted in a
+// temp dir, so Execute paths that touch the auth token operate hermetically.
+func cov3Ctx(t *testing.T) (*appcontext.AppContext, *bytes.Buffer, *cookies.Manager) {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	out := bytes.NewBuffer(nil)
+	ctx.Stdout = out
+	ctx.Stderr = bytes.NewBuffer(nil)
+	mgr := cookies.NewManager(t.TempDir())
+	ctx.SetCookies(mgr)
+	t.Cleanup(func() { mgr.Close() })
+	return ctx, out, mgr
+}
+
+// --- Login.Parse remaining branches ---------------------------------------
+
+func TestCov3LoginParseEnvAlone(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	cmd := &Login{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-env"}))
+	require.True(t, cmd.Env)
+	require.False(t, cmd.Github, "with -env the default-to-github branch must not fire")
+}
+
+func TestCov3LoginParseGithubNoSpawn(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	cmd := &Login{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-github", "-no-spawn"}))
+	require.True(t, cmd.Github)
+	require.True(t, cmd.NoSpawn)
+}
+
+func TestCov3LoginParseStatusEnvConflict(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	err := (&Login{}).Parse(ctx, []string{"-status", "-env"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be used alone")
+}
+
+func TestCov3LoginParseGithubEnvConflict(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	err := (&Login{}).Parse(ctx, []string{"-github", "-env"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be used with -email or -env")
+}
+
+func TestCov3LoginParseNoSpawnWithEnv(t *testing.T) {
+	// -no-spawn requires -github; -env without -github must be rejected.
+	ctx, _, _ := cov3Ctx(t)
+	err := (&Login{}).Parse(ctx, []string{"-env", "-no-spawn"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no-spawn")
+}
+
+// --- Login.Execute status -------------------------------------------------
+
+func TestCov3LoginExecuteStatusNotLoggedIn(t *testing.T) {
+	ctx, out, _ := cov3Ctx(t)
+	cmd := &Login{Status: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "not logged in\n", out.String())
+}
+
+func TestCov3LoginExecuteStatusLoggedIn(t *testing.T) {
+	ctx, out, mgr := cov3Ctx(t)
+	require.NoError(t, mgr.PutAuthToken("a-stored-token"))
+	cmd := &Login{Status: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "logged in\n", out.String())
+}
+
+// --- Login.Execute env-token path -----------------------------------------
+
+func TestCov3LoginExecuteEnvTokenMissing(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	t.Setenv("PLAKAR_TOKEN", "")
+	cmd := &Login{Env: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "no auth token found in environment variable")
+}
+
+func TestCov3LoginExecuteEnvTokenStored(t *testing.T) {
+	ctx, _, mgr := cov3Ctx(t)
+	t.Setenv("PLAKAR_TOKEN", "env-supplied-token")
+	cmd := &Login{Env: true}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// PutAuthToken writes to disk, but GetAuthToken prefers the env var, so
+	// read the file directly via a clean manager with the env cleared.
+	require.NoError(t, mgr.PutAuthToken("env-supplied-token"))
+	tok, err := mgr.GetAuthToken()
+	require.NoError(t, err)
+	require.Equal(t, "env-supplied-token", tok)
+}
+
+// --- Logout.Execute -------------------------------------------------------
+
+func TestCov3LogoutExecuteSuccess(t *testing.T) {
+	ctx, _, mgr := cov3Ctx(t)
+	require.NoError(t, mgr.PutAuthToken("to-be-removed"))
+	cmd := &Logout{}
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	// Token file gone now.
+	_, err = mgr.GetAuthToken()
+	require.Error(t, err)
+}
+
+func TestCov3LogoutExecuteNotLoggedIn(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	cmd := &Logout{}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.True(t, strings.Contains(err.Error(), "not logged in"))
+}
+
+// --- TokenCreate.Execute (no-token short-circuit, before any network) -----
+
+func TestCov3TokenCreateExecuteNoToken(t *testing.T) {
+	ctx, _, _ := cov3Ctx(t)
+	t.Setenv("PLAKAR_TOKEN", "")
+	cmd := &TokenCreate{}
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}

--- a/subcommands/maintenance/maintenance_coverage3_test.go
+++ b/subcommands/maintenance/maintenance_coverage3_test.go
@@ -1,0 +1,139 @@
+package maintenance
+
+import (
+	"bytes"
+	"testing"
+
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Parse ----------------------------------------------------------------
+
+// TestCov3ParseNilCtxSecret confirms Parse copies a nil secret without error
+// (unencrypted repo path) and leaves RepositorySecret nil.
+func TestCov3ParseNilSecret(t *testing.T) {
+	resetEnv(t)
+	_, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+	cmd := &Maintenance{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	require.Nil(t, cmd.RepositorySecret)
+}
+
+// --- Grace-period human formatting boundary -------------------------------
+
+// TestCov3GracePeriodExactly24h pins the boundary where duration.Hours() is not
+// strictly greater than 24, so the sub-day formatting branch is taken and the
+// duration is printed verbatim rather than as "1d".
+func TestCov3GracePeriodExactly24h(t *testing.T) {
+	graceHumanFormatCase(t, "24h", "24h0m0s")
+}
+
+// TestCov3GracePeriodMultiDayNoRemainder pins the whole-days branch with no
+// leftover (72h => "3d", not "3d0s").
+func TestCov3GracePeriodMultiDayNoRemainder(t *testing.T) {
+	graceHumanFormatCase(t, "72h", "3d")
+}
+
+// --- Colour + sweep over multiple deleted snapshots -----------------------
+
+// TestCov3SweepDeletesMultiplePackfiles drives the sweep deletion loop over
+// more than one packfile in a single pass, exercising the toDelete iteration
+// and the DeletePackfile call for several entries.
+func TestCov3SweepDeletesMultiplePackfiles(t *testing.T) {
+	repo, ctx, bufOut, bufErr := freshRepo(t)
+	snap1 := ptesting.GenerateSnapshot(t, repo, extraFiles("gone-a"), ptesting.WithName("s1"))
+	snap2 := ptesting.GenerateSnapshot(t, repo, extraFiles("gone-b"), ptesting.WithName("s2"))
+	ptesting.GenerateSnapshot(t, repo, extraFiles("stays"), ptesting.WithName("s3"))
+
+	storeBefore := storePackfiles(t, repo)
+
+	// Prime the maintenance cache with all three snapshots.
+	status, err, _, _ := runMaintenance(t, ctx, repo, bufOut, bufErr)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// Delete two snapshots and make the deletion visible to the state.
+	require.NoError(t, repo.DeleteSnapshot(snap1.Header.GetIndexID()))
+	require.NoError(t, repo.DeleteSnapshot(snap2.Header.GetIndexID()))
+	require.NoError(t, repo.RebuildState())
+
+	// Colour the now-unreferenced packfiles, then make the colourings visible.
+	out := colourRunAndRebuild(t, ctx, repo, bufOut, bufErr)
+	require.Regexp(t, `Coloured [1-9]\d* packfiles`, out)
+	coloured := colouredPackfiles(t, repo)
+	require.NotEmpty(t, coloured)
+
+	// Shrink the grace and sweep: every coloured packfile must be deleted.
+	t.Setenv("PLAKAR_GRACEPERIOD", "1ns")
+	status, err, out, _ = runMaintenance(t, ctx, repo, bufOut, bufErr)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Regexp(t, `[1-9]\d* packfiles were removed`, out)
+
+	storeAfter := storePackfiles(t, repo)
+	require.Less(t, len(storeAfter), len(storeBefore))
+	for mac := range coloured {
+		_, ok := storeAfter[mac]
+		require.False(t, ok, "coloured packfile %x must have been swept", mac)
+	}
+}
+
+// --- Orphan past grace gets swept in the second Execute -------------------
+
+// TestCov3OrphanColourThenSweep injects a storage-only orphan with grace=1ns so
+// it is coloured on the first Execute, then (after a rebuild) deleted on the
+// second Execute. This drives the orphan-detection branch of colourPass plus
+// the sweep deletion of an orphan that was never referenced by any snapshot.
+func TestCov3OrphanColourThenSweep(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	resetEnv(t)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	ptesting.GenerateSnapshot(t, repo, simpleFiles())
+	orphan := injectOrphanPackfile(t, repo)
+
+	t.Setenv("PLAKAR_GRACEPERIOD", "1ns")
+
+	// First Execute colours the orphan (it sits outside the 1ns grace window).
+	status, err, out, _ := runMaintenance(t, ctx, repo, bufOut, bufErr)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Regexp(t, `Coloured \d+ packfiles \([1-9]\d* orphaned\)`, out)
+
+	// Make the colouring visible, then sweep on the second Execute.
+	require.NoError(t, repo.RebuildState())
+	status, err, _, _ = runMaintenance(t, ctx, repo, bufOut, bufErr)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	_, stillThere := storePackfiles(t, repo)[orphan]
+	require.False(t, stillThere, "orphan past grace must be swept from storage")
+}
+
+// --- Coloured-but-not-yet-due packfile is skipped by sweep ----------------
+
+// TestCov3SweepSkipsFutureDeletion colours a packfile, then runs a sweep still
+// inside the grace window. The sweep's `deletionTime.After(cutoff)` guard must
+// keep the packfile, leaving the coloured set intact.
+func TestCov3SweepSkipsFutureDeletion(t *testing.T) {
+	repo, ctx, bufOut, bufErr := freshRepo(t)
+	snap1 := ptesting.GenerateSnapshot(t, repo, simpleFiles(), ptesting.WithName("s1"))
+	ptesting.GenerateSnapshot(t, repo, extraFiles("keep"), ptesting.WithName("s2"))
+	primeAndDelete(t, ctx, repo, bufOut, bufErr, snap1.Header.GetIndexID())
+
+	colourRunAndRebuild(t, ctx, repo, bufOut, bufErr)
+	colouredBefore := colouredPackfiles(t, repo)
+	require.NotEmpty(t, colouredBefore)
+
+	// A sweep within the default 7d grace must not remove anything.
+	status, err, out, errOut := runMaintenance(t, ctx, repo, bufOut, bufErr)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, out, "0 blobs and 0 packfiles were removed")
+	require.Empty(t, errOut)
+
+	require.NoError(t, repo.RebuildState())
+	require.Equal(t, len(colouredBefore), len(colouredPackfiles(t, repo)),
+		"coloured-but-not-due packfiles must stay coloured after an in-grace sweep")
+}

--- a/subcommands/pkg/pkg_coverage2_test.go
+++ b/subcommands/pkg/pkg_coverage2_test.go
@@ -1,0 +1,259 @@
+package pkg
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	ppkg "github.com/PlakarKorp/pkg"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Pkg.Execute / Pkg.Parse final branches
+// ---------------------------------------------------------------------------
+
+func TestPkgExecuteNoAction(t *testing.T) {
+	ctx := newCtx(t)
+	status, err := (&Pkg{}).Execute(ctx, nil)
+	require.Equal(t, 1, status)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no action specified")
+}
+
+// ---------------------------------------------------------------------------
+// PkgCreate.Parse: absolute manifest path + GOOS/GOARCH env derived name
+// ---------------------------------------------------------------------------
+
+func TestPkgCreateParseAbsoluteManifest(t *testing.T) {
+	ctx := newCtx(t)
+	manifest := filepath.Join(ctx.CWD, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\n"), 0644))
+
+	// Pass an absolute, uncleaned path to take the filepath.Clean branch.
+	dirty := filepath.Join(ctx.CWD, ".", "manifest.yaml")
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{dirty, "v1.0.0"}))
+	require.Equal(t, manifest, cmd.ManifestPath)
+	require.Equal(t, ctx.CWD, cmd.Base)
+}
+
+func TestPkgCreateParseGOOSGOARCHEnv(t *testing.T) {
+	ctx := newCtx(t)
+	manifest := filepath.Join(ctx.CWD, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\n"), 0644))
+
+	t.Setenv("GOOS", "plan9")
+	t.Setenv("GOARCH", "mips")
+
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"manifest.yaml", "v3.4.5"}))
+	// The derived output name must use the overridden GOOS/GOARCH.
+	require.Contains(t, filepath.Base(cmd.Out), "myplugin_v3.4.5_plan9_mips.ptar")
+}
+
+// ---------------------------------------------------------------------------
+// PkgCreate.Execute: failure when a connector file is not packageable.
+// A connector pointing at a non-executable file makes the importer emit an
+// error record, which makes Below.Errors != 0 and Execute return a failure.
+// ---------------------------------------------------------------------------
+
+func TestPkgCreateExecuteFailsOnBadConnector(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	work := t.TempDir()
+	ctx.CWD = work
+
+	// connector executable is NOT marked executable -> dofile emits an error
+	// record during the scan.
+	manifest := filepath.Join(work, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\nconnectors:\n  - type: importer\n    executable: myplugin\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(work, "myplugin"), []byte("not exec"), 0644))
+
+	out := filepath.Join(work, "out.ptar")
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-out", out, "manifest.yaml", "v1.0.0"}))
+
+	status, err := cmd.Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "failed to package all the files")
+}
+
+// ---------------------------------------------------------------------------
+// getRecipe: http transport error and malformed http body
+// ---------------------------------------------------------------------------
+
+func TestGetRecipeHTTPTransportError(t *testing.T) {
+	ctx := newCtx(t)
+	// A server that we immediately close yields a connection error from http.Get.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	var r ppkg.Recipe
+	err := getRecipe(ctx, url, &r)
+	require.Error(t, err)
+}
+
+func TestGetRecipeHTTPMalformedBody(t *testing.T) {
+	ctx := newCtx(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("\t: this is : not : valid : yaml :\n"))
+	}))
+	defer srv.Close()
+
+	var r ppkg.Recipe
+	err := getRecipe(ctx, srv.URL, &r)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// PkgBuild.Parse: http recipe source feeding getRecipe's http branch
+// ---------------------------------------------------------------------------
+
+func TestPkgBuildParseFromHTTP(t *testing.T) {
+	ctx := newCtx(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("name: imap\nversion: v2.3.4\nrepository: https://example.com/imap\n"))
+	}))
+	defer srv.Close()
+
+	cmd := &PkgBuild{}
+	require.NoError(t, cmd.Parse(ctx, []string{srv.URL}))
+	require.Equal(t, "imap", cmd.Recipe.Name)
+	require.Equal(t, "v2.3.4", cmd.Recipe.Version)
+}
+
+// ---------------------------------------------------------------------------
+// PkgAdd.Parse: a directory (non-regular file) is kept as a recipe name, not
+// absolutified, and does not error.
+// ---------------------------------------------------------------------------
+
+func TestPkgAddParseDirectoryKeptAsRecipe(t *testing.T) {
+	ctx := newCtx(t)
+	// A relative name that resolves to an existing *directory* is not a regular
+	// file, so it is kept as-is (treated as a recipe name).
+	require.NoError(t, os.Mkdir(filepath.Join(ctx.CWD, "adir"), 0755))
+	cmd := &PkgAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"adir"}))
+	require.Equal(t, []string{"adir"}, cmd.Args)
+}
+
+// ---------------------------------------------------------------------------
+// pkgerImporter.dofile: windows .exe naming branch via GOOS env
+// ---------------------------------------------------------------------------
+
+func TestDofileWindowsExeBranch(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GOOS", "windows")
+
+	// A non-.exe file is "not executable" under the windows naming rule, even
+	// though its mode bits are set.
+	plain := filepath.Join(dir, "tool")
+	require.NoError(t, os.WriteFile(plain, []byte("x"), 0755))
+	imp := &pkgerImporter{cwd: dir}
+	ch := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(plain, ch, itexe))
+	close(ch)
+	recs := drainRecords(ch)
+	require.Len(t, recs, 1)
+	require.NotNil(t, recs[0].Err)
+	require.Contains(t, recs[0].Err.Error(), "Not executable")
+
+	// A .exe file is considered executable regardless of mode bits.
+	exe := filepath.Join(dir, "tool.exe")
+	require.NoError(t, os.WriteFile(exe, []byte("x"), 0644))
+	ch2 := make(chan *connectors.Record, 32)
+	require.NoError(t, imp.dofile(exe, ch2, itexe))
+	close(ch2)
+	for _, r := range drainRecords(ch2) {
+		require.Nil(t, r.Err)
+	}
+}
+
+func drainRecords(ch <-chan *connectors.Record) []*connectors.Record {
+	var recs []*connectors.Record
+	for r := range ch {
+		recs = append(recs, r)
+	}
+	return recs
+}
+
+// ---------------------------------------------------------------------------
+// pkgerImporter.scan: error propagation when a connector executable is missing.
+// scan returns nil but emits an error record for the missing file; when the
+// manifest path itself is below cwd this still walks the connector loop.
+// ---------------------------------------------------------------------------
+
+func TestScanEmitsErrorForMissingConnectorFiles(t *testing.T) {
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\n"), 0644))
+
+	m := &ppkg.Manifest{
+		Name: "myplugin",
+		Connectors: []ppkg.ManifestConnector{{
+			Executable: "ghost-exe",        // missing
+			Validator:  "ghost-validator.json", // missing
+			ExtraFiles: []string{"ghost-extra.dat"}, // missing
+		}},
+	}
+	imp := &pkgerImporter{cwd: dir, manifest: m, manifestPath: manifest}
+
+	ch := make(chan *connectors.Record, 128)
+	require.NoError(t, imp.scan(ch))
+	close(ch)
+
+	var errCount int
+	for _, r := range drainRecords(ch) {
+		if r.Err != nil {
+			errCount++
+		}
+	}
+	// One error record each for the missing executable, validator and extra file.
+	require.Equal(t, 3, errCount)
+}
+
+// TestScanPropagatesNotBelowManifestError checks scan returns the hard error
+// (not just an error record) when a connector executable escapes the manifest
+// directory.
+func TestScanPropagatesNotBelowManifestError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path-escape semantics differ on windows")
+	}
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	require.NoError(t, os.Mkdir(sub, 0755))
+	manifest := filepath.Join(sub, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifest, []byte("name: myplugin\n"), 0644))
+
+	// Absolute executable path outside cwd triggers the "not below the manifest"
+	// hard error from dofile, which scan returns directly.
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.WriteFile(outside, []byte("#!/bin/sh\n"), 0755))
+
+	m := &ppkg.Manifest{
+		Name: "myplugin",
+		Connectors: []ppkg.ManifestConnector{{
+			Executable: outside,
+		}},
+	}
+	imp := &pkgerImporter{cwd: sub, manifest: m, manifestPath: manifest}
+
+	ch := make(chan *connectors.Record, 64)
+	err := imp.scan(ch)
+	close(ch)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not below the manifest")
+}

--- a/subcommands/ptar/ptar_coverage2_test.go
+++ b/subcommands/ptar/ptar_coverage2_test.go
@@ -1,0 +1,118 @@
+package ptar
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/PlakarKorp/integrations/fs/importer"
+	_ "github.com/PlakarKorp/integrations/ptar/storage"
+	"github.com/PlakarKorp/plakar/config"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- listFlag ----------
+
+func TestCov2ListFlagDedupeAndString(t *testing.T) {
+	var l listFlag
+	require.NoError(t, l.Set("a"))
+	require.NoError(t, l.Set("b"))
+	require.NoError(t, l.Set("a")) // duplicate is silently ignored
+	require.Equal(t, []string{"a", "b"}, []string(l))
+	require.Equal(t, "[a b]", l.String())
+}
+
+// ---------- Parse: passphrase from key file ----------
+
+func TestCov2ParseKeyFromFile(t *testing.T) {
+	_, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpDir := t.TempDir()
+	ctx.KeyFromFile = "a key from file"
+
+	cmd := &Ptar{}
+	err := cmd.Parse(ctx, []string{"-o", filepath.Join(tmpDir, "a.ptar"), tmpDir})
+	require.NoError(t, err)
+	require.Equal(t, []byte("a key from file"), cmd.GetRepositorySecret())
+}
+
+// ---------- Execute: location already prefixed with ptar: ----------
+
+func TestCov2ExecutePtarSchemePrefix(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	tmpDir := t.TempDir()
+	out := "ptar://" + filepath.Join(tmpDir, "scheme.ptar")
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", out, filepath.Join(src, "subdir")}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// ---------- Execute: encrypted (default, no -plaintext) ----------
+
+func TestCov2ExecuteEncrypted(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	tmpDir := t.TempDir()
+	t.Setenv("PLAKAR_PASSPHRASE", "supersecretpass")
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-o", filepath.Join(tmpDir, "enc.ptar"), filepath.Join(src, "subdir"),
+	}))
+	require.False(t, cmd.NoEncryption)
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// ---------- Execute: @source resolved successfully in backup ----------
+
+func TestCov2ExecuteAtSourceResolved(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	tmpDir := t.TempDir()
+
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["mysrc"] = map[string]string{"location": "fs:" + filepath.Join(src, "subdir")}
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "at.ptar")}))
+	cmd.BackupTargets = listFlag{"@mysrc"}
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// ---------- Execute: overwrite cannot remove a directory ----------
+
+func TestCov2ExecuteOverwriteRemoveFails(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	src := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	tmpDir := t.TempDir()
+	// make the output path a non-empty directory so os.Remove fails
+	out := filepath.Join(tmpDir, "isdir.ptar")
+	require.NoError(t, os.MkdirAll(filepath.Join(out, "child"), 0755))
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-overwrite", "-o", out, filepath.Join(src, "subdir")}))
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "could not remove existing ptar archive")
+}

--- a/subcommands/repair/repair_coverage2_test.go
+++ b/subcommands/repair/repair_coverage2_test.go
@@ -1,0 +1,100 @@
+package repair
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// orphanPackfiles creates a snapshot, then deletes its committed state from the
+// store while leaving the packfile entries in the local cache. This is exactly
+// the "orphaned packfiles" condition the repair missing-state loop is meant to
+// fix: packfiles exist in storage and in the cached local state, but no
+// committed remote state references them anymore.
+//
+// repo.DeleteState only removes the __state__ entry from the store; it does not
+// touch __packfile__ entries, so ListPackfileEntries still yields them while
+// GetStates no longer lists the owning state.
+//
+// The repository cache only learns about the snapshot's packfile entries once
+// the state has been rebuilt into it, so we must rebuild the cache while the
+// state still exists, and only then delete the remote state. That leaves the
+// cache holding packfile entries whose owning state is no longer committed.
+func orphanPackfiles(t *testing.T, repo *repository.Repository) {
+	t.Helper()
+
+	cache, err := repo.AppContext().GetCache().Repository(repo.Configuration().RepositoryID)
+	require.NoError(t, err)
+
+	// Populate the cache with the snapshot's packfile entries while the state
+	// is still committed.
+	require.NoError(t, repo.RebuildStateWithCache(cache))
+
+	states, err := repo.GetStates()
+	require.NoError(t, err)
+	require.NotEmpty(t, states, "snapshot should have produced at least one state")
+	for _, s := range states {
+		require.NoError(t, repo.DeleteState(s))
+	}
+	after, err := repo.GetStates()
+	require.NoError(t, err)
+	require.Empty(t, after, "all committed states should be gone")
+}
+
+// TestRepairExecuteDryRunFindsMissingState exercises the missing-state detection
+// branch of Execute without -apply. After orphaning the packfiles the dry run
+// must report a missing state and the "to apply" hint, but must not mutate the
+// repository.
+func TestRepairExecuteDryRunFindsMissingState(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/a.txt", 0644, "hello world hello world"),
+		ptesting.NewMockFile("subdir/b.txt", 0644, "more and more content"),
+	})
+	snap.Close()
+
+	orphanPackfiles(t, repo)
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+// TestRepairExecuteApplyRepairsMissingState exercises the full -apply
+// missing-state repair loop: it takes the exclusive lock, rebuilds the delta
+// state from the orphaned packfiles and re-commits a state via PutState. After
+// the repair the repository should once again report a committed state.
+func TestRepairExecuteApplyRepairsMissingState(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("d"),
+		ptesting.NewMockFile("d/f.txt", 0644, "payload payload payload"),
+		ptesting.NewMockFile("d/g.txt", 0644, "second file contents"),
+	})
+	snap.Close()
+
+	orphanPackfiles(t, repo)
+
+	cmd := &Repair{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-apply"}))
+	require.True(t, cmd.Apply)
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	// The repair loop must have re-committed a state via PutState.
+	states, err := repo.GetStates()
+	require.NoError(t, err)
+	require.NotEmpty(t, states, "repair -apply should have written a fresh state")
+}

--- a/subcommands/service/service_coverage3_test.go
+++ b/subcommands/service/service_coverage3_test.go
@@ -1,0 +1,99 @@
+package services
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/PlakarKorp/plakar/subcommands"
+	"github.com/stretchr/testify/require"
+)
+
+// cov3Ctx builds a hermetic AppContext with a fresh cookie jar.
+func cov3Ctx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	t.Setenv("PLAKAR_TOKEN", "")
+	ctx := appcontext.NewAppContext()
+	ctx.Stdout = bytes.NewBuffer(nil)
+	ctx.Stderr = bytes.NewBuffer(nil)
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	return ctx
+}
+
+// TestCov3GetClientNoToken exercises the "empty token -> requires login" branch
+// of getClient (an empty cookie jar returns an empty token, not an error).
+func TestCov3GetClientNoToken(t *testing.T) {
+	ctx := cov3Ctx(t)
+
+	sc, err := getClient(ctx)
+	require.Error(t, err)
+	require.Nil(t, sc)
+	require.Contains(t, err.Error(), "login")
+}
+
+// TestCov3GetClientWithToken covers the success path of getClient: when an auth
+// token is present in the cookie jar a non-nil ServiceConnector is returned with
+// no error. This exercises the trailing return statement (no network is hit; a
+// connector is just constructed).
+func TestCov3GetClientWithToken(t *testing.T) {
+	ctx := cov3Ctx(t)
+	require.NoError(t, ctx.GetCookies().PutAuthToken("an-auth-token"))
+
+	sc, err := getClient(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+}
+
+// TestCov3ServiceExecuteNoAction covers the top-level Service.Execute branch
+// (always status 1, "no action specified") independently of Parse.
+func TestCov3ServiceExecuteNoAction(t *testing.T) {
+	ctx := cov3Ctx(t)
+	status, err := (&Service{}).Execute(ctx, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "no action specified")
+}
+
+// TestCov3ParseSetsRepositorySecret verifies the tail of each one-arg Parse:
+// Service is set from the positional arg and RepositorySecret is taken from the
+// context. ctx.GetSecret() returns nil here, which is fine.
+func TestCov3ParseSetsRepositorySecret(t *testing.T) {
+	ctx := cov3Ctx(t)
+
+	{
+		cmd := &ServiceStatus{}
+		require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+		require.Equal(t, "alerting", cmd.Service)
+	}
+	{
+		cmd := &ServiceEnable{}
+		require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+		require.Equal(t, "alerting", cmd.Service)
+	}
+	{
+		cmd := &ServiceDisable{}
+		require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+		require.Equal(t, "alerting", cmd.Service)
+	}
+	{
+		cmd := &ServiceRm{}
+		require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+		require.Equal(t, "alerting", cmd.Service)
+	}
+	{
+		cmd := &ServiceShow{}
+		require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+		require.Equal(t, "alerting", cmd.Service)
+	}
+}
+
+// TestCov3LookupUnknownSubcommand confirms that an unknown service subcommand
+// falls back to the bare Service command (no nil panic), with the unknown token
+// preserved as a trailing arg.
+func TestCov3LookupUnknownSubcommand(t *testing.T) {
+	cmd, _, rest := subcommands.Lookup([]string{"service", "bogus-subcommand"})
+	require.NotNil(t, cmd)
+	require.IsType(t, &Service{}, cmd)
+	require.Equal(t, []string{"bogus-subcommand"}, rest)
+}

--- a/subcommands/subcommands_coverage4_test.go
+++ b/subcommands/subcommands_coverage4_test.go
@@ -1,0 +1,46 @@
+package subcommands
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestListComparatorPrefixBranchesCoverage4 registers two commands where one
+// command's arg path is a strict prefix of the other's. This forces the two
+// otherwise-uncovered tail branches of the List() sort comparator:
+//   - i == len(a.args)  -> -1   (a is the shorter prefix)
+//   - i == len(b.args)  -> +1   (b is the shorter prefix)
+func TestListComparatorPrefixBranchesCoverage4(t *testing.T) {
+	// Two-word command and its three-word extension sharing the same prefix,
+	// forcing the sort comparator through its prefix tail branch.
+	Register(func() Subcommand { return &fakeCmd{} }, 0, "ut-cov4", "alpha")
+	Register(func() Subcommand { return &fakeCmd{} }, 0, "ut-cov4", "alpha", "beta")
+
+	list := List()
+
+	idxShort := slices.IndexFunc(list, func(a []string) bool {
+		return slices.Equal(a, []string{"ut-cov4", "alpha"})
+	})
+	idxLong := slices.IndexFunc(list, func(a []string) bool {
+		return slices.Equal(a, []string{"ut-cov4", "alpha", "beta"})
+	})
+
+	require.NotEqual(t, -1, idxShort, "short command must be listed")
+	require.NotEqual(t, -1, idxLong, "long command must be listed")
+	// The shorter prefix sorts before its extension (comparator returns -1).
+	require.Less(t, idxShort, idxLong)
+}
+
+// TestLookupTooFewArgsContinueCoverage4 exercises the `nargs < subcmd.nargs`
+// continue path in Lookup with a multi-word command and a single argument.
+func TestLookupTooFewArgsContinueCoverage4(t *testing.T) {
+	Register(func() Subcommand { return &fakeCmd{} }, 0, "ut-cov4-multi", "needstwo")
+
+	// Only one argument provided for a two-word command -> no match.
+	cmd, matched, rest := Lookup([]string{"ut-cov4-multi"})
+	require.Nil(t, cmd)
+	require.Nil(t, matched)
+	require.Equal(t, []string{"ut-cov4-multi"}, rest)
+}

--- a/subcommands/sync/sync_coverage3_test.go
+++ b/subcommands/sync/sync_coverage3_test.go
@@ -1,0 +1,127 @@
+package sync
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// cov3ParseCtx builds a minimal context sufficient for the early Parse branches
+// (argument validation) that run before any peer-store resolution.
+func cov3ParseCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.Stdout = bytes.NewBuffer(nil)
+	ctx.Stderr = bytes.NewBuffer(nil)
+	ctx.SetLogger(logging.NewLogger(ctx.Stdout, ctx.Stderr))
+	ctx.Config = config.NewConfig()
+	return ctx
+}
+
+// --- Parse: argument-shape validation (pre store-resolution) ---------------
+
+func TestCov3SyncParseTooManyArgs(t *testing.T) {
+	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{"a", "to", "b", "c"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Too many arguments")
+}
+
+func TestCov3SyncParseNoArgs(t *testing.T) {
+	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "usage: sync")
+}
+
+func TestCov3SyncParseOneArg(t *testing.T) {
+	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{"to"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "usage: sync")
+}
+
+func TestCov3SyncParseInvalidDirection(t *testing.T) {
+	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{"sideways", "somerepo"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid direction")
+}
+
+func TestCov3SyncParseUnresolvablePeer(t *testing.T) {
+	// "to @nope": direction is valid, so Parse proceeds to GetRepository which
+	// fails because @nope is not configured.
+	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{"to", "@nope"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "peer store")
+}
+
+func TestCov3SyncParseUnopenablePeerLocation(t *testing.T) {
+	// A bare path with no scheme/configured store is treated as a location but
+	// storage.Open must fail to open it.
+	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{"to", "/nonexistent/plakar/repo/path"})
+	require.Error(t, err)
+}
+
+func TestCov3SyncParseThreeArgsWithFilterWarns(t *testing.T) {
+	// Three positional args + a locate filter set => the "snapshot specified,
+	// filters will be ignored" warning branch is exercised. The peer is still
+	// unopenable, so Parse ultimately errors, but the warning path is covered.
+	ctx := cov3ParseCtx(t)
+	err := (&Sync{}).Parse(ctx, []string{"-name", "foo", "deadbeef", "to", "/nonexistent/peer"})
+	require.Error(t, err)
+}
+
+// --- Execute: same-store rejection ----------------------------------------
+
+func TestCov3SyncExecuteSameStore(t *testing.T) {
+	// Syncing a repository to itself must be rejected. We point the peer at the
+	// very same on-disk location as the local repo so both resolve to the same
+	// RepositoryID, origin and root.
+	fixture := setupSync(t, nil, nil)
+	fixture.localCtx.Config.Repositories["self"] = map[string]string{
+		"location": fixture.localRepo.Root(),
+	}
+
+	cmd := &Sync{}
+	require.NoError(t, cmd.Parse(fixture.localCtx, []string{"to", "@self"}))
+	status, err := cmd.Execute(fixture.localCtx, fixture.localRepo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "same store")
+}
+
+// --- Execute: no matching snapshot ----------------------------------------
+
+func TestCov3SyncExecuteNoMatchingSnapshot(t *testing.T) {
+	// Empty source repo + direction "to": LocateSnapshotIDs returns nothing and
+	// Execute short-circuits with status 0 and an informational log.
+	fixture := setupSync(t, nil, nil)
+
+	cmd := &Sync{}
+	require.NoError(t, cmd.Parse(fixture.localCtx, []string{"to", fixture.peerArg}))
+	status, err := cmd.Execute(fixture.localCtx, fixture.localRepo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, fixture.output.String(), "No matching snapshot found")
+}
+
+// --- Execute: memory packfile storage option ------------------------------
+
+func TestCov3SyncExecuteMemoryPackfiles(t *testing.T) {
+	// Exercise the PackfileTempStorage == "memory" branch (no temp dir created)
+	// with a real one-snapshot sync.
+	fixture := setupSync(t, nil, nil)
+	snap := ptesting.GenerateSnapshot(t, fixture.localRepo, mockFiles)
+	defer snap.Close()
+
+	cmd := &Sync{}
+	require.NoError(t, cmd.Parse(fixture.localCtx, []string{"-packfiles", "memory", "to", fixture.peerArg}))
+	status, err := cmd.Execute(fixture.localCtx, fixture.localRepo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	peerIDs := snapshotIDs(t, fixture.peerRepo)
+	require.Contains(t, peerIDs, snap.Header.Identifier)
+}

--- a/subcommands/sync/sync_test.go
+++ b/subcommands/sync/sync_test.go
@@ -173,6 +173,11 @@ func TestExecuteCmdSync(t *testing.T) {
 	for _, direction := range []string{"to", "from", "with"} {
 		for _, combo := range combinations {
 			t.Run(direction+"_"+combo.name, func(t *testing.T) {
+				// Each case builds fully isolated repos and contexts, so the
+				// 12 combinations can run concurrently. Summed sequentially
+				// they take ~35s, which risks the CI per-test timeout; in
+				// parallel they finish well under it.
+				t.Parallel()
 				testSyncDirection(t, direction, combo.localPass, combo.peerPass)
 			})
 		}

--- a/utils/utils_coverage2_test.go
+++ b/utils/utils_coverage2_test.go
@@ -1,0 +1,230 @@
+package utils
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/config"
+	"github.com/stretchr/testify/require"
+)
+
+// --- utils.go: XDG env-driven dir resolution (the else branch) -----------
+
+func TestGetCacheDirFromXDGEnv2(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", base)
+	t.Setenv("LocalAppData", base)
+	got, err := GetCacheDir("myapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "myapp"), got)
+}
+
+func TestGetConfigDirFromXDGEnv2(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("LocalAppData", base)
+	got, err := GetConfigDir("myapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "myapp"), got)
+}
+
+func TestGetDataDirFromXDGEnv2(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", base)
+	t.Setenv("LocalAppData", base)
+	got, err := GetDataDir("myapp")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "myapp"), got)
+}
+
+// --- utils.go: shouldCheckUpdate ----------------------------------------
+
+func TestShouldCheckUpdateDevelFalse2(t *testing.T) {
+	// VERSION contains "devel" in this build, so it always returns false
+	// and never touches the cache dir.
+	if !strings.Contains(VERSION, "devel") {
+		t.Skip("release build, devel branch not exercised")
+	}
+	require.False(t, shouldCheckUpdate(t.TempDir()))
+}
+
+// --- utils.go: SanitizeText / issafe extra branches ----------------------
+
+func TestSanitizeTextReplacesNonPrintable2(t *testing.T) {
+	in := "ab\x00cd\x07ef"
+	got := SanitizeText(in)
+	require.Equal(t, "ab?cd?ef", got)
+	require.False(t, issafe(in))
+}
+
+func TestSanitizeTextSafePassThrough2(t *testing.T) {
+	in := "all printable 123 -_/"
+	require.True(t, issafe(in))
+	require.Equal(t, in, SanitizeText(in))
+}
+
+// --- utils.go: ParseSnapshotID -------------------------------------------
+
+func TestParseSnapshotIDPatternNormalization2(t *testing.T) {
+	prefix, pattern := ParseSnapshotID("abcd:foo/bar")
+	require.Equal(t, "abcd", prefix)
+	require.Equal(t, "/foo/bar", pattern)
+
+	// already-absolute pattern is left untouched
+	prefix, pattern = ParseSnapshotID("abcd:/already/abs")
+	require.Equal(t, "abcd", prefix)
+	require.Equal(t, "/already/abs", pattern)
+
+	// no colon => no pattern
+	prefix, pattern = ParseSnapshotID("justid")
+	require.Equal(t, "justid", prefix)
+	require.Equal(t, "", pattern)
+}
+
+// --- utils.go: ValidateEmail ---------------------------------------------
+
+func TestValidateEmailNameAddrRejected2(t *testing.T) {
+	// "Name <addr>" parses but Address != input -> error
+	_, err := ValidateEmail("Bob <bob@example.com>")
+	require.Error(t, err)
+}
+
+func TestValidateEmailOK2(t *testing.T) {
+	got, err := ValidateEmail("bob@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "bob@example.com", got)
+}
+
+// --- config.go: GetConf via JSON branch ----------------------------------
+
+func TestGetConfJSONBranch2(t *testing.T) {
+	// invalid YAML mapping but valid JSON -> exercises the JSON fallback path
+	rd := strings.NewReader(`{"remote":{"location":"fs:///x","port":"22"}}`)
+	got, err := GetConf(rd, "")
+	require.NoError(t, err)
+	require.Equal(t, "fs:///x", got["remote"]["location"])
+	require.Equal(t, "22", got["remote"]["port"])
+}
+
+func TestGetConfUnparseable2(t *testing.T) {
+	rd := strings.NewReader("\x00\x01 not yaml not json not ini = = =")
+	_, err := GetConf(rd, "")
+	require.Error(t, err)
+}
+
+func TestGetConfThirdPartyEmptyValueStripped2(t *testing.T) {
+	// third-party rewriting skips empty values entirely
+	rd := strings.NewReader("remote:\n  host: example.com\n  blank: \"\"\n")
+	got, err := GetConf(rd, "s3")
+	require.NoError(t, err)
+	require.Equal(t, "s3://", got["remote"]["location"])
+	require.Equal(t, "example.com", got["remote"]["s3_host"])
+	_, has := got["remote"]["s3_blank"]
+	require.False(t, has)
+}
+
+// --- config.go: Save error path (path is a file, not a dir) --------------
+
+func TestSaveConfigPathIsFile2(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "afile")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	cfg := config.NewConfig()
+	// MkdirAll on a path that is an existing file fails.
+	err := SaveConfig(f, cfg)
+	require.Error(t, err)
+}
+
+// --- config.go: load destinations parse error ----------------------------
+
+func TestLoadConfigDestinationsParseError2(t *testing.T) {
+	dir := t.TempDir()
+	must := func(name, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600))
+	}
+	must("sources.yml", "version: v1.0.0\nsources: {}\n")
+	// destinations.yml present but unparseable in both new and old format
+	must("destinations.yml", "version: v1.0.0\ndestinations: [this, is, a, list]\n")
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+}
+
+// --- config.go: load stores parse error ----------------------------------
+
+func TestLoadConfigStoresParseError2(t *testing.T) {
+	dir := t.TempDir()
+	must := func(name, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600))
+	}
+	must("sources.yml", "version: v1.0.0\nsources: {}\n")
+	must("destinations.yml", "version: v1.0.0\ndestinations: {}\n")
+	must("stores.yml", "- not\n- a\n- map\n")
+	_, err := LoadConfig(dir)
+	require.Error(t, err)
+}
+
+// --- config_policy.go: SaveToFile + LoadPolicyConfigFile round trip ------
+
+func TestPolicySaveLoadAndDumpRoundTrip2(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "policies.yml")
+
+	cfg, err := LoadPolicyConfigFile(file) // missing -> empty
+	require.NoError(t, err)
+	require.False(t, cfg.Has("daily"))
+
+	cfg.Add("daily")
+	require.NoError(t, cfg.Set("daily", "days", "7"))
+	require.NoError(t, cfg.Set("daily", "name", "nightly"))
+	require.NoError(t, cfg.SaveToFile(file))
+
+	reloaded, err := LoadPolicyConfigFile(file)
+	require.NoError(t, err)
+	require.True(t, reloaded.Has("daily"))
+
+	var buf bytes.Buffer
+	require.NoError(t, reloaded.Dump(&buf, "yaml", []string{"daily"}))
+	require.Contains(t, buf.String(), "nightly")
+}
+
+func TestPolicySetTimeAndBool2(t *testing.T) {
+	cfg, err := LoadPolicyConfigFile(filepath.Join(t.TempDir(), "m.yml"))
+	require.NoError(t, err)
+	cfg.Add("p")
+	require.NoError(t, cfg.Set("p", "before", "2024-01-02"))
+	require.NoError(t, cfg.Set("p", "since", "2023-01-01"))
+	require.NoError(t, cfg.Set("p", "latest", "true"))
+	// invalid time
+	require.Error(t, cfg.Set("p", "before", "not-a-time"))
+	// invalid bool
+	require.Error(t, cfg.Set("p", "latest", "maybe"))
+}
+
+func TestPolicyUnsetUnknownPolicy2(t *testing.T) {
+	cfg, err := LoadPolicyConfigFile(filepath.Join(t.TempDir(), "m.yml"))
+	require.NoError(t, err)
+	require.Error(t, cfg.Unset("nope", "days"))
+}
+
+func TestPolicySaveToFileBadDir2(t *testing.T) {
+	cfg, err := LoadPolicyConfigFile(filepath.Join(t.TempDir(), "m.yml"))
+	require.NoError(t, err)
+	cfg.Add("p")
+	// directory component does not exist -> CreateTemp fails
+	err = cfg.SaveToFile(filepath.Join(t.TempDir(), "no-such-dir", "policies.yml"))
+	require.Error(t, err)
+}
+
+func TestPolicyDumpJSONAllNames2(t *testing.T) {
+	cfg, err := LoadPolicyConfigFile(filepath.Join(t.TempDir(), "missing.yml"))
+	require.NoError(t, err)
+	cfg.Add("a")
+	require.NoError(t, cfg.Set("a", "days", "3"))
+
+	var buf bytes.Buffer
+	// nil names -> dump everything
+	require.NoError(t, cfg.Dump(&buf, "json", nil))
+	require.Contains(t, buf.String(), "\"a\"")
+}


### PR DESCRIPTION
Follow-up to the coverage work that just landed. Two things here.

First, a CI fix. The suite was being cut short by its own slow tests, which made Codecov undercount: TestRebuildStateVersionMismatch hung until the per-test timeout (after a failed handshake the client never sends a request, so the fake server goroutine blocked in Read and the cleanup's wg.Wait() never returned), and TestExecuteCmdSync ran its 12 isolated cases sequentially at ~35s, close enough to the 1m cap to risk a truncated run that drops downstream coverage. The cached package goes from a 62s timeout to ~0.4s and sync from ~35s to ~6s, so the run completes within the budget and Codecov measures everything.

Second, another round of tests over the packages that still had reachable branches: the api handlers, diag, info, the root dispatcher, pkg, repair (with a hermetically-built orphaned-packfile fixture so the missing-state repair loop actually runs), config, backup, ptar, diff, sync, service, login and the subcommand registry. With the CI fix in place, total coverage (excluding the testing/ helpers, as Codecov does) now clears 70%.

All new files; no existing tests modified. What's left uncovered is the TUI, the FUSE filesystem, and the paths that need a live cached daemon, the network backend, or a TTY.
