### PR TITLE
lint: fix ineffectual assignments

### DIFF
--- a/subcommands/help/help.go
+++ b/subcommands/help/help.go
@@ -79,7 +79,7 @@ func (cmd *Help) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		disableColors = true
 	}
 
-	options := []glamour.TermRendererOption{}
+	var options []glamour.TermRendererOption
 	if disableColors {
 		options = []glamour.TermRendererOption{
 			glamour.WithColorProfile(termenv.Ascii),

--- a/subcommands/help/help_test.go
+++ b/subcommands/help/help_test.go
@@ -91,6 +91,7 @@ func _TestParseCmdHelpDefault(t *testing.T) {
 	logger.EnableInfo()
 	ctx.SetLogger(logger)
 	repo, err := repository.New(ctx.GetInner(), nil, r, serializedConfig)
+	require.NoError(t, err)
 	args := []string{"-style", "notty"}
 
 	subcommand := &Help{}
@@ -216,6 +217,7 @@ func TestParseCmdHelpCommand(t *testing.T) {
 	logger.EnableInfo()
 	ctx.SetLogger(logger)
 	repo, err := repository.New(ctx.GetInner(), nil, r, serializedConfig)
+	require.NoError(t, err)
 	args := []string{"-style", "notty", "version"}
 
 	subcommand := &Help{}

--- a/testing/snapshot.go
+++ b/testing/snapshot.go
@@ -114,6 +114,7 @@ func GenerateFiles(t *testing.T, files []MockFile) string {
 		} else {
 			err = os.WriteFile(dest, file.Content, file.Mode)
 		}
+		require.NoError(t, err)
 	}
 
 	return tmpBackupDir


### PR DESCRIPTION
First of a few small linter-cleanup PRs (split by linter class). This one clears the 4 ineffassign findings.

- `help.go`: dropped the empty-literal initializer on `options` that every if-branch immediately overwrote.
- `help_test.go` (x2): the `repo, err :=` line's error was overwritten by the next `Parse` call before being checked — assert on it.
- `testing/snapshot.go`: `GenerateFiles` assigned to `err` in its write loop without ever checking it, so a failing MkdirAll/WriteFile was silently ignored — now asserts each iteration.

No behaviour change in production code; the test/helper fixes turn previously-ignored errors into real assertions.