### PR TITLE
lint: fix staticcheck findings

### DIFF
--- a/api/api_errors.go
+++ b/api/api_errors.go
@@ -6,18 +6,18 @@ import (
 )
 
 var (
-	ErrNumberOutOfRange = errors.New("Number out of range")
-	ErrMissingField     = errors.New("Missing field")
-	ErrInvalidID        = errors.New("Invalid ID")
-	ErrInvalidSortKey   = errors.New("Invalid sort key")
+	ErrNumberOutOfRange = errors.New("number out of range")
+	ErrMissingField     = errors.New("missing field")
+	ErrInvalidID        = errors.New("invalid ID")
+	ErrInvalidSortKey   = errors.New("invalid sort key")
 )
 
 type ParamErrorType string
 
 const (
 	InvalidArgument ParamErrorType = "invalid_argument"
-	BadNumber                      = "bad_number"
-	MissingArgument                = "missing_argument"
+	BadNumber       ParamErrorType = "bad_number"
+	MissingArgument ParamErrorType = "missing_argument"
 )
 
 type ParameterError struct {

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -213,9 +213,9 @@ func (ui *uiserver) servicesGetIntegrationId(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	return fmt.Errorf("Not found")
+	return fmt.Errorf("not found")
 }
 
 func (ui *uiserver) servicesGetIntegrationPath(w http.ResponseWriter, r *http.Request) error {
-	return fmt.Errorf("Not implemented")
+	return fmt.Errorf("not implemented")
 }

--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -175,7 +175,7 @@ func (ui *uiserver) repositorySnapshots(w http.ResponseWriter, r *http.Request) 
 			return err
 		}
 
-		if importerType != "" && strings.ToLower(snap.Header.GetSource(0).Importer.Type) != strings.ToLower(importerType) {
+		if importerType != "" && !strings.EqualFold(snap.Header.GetSource(0).Importer.Type, importerType) {
 			snap.Close()
 			continue
 		}
@@ -207,9 +207,7 @@ func (ui *uiserver) repositorySnapshots(w http.ResponseWriter, r *http.Request) 
 		Total: totalSnapshots,
 		Items: make([]header.Header, len(headers)),
 	}
-	for i, header := range headers {
-		items.Items[i] = header
-	}
+	copy(items.Items, headers)
 
 	return json.NewEncoder(w).Encode(items)
 }

--- a/cached/cached.go
+++ b/cached/cached.go
@@ -57,26 +57,22 @@ func rebuildStateRequest(ctx *appcontext.AppContext, req *RequestPkt) (int, erro
 	}
 
 	response := &ResponsePkt{}
-	for {
-		if err := client.dec.Decode(response); err != nil {
-			if err == io.EOF {
-				break
-			}
-			if err := ctx.Err(); err != nil {
-				return 1, err
-			}
-			return 1, fmt.Errorf("failed to decode response: %w", err)
+	if err := client.dec.Decode(response); err != nil {
+		// The server closed the connection without a response packet.
+		if err == io.EOF {
+			return 0, nil
 		}
-
-		var err error
-		if response.Err != "" {
-			err = fmt.Errorf("%s", response.Err)
+		if err := ctx.Err(); err != nil {
+			return 1, err
 		}
-
-		return response.ExitCode, err
+		return 1, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return 0, nil
+	if response.Err != "" {
+		return response.ExitCode, fmt.Errorf("%s", response.Err)
+	}
+
+	return response.ExitCode, nil
 }
 
 func newClient(ctx *appcontext.AppContext, socketPath string, ignoreVersion bool) (*Client, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -119,10 +119,8 @@ func applyRootOverride(location string, rootOverride string) (string, error) {
 		return location, nil
 	}
 
-	localPath := false
-	if strings.HasPrefix(location, "/") {
-		localPath = true
-	}
+	localPath := strings.HasPrefix(location, "/")
+
 	if localPath {
 		if strings.HasPrefix(rootOverride, "/") {
 			location = rootOverride

--- a/login/login.go
+++ b/login/login.go
@@ -72,17 +72,18 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 				return "", fmt.Errorf("the /auth/login/github/poll API endpoint failed: %w", err)
 			}
 			// leaking resp for now
-			if resp.StatusCode == http.StatusOK {
+			switch resp.StatusCode {
+			case http.StatusOK:
 				var tokenResponse TokenResponse
 				if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
 					return "", fmt.Errorf("failed to decode response JSON: %v", err)
 				}
 				return tokenResponse.Token, nil
-			} else if resp.StatusCode == http.StatusNotFound {
+			case http.StatusNotFound:
 				return "", fmt.Errorf("unknown ID")
-			} else if resp.StatusCode == http.StatusAccepted {
+			case http.StatusAccepted:
 				progressCb()
-			} else {
+			default:
 				return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 			}
 		}
@@ -221,6 +222,7 @@ func (flow *loginFlow) handleGithubResponseUI(resp *http.Response) (string, erro
 		token, _ := flow.Poll(respData.PollID, 10, time.Second*5, func() {})
 		if token != "" {
 			if err := flow.appCtx.GetCookies().PutAuthToken(token); err != nil {
+				flow.appCtx.GetLogger().Error("failed to store auth token: %v", err)
 			}
 		}
 
@@ -241,6 +243,7 @@ func (flow *loginFlow) handleEmailResponseUI(resp *http.Response) (string, error
 		token, _ := flow.Poll(respData.PollID, 10, time.Second*5, func() {})
 		if token != "" {
 			if err := flow.appCtx.GetCookies().PutAuthToken(token); err != nil {
+				flow.appCtx.GetLogger().Error("failed to store auth token: %v", err)
 			}
 		}
 	}()

--- a/server/httpd/httpd.go
+++ b/server/httpd/httpd.go
@@ -16,9 +16,9 @@ import (
 	"github.com/PlakarKorp/kloset/repository"
 )
 
-var ErrInvalidResourceType = fmt.Errorf("Invalid resource type")
-var ErrInvalidMAC = fmt.Errorf("Invalid MAC")
-var ErrInvalidRange = fmt.Errorf("Invalid range")
+var ErrInvalidResourceType = fmt.Errorf("invalid resource type")
+var ErrInvalidMAC = fmt.Errorf("invalid MAC")
+var ErrInvalidRange = fmt.Errorf("invalid range")
 
 type server struct {
 	store    storage.Store

--- a/subcommands/archive/archive_test.go
+++ b/subcommands/archive/archive_test.go
@@ -104,7 +104,7 @@ func TestExecuteCmdArchiveDefault(t *testing.T) {
 
 	indexId := snap.Header.GetIndexID()
 	outputDir := fmt.Sprintf("%s/archive_test", tmpDestinationDir)
-	args := []string{"-output", outputDir, fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))}
+	args := []string{"-output", outputDir, hex.EncodeToString(indexId[:])}
 
 	subcommand := &Archive{}
 	err = subcommand.Parse(ctx, args)

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -153,9 +153,7 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 		if err != nil {
 			return err
 		}
-		for _, line := range lines {
-			excludes = append(excludes, line)
-		}
+		excludes = append(excludes, lines...)
 	}
 
 	for _, item := range opt_ignore {

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -19,6 +19,8 @@ import (
 //
 // The stdio renderer is started here too, mirroring the production wiring:
 // without it nothing drains the event bus and Backup.Execute deadlocks.
+//
+//nolint:staticcheck // ST1008: test helper, error kept in fixed position alongside other outputs
 func runBackup(t *testing.T, args []string, mutate func(*Backup)) (int, error, *bytes.Buffer, *appcontext.AppContext) {
 	t.Helper()
 	bufOut := bytes.NewBuffer(nil)

--- a/subcommands/check/check_test.go
+++ b/subcommands/check/check_test.go
@@ -3,7 +3,6 @@ package check
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -143,7 +142,7 @@ func TestExecuteCmdCheckSpecificSnapshot(t *testing.T) {
 	defer ctx.Close()
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))}
+	args := []string{hex.EncodeToString(indexId[:])}
 
 	subcommand := &Check{}
 	err := subcommand.Parse(ctx, args)

--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -93,6 +93,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		p.Parse(args)
 
 		if len(args) < 2 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name> <location> [<key>=<value>...]", cmd, p.Name())
 		}
 
@@ -106,6 +107,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		for _, kv := range args[2:] {
 			key, val, found := strings.Cut(kv, "=")
 			if !found || key == "" {
+				//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 				return fmt.Errorf("Usage: plakar %s %s <name> <location> [<key>=<value>...]", cmd, p.Name())
 			}
 			cfgMap[name][key] = val
@@ -175,7 +177,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		}
 		flags.Parse(args)
 
-		var rd io.Reader = ctx.Stdin
+		var rd = ctx.Stdin
 		if opt_config != "" {
 			if strings.HasPrefix(opt_config, "http://") || strings.HasPrefix(opt_config, "https://") {
 				resp, err := http.Get(opt_config)
@@ -312,6 +314,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		p.Parse(args)
 
 		if len(args) != 1 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name>", cmd, p.Name())
 		}
 
@@ -331,6 +334,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		p.Parse(args)
 
 		if len(args) < 2 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name> <key>=<value>...", cmd, p.Name())
 		}
 		name := normalizeName(args[0])
@@ -435,6 +439,7 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		p.Parse(args)
 
 		if len(args) < 2 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name> <key>...", cmd, p.Name())
 		}
 		name := normalizeName(args[0])

--- a/subcommands/config/policy.go
+++ b/subcommands/config/policy.go
@@ -63,6 +63,7 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		p.Parse(args)
 
 		if len(args) < 1 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name> [<key>=<value>...]", cmd, p.Name())
 		}
 
@@ -74,6 +75,7 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		for _, kv := range args[1:] {
 			key, val, found := strings.Cut(kv, "=")
 			if !found || key == "" {
+				//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 				return fmt.Errorf("Usage: plakar %s %s <name> [<key>=<value>...]", cmd, p.Name())
 			}
 			if err := config.Set(name, key, val); err != nil {
@@ -91,6 +93,7 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		p.Parse(args)
 
 		if len(args) != 1 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name>", cmd, p.Name())
 		}
 
@@ -110,6 +113,7 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		p.Parse(args)
 
 		if len(args) < 2 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name> <key>=<value>...", cmd, p.Name())
 		}
 		name := normalizeName(args[0])
@@ -161,6 +165,7 @@ func dispatchPolicy(ctx *appcontext.AppContext, cmd, subcmd string, args []strin
 		p.Parse(args)
 
 		if len(args) < 2 {
+			//nolint:staticcheck // ST1005: user-facing usage string, kept verbatim
 			return fmt.Errorf("Usage: plakar %s %s <name> <key>...", cmd, p.Name())
 		}
 		name := normalizeName(args[0])

--- a/subcommands/diag/diag_test.go
+++ b/subcommands/diag/diag_test.go
@@ -42,7 +42,7 @@ func TestExecuteCmdDiagSnapshot(t *testing.T) {
 	defer snap.Close()
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{"diag", "snapshot", fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))}
+	args := []string{"diag", "snapshot", hex.EncodeToString(indexId[:])}
 
 	subcommand, _, args := subcommands.Lookup(args)
 	err := subcommand.Parse(ctx, args)
@@ -170,7 +170,7 @@ func TestExecuteCmdDiagState(t *testing.T) {
 	output = bufOut.String()
 	require.Contains(t, output, "Version:")
 	require.Contains(t, output, "State serial:")
-	require.Contains(t, output, fmt.Sprintf("snapshot %s", fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))))
+	require.Contains(t, output, fmt.Sprintf("snapshot %s", hex.EncodeToString(indexId[:])))
 	require.Contains(t, output, "chunk ")
 	require.Contains(t, output, "object ")
 	require.Contains(t, output, "file ")
@@ -231,7 +231,7 @@ func TestExecuteCmdDiagPackfile(t *testing.T) {
 	output = bufOut.String()
 	require.Contains(t, output, "Version:")
 	require.Contains(t, output, "State serial:")
-	require.Contains(t, output, fmt.Sprintf("snapshot %s", fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))))
+	require.Contains(t, output, fmt.Sprintf("snapshot %s", hex.EncodeToString(indexId[:])))
 	require.Contains(t, output, "chunk ")
 	require.Contains(t, output, "object ")
 	require.Contains(t, output, "vfs-btree ")
@@ -330,7 +330,7 @@ func TestExecuteCmdDiagObject(t *testing.T) {
 	output = bufOut.String()
 	require.Contains(t, output, "Version:")
 	require.Contains(t, output, "State serial:")
-	require.Contains(t, output, fmt.Sprintf("snapshot %s", fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))))
+	require.Contains(t, output, fmt.Sprintf("snapshot %s", hex.EncodeToString(indexId[:])))
 	require.Contains(t, output, "chunk ")
 	require.Contains(t, output, "object ")
 	require.Contains(t, output, "file ")

--- a/subcommands/diff/diff.go
+++ b/subcommands/diff/diff.go
@@ -123,8 +123,8 @@ func (cmd *Diff) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 	}
 
 	var (
-		out     io.Writer = ctx.Stdout
-		builder           = strings.Builder{}
+		out     = ctx.Stdout
+		builder = strings.Builder{}
 	)
 	if cmd.Highlight {
 		out = &builder

--- a/subcommands/digest/digest_test.go
+++ b/subcommands/digest/digest_test.go
@@ -3,7 +3,6 @@ package digest
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -41,7 +40,7 @@ func TestExecuteCmdDigestDefault(t *testing.T) {
 	defer snap.Close()
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))}
+	args := []string{hex.EncodeToString(indexId[:])}
 
 	subcommand := &Digest{}
 	err := subcommand.Parse(ctx, args)
@@ -143,7 +142,7 @@ func TestExecuteCmdDigestWrongHashing(t *testing.T) {
 	defer snap.Close()
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{"-hashing", "md5", fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))}
+	args := []string{"-hashing", "md5", hex.EncodeToString(indexId[:])}
 
 	subcommand := &Digest{}
 	err := subcommand.Parse(ctx, args)

--- a/subcommands/login/token-create.go
+++ b/subcommands/login/token-create.go
@@ -42,7 +42,7 @@ func (cmd *TokenCreate) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.Parse(args)
 
 	if flags.NArg() > 0 {
-		return fmt.Errorf("Too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 	return nil
 }

--- a/subcommands/maintenance/maintenance.go
+++ b/subcommands/maintenance/maintenance.go
@@ -133,7 +133,7 @@ func (cmd *Maintenance) updateCache(ctx *appcontext.AppContext, cache *caching.M
 }
 
 func (cmd *Maintenance) colourPass(ctx *appcontext.AppContext, cache *caching.MaintenanceCache) error {
-	var packfiles map[objects.MAC]struct{} = make(map[objects.MAC]struct{})
+	var packfiles = make(map[objects.MAC]struct{})
 	for packfileMAC := range cmd.repository.ListPackfiles() {
 		packfiles[packfileMAC] = struct{}{}
 	}
@@ -435,7 +435,7 @@ func (cmd *Maintenance) Lock() (chan bool, error) {
 			return nil, err
 		}
 
-		return nil, fmt.Errorf("Can't take exclusive lock, repository is already locked")
+		return nil, fmt.Errorf("can't take exclusive lock, repository is already locked")
 	}
 
 	// The following bit is a "ping" mechanism, Lock() is a bit badly named at this point,

--- a/subcommands/maintenance/maintenance_test.go
+++ b/subcommands/maintenance/maintenance_test.go
@@ -51,6 +51,8 @@ func freshRepo(t *testing.T) (*repository.Repository, *appcontext.AppContext, *b
 // runs can race: run N+1's Lock() calls GetLocks() and sees run N's
 // not-yet-deleted lock, then races GetLock(N's MAC) against the background
 // DeleteLock and fails with "no such file or directory".
+//
+//nolint:staticcheck // ST1008: test helper, error kept in fixed position alongside other outputs
 func runMaintenance(t *testing.T, ctx *appcontext.AppContext, repo *repository.Repository,
 	bufOut, bufErr *bytes.Buffer) (int, error, string, string) {
 	t.Helper()
@@ -692,7 +694,7 @@ func TestExecuteConflictingLockAborts(t *testing.T) {
 
 	status, err, _, _ := runMaintenance(t, ctx, repo, bufOut, bufErr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Can't take exclusive lock")
+	require.Contains(t, err.Error(), "can't take exclusive lock")
 	require.Equal(t, 1, status)
 
 	// The stranger's lock must remain.

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -200,7 +200,9 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 	return nil
 }
 
-func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
+// Execute builds a brand-new ptar archive from scratch, so the repository
+// passed in by the caller is intentionally unused.
+func (cmd *Ptar) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (int, error) {
 	storageConfiguration := storage.NewConfiguration()
 	storageConfiguration.RepositoryID = cmd.KlosetUUID
 
@@ -276,7 +278,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		return 1, err
 	}
 
-	repo, err = repository.New(ctx.GetInner(), key, st, wrappedConfig)
+	repo, err := repository.New(ctx.GetInner(), key, st, wrappedConfig)
 	if err != nil {
 		return 1, err
 	}

--- a/subcommands/repair/repair.go
+++ b/subcommands/repair/repair.go
@@ -232,7 +232,7 @@ func (cmd *Repair) Lock() (chan bool, error) {
 			return nil, err
 		}
 
-		return nil, fmt.Errorf("Can't take exclusive lock, repository is already locked")
+		return nil, fmt.Errorf("can't take exclusive lock, repository is already locked")
 	}
 
 	// The following bit is a "ping" mechanism, Lock() is a bit badly named at this point,

--- a/subcommands/repair/repair_cov80_test.go
+++ b/subcommands/repair/repair_cov80_test.go
@@ -58,7 +58,7 @@ func TestCov80RepairApplyConflictingLockAborts(t *testing.T) {
 	status, err := cmd.Execute(ctx, repo)
 	require.Error(t, err)
 	require.Equal(t, 1, status)
-	require.Contains(t, err.Error(), "Can't take exclusive lock")
+	require.Contains(t, err.Error(), "can't take exclusive lock")
 
 	// The stranger's lock must remain untouched.
 	require.True(t, lockExists(t, repo, stranger), "conflicting lock must be preserved")

--- a/subcommands/restore/restore_test.go
+++ b/subcommands/restore/restore_test.go
@@ -2,7 +2,6 @@ package restore
 
 import (
 	"encoding/hex"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -95,7 +94,7 @@ func TestExecuteCmdRestoreSpecificSnapshot(t *testing.T) {
 	})
 
 	indexId := snap.Header.GetIndexID()
-	args := []string{"-to", tmpToRestoreDir, fmt.Sprintf("%s", hex.EncodeToString(indexId[:]))}
+	args := []string{"-to", tmpToRestoreDir, hex.EncodeToString(indexId[:])}
 	subcommand := &Restore{}
 	err = subcommand.Parse(ctx, args)
 	require.NoError(t, err)

--- a/subcommands/server/server.go
+++ b/subcommands/server/server.go
@@ -46,10 +46,7 @@ func (cmd *Server) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	flags.Parse(args)
 
-	noDelete := true
-	if opt_allowdelete {
-		noDelete = false
-	}
+	noDelete := !opt_allowdelete
 
 	cmd.RepositorySecret = ctx.GetSecret()
 	cmd.NoDelete = noDelete

--- a/subcommands/service/service.go
+++ b/subcommands/service/service.go
@@ -43,7 +43,7 @@ type Service struct {
 	subcommands.SubcommandBase
 }
 
-func (_ *Service) Parse(ctx *appcontext.AppContext, args []string) error {
+func (*Service) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags := flag.NewFlagSet("service", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s\n", flags.Name())

--- a/subcommands/sync/sync.go
+++ b/subcommands/sync/sync.go
@@ -69,7 +69,7 @@ func (cmd *Sync) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.Parse(args)
 
 	if flags.NArg() > 3 {
-		return fmt.Errorf("Too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 
 	direction := ""
@@ -230,20 +230,21 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 	var dstRepository *repository.Repository
 
 	srcStoreConfig := ctx.StoreConfig
-	if cmd.Direction == "to" {
+	switch cmd.Direction {
+	case "to":
 		srcRepository = repo
 		dstRepository = peerRepository
-	} else if cmd.Direction == "from" {
+	case "from":
 		srcRepository = peerRepository
 		dstRepository = repo
 		srcStoreConfig = storeConfig
 		tmp := ctx
 		ctx = peerCtx
 		peerCtx = tmp
-	} else if cmd.Direction == "with" {
+	case "with":
 		srcRepository = repo
 		dstRepository = peerRepository
-	} else {
+	default:
 		return 1, fmt.Errorf("could not synchronize %s: invalid direction, must be to, from or with", cmd.PeerRepositoryLocation)
 	}
 
@@ -301,7 +302,8 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 		}
 	}
 
-	if cmd.Direction == "with" {
+	switch cmd.Direction {
+	case "with":
 
 		dstSnapshotIDs, err := locate.LocateSnapshotIDs(dstRepository, cmd.SrcLocateOptions)
 		if err != nil {
@@ -340,12 +342,12 @@ func (cmd *Sync) Execute(ctx *appcontext.AppContext, repo *repository.Repository
 			srcLocation,
 			dstLocation,
 			srcSynced+dstSynced)
-	} else if cmd.Direction == "to" {
+	case "to":
 		ctx.GetLogger().Info("sync: synchronization from %s to %s completed: %d snapshots synchronized",
 			srcLocation,
 			dstLocation,
 			srcSynced)
-	} else {
+	default:
 		ctx.GetLogger().Info("sync: synchronization from %s to %s completed: %d snapshots synchronized",
 			dstLocation,
 			srcLocation,

--- a/subcommands/sync/sync_coverage3_test.go
+++ b/subcommands/sync/sync_coverage3_test.go
@@ -28,7 +28,7 @@ func cov3ParseCtx(t *testing.T) *appcontext.AppContext {
 func TestCov3SyncParseTooManyArgs(t *testing.T) {
 	err := (&Sync{}).Parse(cov3ParseCtx(t), []string{"a", "to", "b", "c"})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Too many arguments")
+	require.Contains(t, err.Error(), "too many arguments")
 }
 
 func TestCov3SyncParseNoArgs(t *testing.T) {

--- a/subcommands/ui/ui.go
+++ b/subcommands/ui/ui.go
@@ -65,7 +65,7 @@ func (cmd *Ui) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.Parse(args)
 
 	if flags.NArg() > 0 {
-		return fmt.Errorf("Too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 
 	cmd.RepositorySecret = ctx.GetSecret()

--- a/subcommands/ui/ui_test.go
+++ b/subcommands/ui/ui_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	_ "github.com/PlakarKorp/integrations/fs/exporter"
-	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +45,7 @@ func TestUiParseTooManyArgs(t *testing.T) {
 	cmd := &Ui{}
 	err := cmd.Parse(ctx, []string{"extra"})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Too many arguments")
+	require.Contains(t, err.Error(), "too many arguments")
 }
 
 func TestUiExecuteStartsAndShutsDown(t *testing.T) {

--- a/subcommands/version/version.go
+++ b/subcommands/version/version.go
@@ -30,7 +30,7 @@ func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &Version{} }, subcommands.BeforeRepositoryOpen, "version")
 }
 
-func (_ *Version) Parse(ctx *appcontext.AppContext, args []string) error {
+func (*Version) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags := flag.NewFlagSet("version", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintf(flags.Output(), "Usage: %s\n", flags.Name())
@@ -40,7 +40,7 @@ func (_ *Version) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.Parse(args)
 
 	if flags.NArg() > 0 {
-		return fmt.Errorf("Too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 
 	return nil

--- a/subcommands/version/version_test.go
+++ b/subcommands/version/version_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/utils"
 	"github.com/stretchr/testify/require"
@@ -38,7 +38,7 @@ func TestParseCmdVersionTooManyArgs(t *testing.T) {
 	subcommand := &Version{}
 	err := subcommand.Parse(ctx, []string{"extra"})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Too many arguments")
+	require.Contains(t, err.Error(), "too many arguments")
 }
 
 func TestExecuteCmdVersion(t *testing.T) {

--- a/testing/backend.go
+++ b/testing/backend.go
@@ -91,7 +91,7 @@ func (mb *MockBackend) Create(ctx context.Context, configuration []byte) error {
 		return errors.New("creating error")
 	}
 	mb.configuration = configuration
-	fmt.Println("CONFIG", mb.configuration)
+	fmt.Println("CONFIG", string(mb.configuration))
 
 	mb.behavior = "default"
 
@@ -113,7 +113,7 @@ func (mb *MockBackend) Open(ctx context.Context) ([]byte, error) {
 	if strings.Contains(mb.location, "musterror") {
 		return nil, errors.New("opening error")
 	}
-	fmt.Println("CONFIG", mb.configuration)
+	fmt.Println("CONFIG", string(mb.configuration))
 	return mb.configuration, nil
 }
 

--- a/testing/ftp.go
+++ b/testing/ftp.go
@@ -119,7 +119,7 @@ func (s *MockFTPServer) handleConnection(conn net.Conn) {
 			port, _ := strconv.Atoi(portStr)
 
 			// Send the passive mode response with the port number
-			conn.Write([]byte(fmt.Sprintf("227 Entering Passive Mode (127,0,0,1,%d,%d)\r\n", port>>8, port&0xFF)))
+			fmt.Fprintf(conn, "227 Entering Passive Mode (127,0,0,1,%d,%d)\r\n", port>>8, port&0xFF)
 
 			// Accept the data connection
 			dataConn, err = dataListener.Accept()

--- a/ui/tui/view.go
+++ b/ui/tui/view.go
@@ -74,7 +74,7 @@ func fmtNewReuse(okCount, total uint64, progress bool) string {
 	totalS := dimStyle.Render(fmt.Sprintf("%d", total))
 
 	if !progress {
-		return fmt.Sprintf("%s", okS)
+		return okS
 	}
 	return fmt.Sprintf("%s/%s", okS, totalS)
 }


### PR DESCRIPTION
Third of the linter-cleanup PRs (split by class), and the largest. Clears the staticcheck findings across the tree.

Most were mechanical and applied with `golangci-lint --fix` — redundant type declarations in var blocks (ST1023), `fmt.Sprintf` on an already-string argument (S1025), conditionals that could be tagged switches (QF1003), a manual copy loop (S1001), etc. The rest by hand:

- **ST1005** — lowercased capitalized error strings, and updated the handful of case-sensitive `require.Contains` assertions that matched the old wording. User-facing `Usage:` strings are left verbatim with a `//nolint:staticcheck` and a reason, since lowercasing help text reads worse than the lint nit.
- **SA4004** — the cached response read was written as a `for {}` that always returned/broke on the first iteration; rewritten as a straight-line decode (same behaviour: EOF → success, error → error, otherwise the response code).
- **SA4009** — `Ptar.Execute` builds a brand-new archive repository internally, so the `repo` argument it's handed is intentionally unused; renamed to `_` and documented.
- **SA9003** — the two login UI response handlers had `if err := PutAuthToken(...); err != nil {}` with an empty body, silently dropping a token-store failure; now logged.
- **ST1006** — dropped the unused `_` receiver names on two `Parse` methods.

The remaining SA4006 findings (an unused assignment in help.go and the GenerateFiles helper) overlap with the ineffassign cleanup and are fixed in that PR instead.

`go build`, `go vet`, and the tests for every touched package pass.