### PR TITLE
ci: cap test parallelism so heavy packages stop timing out

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,14 @@ jobs:
       run: |
         go install github.com/jstemmer/go-junit-report/v2@latest
         set -o pipefail
-        timeout -s QUIT 5m go test -v -coverprofile=coverage.out -covermode=atomic -timeout 1m -json ./... \
+        # -p 4 caps how many package test binaries run at once. Several
+        # packages (api, diag, maintenance) each spin up pebble caches and do
+        # real encryption/snapshot work; with the default parallelism they
+        # over-subscribe the runner's cores, starve each other, and blow the
+        # per-test timeout -- which kills the whole package and reports every
+        # test in it as failed-to-return to Codecov. Capping concurrency keeps
+        # the run both fast and reliable.
+        timeout -s QUIT 5m go test -v -p 4 -coverprofile=coverage.out -covermode=atomic -timeout 2m -json ./... \
           | "$(go env GOPATH)/bin/go-junit-report" -parser gojson -set-exit-code > junit.xml
         status=$?
         echo "test_exit=$status" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This is what's behind Codecov Test Analytics showing thousands of "failed to return", hundreds of "flaky", and the "slow" tests.

**Root cause:** `go test ./...` runs package test binaries concurrently, defaulting to NumCPU. A handful of packages — `api`, `subcommands/diag`, `subcommands/maintenance` — each stand up pebble caches and do real encryption + snapshot work. Run on their own they take ~14s; run simultaneously with ~10 other heavy packages they over-subscribe the runner's cores, starve each other, and a package that should finish in 14s crawls past the **1m per-test timeout**. When that fires, `go test` panics and kills the *entire* package binary — so every test in it that hadn't returned gets reported to Codecov as **failed-to-return**, and tests that squeak under the wire in one run but not the next show up as **flaky**.

Reproduced locally with the exact CI flags:

| invocation | result |
|---|---|
| `go test ./... -timeout 1m` (current) | api 63s, diag 64s, maintenance 61s → **3 packages time out / FAIL** |
| `go test -p 4 ./... -timeout 1m` | full suite ~clean, **0 timeouts** |

**Fix:** pin `-p 4` to match the runner core count and raise the per-test timeout to `2m` for headroom (the fat packages run ~14s solo, so that's generous). The suite goes from three timed-out packages to a clean run; total coverage is unchanged at ~70%.

Once this lands, the Codecov failed-to-return / flaky counts should collapse on the next run, since packages will actually finish and report real per-test results.