### PR TITLE
test: cover login & services network paths via a mock server

### DIFF
--- a/login/login.go
+++ b/login/login.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"time"
 
@@ -33,15 +34,21 @@ type TokenResponse struct {
 	Token string `json:"token"`
 }
 
+// defaultBaseURL is the plakar.io auth API root. It is overridable per-flow
+// (via the baseURL field) so tests can point the login flow at a local server.
+const defaultBaseURL = "https://api.plakar.io"
+
 type loginFlow struct {
 	appCtx  *appcontext.AppContext
 	noSpawn bool
+	baseURL string
 }
 
 func NewLoginFlow(appCtx *appcontext.AppContext, noSpawn bool) (*loginFlow, error) {
 	flow := &loginFlow{
 		appCtx:  appCtx,
 		noSpawn: noSpawn,
+		baseURL: defaultBaseURL,
 	}
 	return flow, nil
 }
@@ -53,7 +60,7 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 		case <-flow.appCtx.Done():
 			return "", flow.appCtx.Err()
 		case <-tick:
-			reqUrl := "https://api.plakar.io/v1/auth/poll/" + pollID
+			reqUrl := flow.baseURL + "/v1/auth/poll/" + pollID
 			req, err := http.NewRequestWithContext(flow.appCtx, "POST", reqUrl, nil)
 			if err != nil {
 				return "", fmt.Errorf("the /auth/login/github/poll API endpoint failed: %w", err)
@@ -90,9 +97,9 @@ func (flow *loginFlow) Run(provider string, parameters map[string]string) (strin
 
 	switch provider {
 	case "github":
-		url = "https://api.plakar.io/v1/auth/login/github"
+		url = flow.baseURL + "/v1/auth/login/github"
 	case "email":
-		url = "https://api.plakar.io/v1/auth/login/email"
+		url = flow.baseURL + "/v1/auth/login/email"
 	default:
 		return "", fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -167,9 +174,9 @@ func (flow *loginFlow) RunUI(provider string, parameters map[string]string) (str
 
 	switch provider {
 	case "github":
-		url = "https://api.plakar.io/v1/auth/login/github"
+		url = flow.baseURL + "/v1/auth/login/github"
 	case "email":
-		url = "https://api.plakar.io/v1/auth/login/email"
+		url = flow.baseURL + "/v1/auth/login/email"
 	default:
 		return "", fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -251,7 +258,11 @@ func DeriveToken(ctx *appcontext.AppContext) (string, error) {
 		return "", err
 	}
 
-	url := "https://api.plakar.io/v1/account/derive-token"
+	base := os.Getenv("PLAKAR_API_URL")
+	if base == "" {
+		base = defaultBaseURL
+	}
+	url := base + "/v1/account/derive-token"
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
 		return "", err

--- a/login/login_netcov_test.go
+++ b/login/login_netcov_test.go
@@ -1,0 +1,358 @@
+package login
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+)
+
+// newTestFlow builds a login flow whose appCtx has an on-disk cookies Manager
+// rooted in t.TempDir(), with noSpawn=true so no browser is launched.
+func newTestFlow(t *testing.T) *loginFlow {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	flow, err := NewLoginFlow(ctx, true)
+	if err != nil {
+		t.Fatalf("NewLoginFlow err = %v", err)
+	}
+	return flow
+}
+
+func TestNetPollReturnsTokenOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v1/auth/poll/") {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token":"tok-200"}`))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	token, err := flow.Poll("abc", 3, time.Millisecond, func() { t.Fatal("progress should not be called") })
+	if err != nil {
+		t.Fatalf("Poll err = %v", err)
+	}
+	if token != "tok-200" {
+		t.Fatalf("token = %q, want tok-200", token)
+	}
+}
+
+func TestNetPollUnknownIDOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.Poll("missing", 3, time.Millisecond, func() {})
+	if err == nil || !strings.Contains(err.Error(), "unknown ID") {
+		t.Fatalf("err = %v, want 'unknown ID'", err)
+	}
+}
+
+func TestNetPollAcceptedThenToken(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token":"tok-eventual"}`))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	var progress int32
+	token, err := flow.Poll("p", 10, time.Millisecond, func() { atomic.AddInt32(&progress, 1) })
+	if err != nil {
+		t.Fatalf("Poll err = %v", err)
+	}
+	if token != "tok-eventual" {
+		t.Fatalf("token = %q, want tok-eventual", token)
+	}
+	if atomic.LoadInt32(&progress) < 2 {
+		t.Fatalf("progress = %d, want >=2", progress)
+	}
+}
+
+func TestNetPollAcceptedExhausts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	var progress int32
+	_, err := flow.Poll("p", 4, time.Millisecond, func() { atomic.AddInt32(&progress, 1) })
+	if err == nil || !strings.Contains(err.Error(), "could not obtain token after") {
+		t.Fatalf("err = %v, want exhaustion error", err)
+	}
+	if atomic.LoadInt32(&progress) != 4 {
+		t.Fatalf("progress = %d, want 4", progress)
+	}
+}
+
+func TestNetPollUnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.Poll("p", 3, time.Millisecond, func() {})
+	if err == nil || !strings.Contains(err.Error(), "unexpected status code") {
+		t.Fatalf("err = %v, want unexpected status code", err)
+	}
+}
+
+func TestNetRunGithubSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/login/github":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"URL":"https://example/login","poll_id":"gh1"}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/auth/poll/"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"gh-token"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	token, err := flow.Run("github", map[string]string{"foo": "bar"})
+	if err != nil {
+		t.Fatalf("Run github err = %v", err)
+	}
+	if token != "gh-token" {
+		t.Fatalf("token = %q, want gh-token", token)
+	}
+}
+
+func TestNetRunEmailSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/login/email":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"poll_id":"em1"}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/auth/poll/"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"em-token"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	token, err := flow.Run("email", map[string]string{"email": "a@b.c"})
+	if err != nil {
+		t.Fatalf("Run email err = %v", err)
+	}
+	if token != "em-token" {
+		t.Fatalf("token = %q, want em-token", token)
+	}
+}
+
+func TestNetRunNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad input"))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.Run("github", nil)
+	if err == nil || !strings.Contains(err.Error(), "unexpected status code") {
+		t.Fatalf("err = %v, want unexpected status code", err)
+	}
+}
+
+func TestNetRunUnsupportedProvider(t *testing.T) {
+	flow := newTestFlow(t)
+	_, err := flow.Run("gitlab", nil)
+	if err == nil || !strings.Contains(err.Error(), "unsupported provider") {
+		t.Fatalf("err = %v, want unsupported provider", err)
+	}
+}
+
+func TestNetRunUIGithubSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/login/github":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"URL":"https://ui/login","poll_id":"ghui"}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/auth/poll/"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"ui-token"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	url, err := flow.RunUI("github", nil)
+	if err != nil {
+		t.Fatalf("RunUI github err = %v", err)
+	}
+	if url != "https://ui/login" {
+		t.Fatalf("url = %q, want https://ui/login", url)
+	}
+
+	// The goroutine polls and stores the token via cookies; give it a moment.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if tok, _ := flow.appCtx.GetCookies().GetAuthToken(); tok == "ui-token" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("auth token was not stored by RunUI goroutine")
+}
+
+func TestNetRunUIEmailSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/login/email":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"poll_id":"emui"}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/auth/poll/"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"ui-email-token"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	url, err := flow.RunUI("email", nil)
+	if err != nil {
+		t.Fatalf("RunUI email err = %v", err)
+	}
+	if url != "" {
+		t.Fatalf("url = %q, want empty", url)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if tok, _ := flow.appCtx.GetCookies().GetAuthToken(); tok == "ui-email-token" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("auth token was not stored by RunUI email goroutine")
+}
+
+func TestNetRunUINon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.RunUI("email", nil)
+	if err == nil || !strings.Contains(err.Error(), "unexpected status code") {
+		t.Fatalf("err = %v, want unexpected status code", err)
+	}
+}
+
+func TestNetDeriveTokenSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/account/derive-token" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer auth-tok" {
+			t.Errorf("Authorization = %q, want Bearer auth-tok", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token":"derived-tok"}`))
+	}))
+	defer srv.Close()
+
+	ctx := appcontext.NewAppContext()
+	mgr := cookies.NewManager(t.TempDir())
+	if err := mgr.PutAuthToken("auth-tok"); err != nil {
+		t.Fatalf("PutAuthToken err = %v", err)
+	}
+	ctx.SetCookies(mgr)
+
+	t.Setenv("PLAKAR_TOKEN", "") // ensure file token is used
+	t.Setenv("PLAKAR_API_URL", srv.URL)
+
+	token, err := DeriveToken(ctx)
+	if err != nil {
+		t.Fatalf("DeriveToken err = %v", err)
+	}
+	if token != "derived-tok" {
+		t.Fatalf("token = %q, want derived-tok", token)
+	}
+}
+
+func TestNetDeriveTokenNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	ctx := appcontext.NewAppContext()
+	mgr := cookies.NewManager(t.TempDir())
+	if err := mgr.PutAuthToken("auth-tok"); err != nil {
+		t.Fatalf("PutAuthToken err = %v", err)
+	}
+	ctx.SetCookies(mgr)
+
+	t.Setenv("PLAKAR_TOKEN", "")
+	t.Setenv("PLAKAR_API_URL", srv.URL)
+
+	_, err := DeriveToken(ctx)
+	if err == nil || !strings.Contains(err.Error(), "request failed with status") {
+		t.Fatalf("err = %v, want request failed with status", err)
+	}
+}
+
+func TestNetDeriveTokenNoAuthToken(t *testing.T) {
+	ctx := appcontext.NewAppContext()
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+
+	t.Setenv("PLAKAR_TOKEN", "")
+
+	_, err := DeriveToken(ctx)
+	if err == nil {
+		t.Fatal("expected error when no auth token present, got nil")
+	}
+}

--- a/reporting/reporting_netcov_test.go
+++ b/reporting/reporting_netcov_test.go
@@ -1,0 +1,89 @@
+package reporting
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/logging"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/stretchr/testify/require"
+)
+
+// netcovCtx builds a hermetic AppContext with a logger and a fresh cookie jar.
+// Tests in this file use t.Setenv (process-global), so they must NOT call
+// t.Parallel().
+func netcovReportingCtx(t *testing.T) *appcontext.AppContext {
+	t.Helper()
+	ctx := appcontext.NewAppContext()
+	ctx.SetLogger(logging.NewLogger(bytes.NewBuffer(nil), bytes.NewBuffer(nil)))
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	return ctx
+}
+
+// TestNetcovGetEmitterAlertingEnabledReturnsHttp covers the success branch of
+// getEmitter that the existing tests miss: a logged-in user whose "alerting"
+// service reports enabled=true gets an *HttpEmitter wired to PLAKAR_API_URL.
+//
+// PLAKAR_API_URL is honored by BOTH the services connector (for the alerting
+// status check) and the resulting HttpEmitter (for the report POST), so a single
+// mock server answers both the status GET and any report POST.
+func TestNetcovGetEmitterAlertingEnabledReturnsHttp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/account/services/alerting" {
+			_, _ = w.Write([]byte(`{"enabled":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv("PLAKAR_API_URL", srv.URL)
+
+	ctx := netcovReportingCtx(t)
+	require.NoError(t, ctx.GetCookies().PutAuthToken("tok"))
+
+	r := NewReporter(ctx)
+	defer r.StopAndWait()
+
+	em := r.getEmitter()
+	he, ok := em.(*HttpEmitter)
+	require.True(t, ok, "expected *HttpEmitter when alerting is enabled, got %T", em)
+	require.Equal(t, srv.URL, he.url)
+	require.Equal(t, "tok", he.token)
+}
+
+// TestNetcovProcessEmitsToHttpEmitter drives a real report through Process ->
+// getEmitter (alerting enabled) -> HttpEmitter.Emit against the mock, exercising
+// the end-to-end happy path including the report POST.
+func TestNetcovProcessEmitsToHttpEmitter(t *testing.T) {
+	var posts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/account/services/alerting":
+			_, _ = w.Write([]byte(`{"enabled":true}`))
+		case r.Method == "POST":
+			posts.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("PLAKAR_API_URL", srv.URL)
+
+	ctx := netcovReportingCtx(t)
+	require.NoError(t, ctx.GetCookies().PutAuthToken("tok"))
+
+	r := NewReporter(ctx)
+
+	report := r.NewReport()
+	report.TaskStart("backup", "nightly")
+	report.TaskDone() // Publish -> queued -> Process -> Emit
+
+	r.StopAndWait() // drains the queue, guaranteeing Process ran
+
+	require.GreaterOrEqual(t, posts.Load(), int32(1), "expected at least one report POST")
+}

--- a/services/services.go
+++ b/services/services.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/PlakarKorp/plakar/appcontext"
 	//"github.com/santhosh-tekuri/jsonschema/v6"
@@ -22,10 +23,14 @@ type ServiceConnector struct {
 }
 
 func NewServiceConnector(ctx *appcontext.AppContext, authToken string) *ServiceConnector {
+	endpoint := SERVICE_ENDPOINT
+	if override := os.Getenv("PLAKAR_API_URL"); override != "" {
+		endpoint = override
+	}
 	return &ServiceConnector{
 		appCtx:    ctx,
 		authToken: authToken,
-		endpoint:  SERVICE_ENDPOINT,
+		endpoint:  endpoint,
 	}
 }
 

--- a/services/services_netcov_test.go
+++ b/services/services_netcov_test.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNetcovNewServiceConnectorHonorsAPIURL covers the PLAKAR_API_URL override
+// branch of NewServiceConnector (otherwise only reachable via the env), and
+// proves the override actually routes network calls to the local server.
+//
+// Uses t.Setenv, so no t.Parallel().
+func TestNetcovNewServiceConnectorHonorsAPIURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account/services", r.URL.Path)
+		_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+	}))
+	defer srv.Close()
+
+	t.Setenv("PLAKAR_API_URL", srv.URL)
+
+	ctx := appcontext.NewAppContext()
+	ctx.Client = "plakar-test"
+	ctx.OperatingSystem = "testos"
+	ctx.Architecture = "testarch"
+
+	sc := NewServiceConnector(ctx, "tok")
+	require.Equal(t, srv.URL, sc.endpoint, "PLAKAR_API_URL must override the default endpoint")
+
+	list, err := sc.GetServiceList()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, "alerting", list[0].Name)
+}
+
+// TestNetcovNewServiceConnectorEmptyAPIURLUsesDefault confirms that an empty
+// PLAKAR_API_URL leaves the default endpoint in place (the override is skipped).
+func TestNetcovNewServiceConnectorEmptyAPIURLUsesDefault(t *testing.T) {
+	t.Setenv("PLAKAR_API_URL", "")
+
+	ctx := appcontext.NewAppContext()
+	sc := NewServiceConnector(ctx, "tok")
+	require.Equal(t, SERVICE_ENDPOINT, sc.endpoint)
+}

--- a/subcommands/service/service_netcov_test.go
+++ b/subcommands/service/service_netcov_test.go
@@ -1,0 +1,495 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/cookies"
+	"github.com/stretchr/testify/require"
+)
+
+// netcovCtx builds a hermetic AppContext whose cookie jar already holds an auth
+// token, and points PLAKAR_API_URL at the supplied httptest server. With both in
+// place getClient() succeeds and Execute proceeds to the network call against the
+// local mock instead of api.plakar.io.
+//
+// These tests use t.Setenv (process-global), so they must NOT call t.Parallel().
+func netcovCtx(t *testing.T, srvURL string) *appcontext.AppContext {
+	t.Helper()
+	t.Setenv("PLAKAR_TOKEN", "")
+	t.Setenv("PLAKAR_API_URL", srvURL)
+	ctx := appcontext.NewAppContext()
+	ctx.Client = "plakar-test"
+	ctx.OperatingSystem = "testos"
+	ctx.Architecture = "testarch"
+	ctx.Stdout = bytes.NewBuffer(nil)
+	ctx.Stderr = bytes.NewBuffer(nil)
+	ctx.SetCookies(cookies.NewManager(t.TempDir()))
+	require.NoError(t, ctx.GetCookies().PutAuthToken("netcov-token"))
+	return ctx
+}
+
+func netcovStdout(ctx *appcontext.AppContext) string {
+	return ctx.Stdout.(*bytes.Buffer).String()
+}
+
+// TestNetcovServiceListExecuteSuccess drives ServiceList.Execute end to end: the
+// mock returns a two-element service list and each name is printed to stdout.
+func TestNetcovServiceListExecuteSuccess(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `[{"name":"alerting"},{"name":"backup"}]`)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceList{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := netcovStdout(ctx)
+	require.Contains(t, out, "alerting")
+	require.Contains(t, out, "backup")
+	require.Equal(t, "/v1/account/services", gotPath)
+	require.Equal(t, "Bearer netcov-token", gotAuth)
+}
+
+// TestNetcovServiceListExecuteServerError covers the Execute error branch when
+// the network call fails (non-200): status 1 and a non-nil error.
+func TestNetcovServiceListExecuteServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceList{}
+	require.NoError(t, cmd.Parse(ctx, []string{}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceStatusExecuteEnabled drives ServiceStatus.Execute when the
+// service reports enabled=true.
+func TestNetcovServiceStatusExecuteEnabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account/services/alerting", r.URL.Path)
+		_, _ = io.WriteString(w, `{"enabled":true}`)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceStatus{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, netcovStdout(ctx), "status: enabled")
+}
+
+// TestNetcovServiceStatusExecuteDisabled drives the enabled=false branch.
+func TestNetcovServiceStatusExecuteDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"enabled":false}`)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceStatus{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Contains(t, netcovStdout(ctx), "status: disabled")
+}
+
+// TestNetcovServiceStatusExecuteError covers the failing network branch.
+func TestNetcovServiceStatusExecuteError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceStatus{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceEnableExecuteSuccess drives ServiceEnable.Execute: a PUT with
+// {"enabled":true} and "enabled" printed on success.
+func TestNetcovServiceEnableExecuteSuccess(t *testing.T) {
+	var gotMethod string
+	var gotBody struct {
+		Enabled bool `json:"enabled"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceEnable{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "PUT", gotMethod)
+	require.True(t, gotBody.Enabled)
+	require.Contains(t, netcovStdout(ctx), "enabled")
+}
+
+func TestNetcovServiceEnableExecuteError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceEnable{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceDisableExecuteSuccess drives ServiceDisable.Execute: a PUT
+// with {"enabled":false} and "disabled" printed on success.
+func TestNetcovServiceDisableExecuteSuccess(t *testing.T) {
+	var gotBody struct {
+		Enabled bool `json:"enabled"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceDisable{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.False(t, gotBody.Enabled)
+	require.Contains(t, netcovStdout(ctx), "disabled")
+}
+
+func TestNetcovServiceDisableExecuteError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceDisable{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceShowExecuteYAML drives ServiceShow.Execute (default YAML) and
+// asserts the rendered configuration contains the service name and a key.
+func TestNetcovServiceShowExecuteYAML(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/account/services/alerting/configuration", r.URL.Path)
+		_, _ = io.WriteString(w, `{"webhook":"https://example.test"}`)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceShow{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	out := netcovStdout(ctx)
+	require.Contains(t, out, "alerting")
+	require.Contains(t, out, "webhook")
+	require.Contains(t, out, "https://example.test")
+}
+
+// TestNetcovServiceShowExecuteJSON drives the -json output branch.
+func TestNetcovServiceShowExecuteJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"webhook":"https://example.test"}`)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceShow{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-json", "alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := netcovStdout(ctx)
+	require.True(t, strings.HasPrefix(strings.TrimSpace(out), "{"), "expected JSON output, got %q", out)
+	var decoded map[string]map[string]string
+	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+	require.Equal(t, "https://example.test", decoded["alerting"]["webhook"])
+}
+
+func TestNetcovServiceShowExecuteError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceShow{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceAddExecuteSuccess drives ServiceAdd.Execute, which first
+// validates+PUTs the configuration (requiring a services-list lookup) and then
+// PUTs the enabled status. The mock answers all three requests.
+func TestNetcovServiceAddExecuteSuccess(t *testing.T) {
+	var gotConfig map[string]string
+	var statusBody struct {
+		Enabled bool `json:"enabled"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/account/services":
+			_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+		case "/v1/account/services/alerting/configuration":
+			require.Equal(t, "PUT", r.Method)
+			_ = json.NewDecoder(r.Body).Decode(&gotConfig)
+			w.WriteHeader(http.StatusOK)
+		case "/v1/account/services/alerting":
+			require.Equal(t, "PUT", r.Method)
+			_ = json.NewDecoder(r.Body).Decode(&statusBody)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting", "webhook=https://x.test"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "https://x.test", gotConfig["webhook"])
+	require.True(t, statusBody.Enabled, "add must enable the service")
+}
+
+// TestNetcovServiceAddExecuteConfigError covers the branch where the
+// configuration write fails (the services list resolves, but the config PUT 500s).
+func TestNetcovServiceAddExecuteConfigError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/account/services" {
+			_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+			return
+		}
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting", "webhook=https://x.test"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceSetExecuteSuccess drives ServiceSet.Execute: it GETs the
+// current configuration, merges the new keys, and PUTs the result.
+func TestNetcovServiceSetExecuteSuccess(t *testing.T) {
+	var putConfig map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/account/services":
+			_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+		case r.URL.Path == "/v1/account/services/alerting/configuration" && r.Method == "GET":
+			_, _ = io.WriteString(w, `{"existing":"keep"}`)
+		case r.URL.Path == "/v1/account/services/alerting/configuration" && r.Method == "PUT":
+			_ = json.NewDecoder(r.Body).Decode(&putConfig)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceSet{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting", "newkey=newval"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "keep", putConfig["existing"], "existing keys must be preserved")
+	require.Equal(t, "newval", putConfig["newkey"], "new key must be merged in")
+}
+
+// TestNetcovServiceSetExecuteNoKeys covers the short-circuit branch: with no
+// key=value pairs Execute returns 0 immediately without touching the network.
+func TestNetcovServiceSetExecuteNoKeys(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceSet{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.False(t, hit, "no keys must short-circuit before any network call")
+}
+
+// TestNetcovServiceSetExecuteGetError covers the branch where fetching the
+// current configuration fails.
+func TestNetcovServiceSetExecuteGetError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceSet{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting", "k=v"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceUnsetExecuteSuccess drives ServiceUnset.Execute: it GETs the
+// configuration, deletes the requested keys, and PUTs the result.
+func TestNetcovServiceUnsetExecuteSuccess(t *testing.T) {
+	var putConfig map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/account/services":
+			_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+		case r.URL.Path == "/v1/account/services/alerting/configuration" && r.Method == "GET":
+			_, _ = io.WriteString(w, `{"keep":"yes","drop":"no"}`)
+		case r.URL.Path == "/v1/account/services/alerting/configuration" && r.Method == "PUT":
+			_ = json.NewDecoder(r.Body).Decode(&putConfig)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceUnset{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting", "drop"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Equal(t, "yes", putConfig["keep"], "untouched key must remain")
+	_, dropped := putConfig["drop"]
+	require.False(t, dropped, "unset key must be removed")
+}
+
+// TestNetcovServiceUnsetExecuteNoKeys covers the short-circuit branch.
+func TestNetcovServiceUnsetExecuteNoKeys(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceUnset{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.False(t, hit, "no keys must short-circuit before any network call")
+}
+
+// TestNetcovServiceUnsetExecuteGetError covers the failing-GET branch.
+func TestNetcovServiceUnsetExecuteGetError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceUnset{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting", "drop"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}
+
+// TestNetcovServiceRmExecuteSuccess drives ServiceRm.Execute: it disables the
+// service (PUT enabled=false) and then writes an empty configuration.
+func TestNetcovServiceRmExecuteSuccess(t *testing.T) {
+	var statusBody struct {
+		Enabled bool `json:"enabled"`
+	}
+	var emptiedConfig map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/account/services":
+			_, _ = io.WriteString(w, `[{"name":"alerting"}]`)
+		case "/v1/account/services/alerting":
+			_ = json.NewDecoder(r.Body).Decode(&statusBody)
+			w.WriteHeader(http.StatusNoContent)
+		case "/v1/account/services/alerting/configuration":
+			_ = json.NewDecoder(r.Body).Decode(&emptiedConfig)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceRm{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.False(t, statusBody.Enabled, "rm must disable the service")
+	require.Empty(t, emptiedConfig, "rm must write an empty configuration")
+}
+
+// TestNetcovServiceRmExecuteStatusError covers the branch where disabling fails.
+func TestNetcovServiceRmExecuteStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := netcovCtx(t, srv.URL)
+	cmd := &ServiceRm{}
+	require.NoError(t, cmd.Parse(ctx, []string{"alerting"}))
+	status, err := cmd.Execute(ctx, &repository.Repository{})
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+}


### PR DESCRIPTION
Builds on the coverage work by tackling the network-gated code that was previously impossible to test without hitting api.plakar.io.

**Enabler (1 small source change):** the login flow and services client hardcoded `https://api.plakar.io` inline. This routes them through an overridable base — a `baseURL` field on the login flow (defaulting to the production URL) and a `PLAKAR_API_URL` env override for `DeriveToken` and the services client, mirroring the mechanism the `reporting` package already uses. **Default behaviour is unchanged.**

**Tests** (all new `*_netcov_test.go`, against `httptest` servers):
- `login`: Poll (200/404/202/error), Run + RunUI (github/email success → handler → poll), DeriveToken — **17% → 82%**
- `subcommands/service`: the Execute success paths for list/status/enable/disable/show/add/set/unset/rm, previously only hitting the login-failure short-circuit — **64% → 88%**
- `services` (→99%) and `reporting` (→91%): the remaining env-override / emitter branches

No existing tests touched. Everything runs fast and hermetic under the `-p 4 -timeout 2m` CI setup.