### PR TITLE
mount: handle snapshot root path

### DIFF
--- a/subcommands/mount/mount.go
+++ b/subcommands/mount/mount.go
@@ -40,6 +40,8 @@ type Mount struct {
 	SnapshotPath string
 }
 
+const snapshotRootPath = "/"
+
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &Mount{} }, 0, "mount")
 }
@@ -81,7 +83,7 @@ func (cmd *Mount) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 			return 1, err
 		}
 
-		subFS, err := fs.Sub(pvfs, path[1:])
+		subFS, err := snapshotSubFS(pvfs, path)
 		if err != nil {
 			return 1, err
 		}
@@ -92,4 +94,11 @@ func (cmd *Mount) Execute(ctx *appcontext.AppContext, repo *repository.Repositor
 		return http.ExecuteHTTP(ctx, repo, cmd.Mountpoint, cmd.LocateOptions, chrootFS)
 	}
 	return fuse.ExecuteFUSE(ctx, repo, cmd.Mountpoint, cmd.LocateOptions, chrootFS, cmd.AllowOthers)
+}
+
+func snapshotSubFS(snapshotFS fs.FS, snapshotPath string) (fs.FS, error) {
+	if snapshotPath == snapshotRootPath {
+		return snapshotFS, nil
+	}
+	return fs.Sub(snapshotFS, strings.TrimPrefix(snapshotPath, snapshotRootPath))
 }

--- a/subcommands/mount/mount_parse_test.go
+++ b/subcommands/mount/mount_parse_test.go
@@ -2,12 +2,19 @@ package mount
 
 import (
 	"bytes"
+	"io/fs"
 	"testing"
+	"testing/fstest"
 
 	_ "github.com/PlakarKorp/integrations/fs/exporter"
-	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/PlakarKorp/plakar/subcommands"
+	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	snapshotSubFSTestFile    = "a.txt"
+	snapshotSubFSTestContent = "x"
 )
 
 func TestMountRegisteredFactory(t *testing.T) {
@@ -44,6 +51,19 @@ func TestMountParseAllowOthers(t *testing.T) {
 	cmd := &Mount{}
 	require.NoError(t, cmd.Parse(ctx, []string{"-allow-others", "-to", "/mnt/x"}))
 	require.True(t, cmd.AllowOthers)
+}
+
+func TestSnapshotSubFSRootPathUsesSnapshotRoot(t *testing.T) {
+	snapshotFS := fstest.MapFS{
+		snapshotSubFSTestFile: &fstest.MapFile{Data: []byte(snapshotSubFSTestContent)},
+	}
+
+	subFS, err := snapshotSubFS(snapshotFS, snapshotRootPath)
+	require.NoError(t, err)
+
+	data, err := fs.ReadFile(subFS, snapshotSubFSTestFile)
+	require.NoError(t, err)
+	require.Equal(t, []byte(snapshotSubFSTestContent), data)
 }
 
 func TestMountExecuteBadSnapshot(t *testing.T) {


### PR DESCRIPTION
## What
Fix `plakar mount -to <path> <snapshotID>` when the selected snapshot path resolves to the snapshot root. The mount path preparation now keeps the full snapshot filesystem for `/` instead of calling `fs.Sub` with an empty path.

Related to #2086

## Why
A root snapshot selection can produce `/` from `locate.OpenSnapshotByPath`; trimming that to an empty subpath makes `fs.Sub` return `sub : invalid argument` before the mount can proceed.

## Original issue repro status
I re-ran the exact issue steps on unmodified `origin/main` in Docker/Linux. The original symptom was **not reproduced** in this environment: the command got past the `fs.Sub` path and failed later at FUSE mount setup.

```text
snapshot=7adcc28f
/tmp/plakar: mount: fusermount: exit status 1
2026/07/16 16:05:09 mount helper error: fusermount: mount failed: Permission denied
```
Full repro log: `/tmp/see-real-bug_PlakarKorp-plakar_2086_rerun.log`.

So this PR should be treated as a targeted root-path regression fix, not as a fully confirmed reproduction of #2086 on Linux. The issue reporter reproduced on macOS; I do not have a macOS/FUSE environment here to confirm the original `plakar: sub : invalid argument` symptom end-to-end.

## Regression proof (RED -> GREEN)
The regression test exercises the failing root-path branch directly.

RED, after temporarily removing the `/` branch from `snapshotSubFS`:
```text
--- FAIL: TestSnapshotSubFSRootPathUsesSnapshotRoot (0.00s)
    mount_parse_test.go:57:
        Error: Received unexpected error:
               sub : invalid argument
FAIL
FAIL github.com/PlakarKorp/plakar/subcommands/mount 0.016s
```

GREEN after restoring the fix:
```text
ok github.com/PlakarKorp/plakar/subcommands/mount 0.438s
```

## Coverage added
- Added a root-path unit test for the mount snapshot filesystem helper.
- The test fails when the root-path branch is reverted, proving it covers the root-path regression.

## Test plan
- `docker run --rm -v "$PWD":/src -v /tmp/plakar-go-cache:/go/pkg/mod -v /tmp/plakar-go-build:/root/.cache/go-build -w /src golang:1.25 go test ./subcommands/mount -run TestSnapshotSubFSRootPathUsesSnapshotRoot -count=1`
- `docker run --rm -v "$PWD":/src -v /tmp/plakar-go-cache:/go/pkg/mod -v /tmp/plakar-go-build:/root/.cache/go-build -w /src golang:1.25 go test ./subcommands/mount -count=1`
- `docker run --rm -v "$PWD":/src -v /tmp/plakar-go-cache:/go/pkg/mod -v /tmp/plakar-go-build:/root/.cache/go-build -w /src golang:1.25 sh -c 'go build -v ./... && go test ./...'`

Full validation result:
```text
exit:0
go build -v ./...: pass
go test ./...: pass
```
