### PR TITLE
config: reject names containing slashes

### DIFF
--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -36,6 +36,11 @@ import (
 	"gopkg.in/ini.v1"
 )
 
+const (
+	configNamePathSeparator     = "/"
+	invalidConfigurationNameFmt = "invalid configuration name %q: names cannot contain %q"
+)
+
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &ConfigStoreCmd{} },
 		subcommands.BeforeRepositoryOpen, "store")
@@ -49,6 +54,13 @@ func init() {
 
 func normalizeName(name string) string {
 	return strings.TrimPrefix(name, "@")
+}
+
+func validateConfigName(name string) error {
+	if strings.Contains(name, configNamePathSeparator) {
+		return fmt.Errorf(invalidConfigurationNameFmt, name, configNamePathSeparator)
+	}
+	return nil
 }
 
 func normalizeLocation(location string) string {
@@ -98,6 +110,9 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		}
 
 		name, location := normalizeName(args[0]), normalizeLocation(args[1])
+		if err := validateConfigName(name); err != nil {
+			return err
+		}
 
 		if hasFunc(name) {
 			return fmt.Errorf("%s %q already exists", cmd, name)

--- a/subcommands/config/config_extra_test.go
+++ b/subcommands/config/config_extra_test.go
@@ -138,6 +138,23 @@ func TestDispatchAddDuplicateAndMalformed(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDispatchAddRejectsNameWithSlash(t *testing.T) {
+	const (
+		configCommand     = "destination"
+		configSubcommand  = "add"
+		invalidConfigName = "s3://xxxx"
+		configLocation    = "access_key=yyy"
+		expectedError     = "invalid configuration name"
+	)
+
+	ctx, _, _ := newConfigCtx(t)
+
+	err := dispatchSubcommand(ctx, configCommand, configSubcommand, []string{invalidConfigName, configLocation})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), expectedError)
+	require.False(t, ctx.Config.HasDestination(invalidConfigName))
+}
+
 func TestDispatchAddWithOptions(t *testing.T) {
 	ctx, _, _ := newConfigCtx(t)
 	require.NoError(t, dispatchSubcommand(ctx, "store", "add", []string{"r", "fs:/tmp/r", "key=val", "k2=v2"}))


### PR DESCRIPTION
## What

Reject configuration names containing `/` when adding a store, source, or destination configuration.

This prevents commands like `plakar destination add s3://xxxx access_key=yyy` from silently creating a destination named `s3://xxxx` instead of reporting the missing name.

Closes PlakarKorp/plakar#2102

## Test verification (RED -> GREEN)

RED on `origin/main` plus the new test, in Docker (`golang:1.25`):

```text
--- FAIL: TestDispatchAddRejectsNameWithSlash (0.00s)
    config_extra_test.go:151:
        Error:       An error is expected but got nil.
FAIL
FAIL github.com/PlakarKorp/plakar/subcommands/config 0.006s
```

GREEN after the fix, same targeted Docker test:

```text
ok github.com/PlakarKorp/plakar/subcommands/config 0.008s
```

Package validation:

```text
ok github.com/PlakarKorp/plakar/subcommands/config 0.069s
```

## Full validation note

Docker `go build -v ./...` completed successfully. Docker `go test ./...` then failed in `subcommands/pkg` with a Pebble closed-cache panic in `TestPkgCreateExecuteFailsOnBadConnector`:

```text
panic: pebble: closed
FAIL github.com/PlakarKorp/plakar/subcommands/pkg 0.263s
FAIL
```

I checked that failure against clean `origin/main`; the same test also fails there in the same Docker non-root environment:

```text
=== RUN   TestPkgCreateExecuteFailsOnBadConnector
panic: pebble/record: closed LogWriter
FAIL github.com/PlakarKorp/plakar/subcommands/pkg 0.141s
FAIL
```