### PR TITLE
ptar: add ignore options (1811)

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -455,10 +455,6 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 	return 0, nil, snap.Header.Identifier, warning
 }
 
-func LoadIgnoreFile(filename string) ([]string, error) {
-	return utils.LoadIgnoreFile(filename)
-}
-
 func executeHook(ctx *appcontext.AppContext, hook string) error {
 	if hook == "" {
 		return nil

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -17,7 +17,6 @@
 package backup
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"maps"
@@ -149,7 +148,7 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 	}
 
 	for _, ignoreFile := range opt_ignore_files {
-		lines, err := LoadIgnoreFile(ignoreFile)
+		lines, err := utils.LoadIgnoreFile(ignoreFile)
 		if err != nil {
 			return err
 		}
@@ -457,28 +456,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 }
 
 func LoadIgnoreFile(filename string) ([]string, error) {
-	fp, err := os.Open(filename)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open excludes file: %w", err)
-	}
-	defer fp.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(fp)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.Trim(line, " \t\r") == "" {
-			continue
-		}
-		lines = append(lines, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return lines, nil
+	return utils.LoadIgnoreFile(filename)
 }
 
 func executeHook(ctx *appcontext.AppContext, hook string) error {

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -201,21 +201,6 @@ func TestBackupIgnoreFileMissing(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoadIgnoreFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "ignores")
-	content := "# header\n\npat1\npat2\n  \t\n  \t# leading-space comment is NOT stripped\n"
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
-	lines, err := LoadIgnoreFile(path)
-	require.NoError(t, err)
-	require.Equal(t, []string{"pat1", "pat2", "  \t# leading-space comment is NOT stripped"}, lines)
-}
-
-func TestLoadIgnoreFileMissing(t *testing.T) {
-	_, err := LoadIgnoreFile("/no/such/file")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unable to open")
-}
-
 func TestBackupPreHookFailureAbortsBackup(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)

--- a/subcommands/help/docs/plakar-ptar.md
+++ b/subcommands/help/docs/plakar-ptar.md
@@ -9,6 +9,8 @@ PLAKAR-PTAR(1) - General Commands Manual
 **plakar&nbsp;ptar**
 \[**-plaintext**]
 \[**-overwrite**]
+\[**-ignore**&nbsp;*pattern*]
+\[**-ignore-file**&nbsp;*file*]
 \[**-k**&nbsp;*location*]
 **-o**&nbsp;*file.ptar*
 \[*path&nbsp;...*]
@@ -58,6 +60,19 @@ The options are as follows:
 > Overwrite an existing
 > *.ptar*
 > file at the destination path.
+
+**-ignore** *pattern*
+
+> Exclude files matching a gitignore-style pattern while backing up filesystem
+> paths into the archive.
+> May be specified multiple times.
+
+**-ignore-file** *file*
+
+> Read newline-separated gitignore-style patterns from
+> *file*.
+> Blank lines and comments are ignored.
+> May be specified multiple times.
 
 **-k** *location*, **-kloset** *location*
 

--- a/subcommands/ptar/plakar-ptar.1
+++ b/subcommands/ptar/plakar-ptar.1
@@ -8,6 +8,8 @@
 .Nm plakar ptar
 .Op Fl plaintext
 .Op Fl overwrite
+.Op Fl ignore Ar pattern
+.Op Fl ignore-file Ar file
 .Op Fl k Ar location
 .Fl o Ar file.ptar
 .Op Ar path ...
@@ -52,6 +54,15 @@ or prompted interactively.
 Overwrite an existing
 .Pa .ptar
 file at the destination path.
+.It Fl ignore Ar pattern
+Exclude files matching a gitignore-style pattern while backing up filesystem
+paths into the archive.
+May be specified multiple times.
+.It Fl ignore-file Ar file
+Read newline-separated gitignore-style patterns from
+.Ar file .
+Blank lines and comments are ignored.
+May be specified multiple times.
 .It Fl k Ar location , Fl kloset Ar location
 Add a kloset repository to include in the archive.
 May be specified multiple times to bundle several repositories.

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -59,6 +59,7 @@ type Ptar struct {
 	SyncTargets   listFlag
 	SyncSecrets   [][]byte
 	BackupTargets listFlag
+	Excludes      []string
 }
 
 func init() {
@@ -81,6 +82,9 @@ func (l *listFlag) Set(value string) error {
 
 func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 	cmd.KlosetUUID = uuid.Must(uuid.NewRandom())
+	var optIgnoreFiles listFlag
+	var optIgnore listFlag
+	excludes := []string{}
 
 	flags := flag.NewFlagSet("ptar", flag.ExitOnError)
 	flags.Usage = func() {
@@ -95,6 +99,8 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.BoolVar(&cmd.Overwrite, "overwrite", false, "overwrite the ptar archive if it already exists")
 	flags.Var(&cmd.SyncTargets, "k", "add a kloset location to include in the ptar archive (can be specified multiple times)")
 	flags.Var(&cmd.SyncTargets, "kloset", "add a kloset location to include in the ptar archive (can be specified multiple times)")
+	flags.Var(&optIgnoreFiles, "ignore-file", "path to a file containing newline-separated gitignore patterns, treated as -ignore; can be specified multiple times")
+	flags.Var(&optIgnore, "ignore", "gitignore pattern to exclude files, can be specified multiple times to add several exclusion patterns")
 	flags.StringVar(&cmd.KlosetPath, "o", "", "name of the ptar archive to create")
 	flags.Parse(args)
 
@@ -110,6 +116,17 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 		cmd.BackupTargets = make([]string, len(flags.Args()))
 		copy(cmd.BackupTargets, flags.Args())
 	}
+
+	for _, ignoreFile := range optIgnoreFiles {
+		lines, err := utils.LoadIgnoreFile(ignoreFile)
+		if err != nil {
+			return err
+		}
+		excludes = append(excludes, lines...)
+	}
+
+	excludes = append(excludes, optIgnore...)
+	cmd.Excludes = excludes
 
 	for _, syncTarget := range cmd.SyncTargets {
 		var peerSecret []byte
@@ -347,7 +364,9 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 			opts = remote
 		}
 
-		imp, err := importer.NewImporter(ctx.GetInner(), ctx.ImporterOpts(), opts)
+		importerOpts := ctx.ImporterOpts()
+		importerOpts.Excludes = cmd.Excludes
+		imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, opts)
 		if err != nil {
 			return err
 		}
@@ -359,6 +378,10 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 
 		source, err := snapshot.NewSource(ctx, imp)
 		if err != nil {
+			return err
+		}
+
+		if err := source.SetExcludes(cmd.Excludes); err != nil {
 			return err
 		}
 

--- a/subcommands/ptar/ptar_test.go
+++ b/subcommands/ptar/ptar_test.go
@@ -1,11 +1,17 @@
 package ptar
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/PlakarKorp/integrations/ptar/storage"
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	lscmd "github.com/PlakarKorp/plakar/subcommands/ls"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +49,40 @@ func TestExecuteCmdPtarDefault(t *testing.T) {
 	require.Equal(t, 0, status)
 }
 
+func TestExecuteCmdPtarWithIgnoreRules(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpSourceDir := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("project"),
+		ptesting.NewMockDir("project/.git"),
+		ptesting.NewMockDir("project/.venv"),
+		ptesting.NewMockFile("project/readme.md", 0644, "hello"),
+		ptesting.NewMockFile("project/.git/config", 0644, "hidden"),
+		ptesting.NewMockFile("project/.venv/site.py", 0644, "hidden"),
+	})
+	tmpDir := t.TempDir()
+	out := filepath.Join(tmpDir, "ignored.ptar")
+	ignoreFile := filepath.Join(tmpDir, "ptar-ignore")
+	require.NoError(t, os.WriteFile(ignoreFile, []byte(".venv\n"), 0600))
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-plaintext",
+		"-ignore", ".git",
+		"-ignore-file", ignoreFile,
+		"-o", out,
+		filepath.Join(tmpSourceDir, "project"),
+	}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := listPtarContents(t, ctx, out)
+	require.Contains(t, output, "/project/readme.md")
+	require.NotContains(t, output, ".git")
+	require.NotContains(t, output, ".venv")
+}
+
 func TestExecuteCmdPtarWithSync(t *testing.T) {
 	// Create source repository
 	srcRepo, _ := ptesting.GenerateRepository(t, nil, nil, nil)
@@ -75,4 +115,44 @@ func TestExecuteCmdPtarWithSync(t *testing.T) {
 	status, err := subcommand.Execute(ctx, dstRepo)
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
+}
+
+func listPtarContents(t *testing.T, ctx *appcontext.AppContext, path string) string {
+	t.Helper()
+
+	storeConfig := map[string]string{"location": "ptar://" + path}
+	st, serializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
+	require.NoError(t, err)
+	defer st.Close(ctx.GetInner())
+
+	repo, err := repository.New(ctx.GetInner(), nil, st, serializedConfig)
+	require.NoError(t, err)
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	ctx.Stdout = stdout
+	ctx.Stderr = stderr
+	cmd := &lscmd.Ls{}
+	require.NoError(t, cmd.Parse(ctx, nil))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Empty(t, strings.TrimSpace(stderr.String()))
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	require.NotEmpty(t, lines)
+	fields := strings.Fields(lines[0])
+	require.GreaterOrEqual(t, len(fields), 2)
+	snapshotID := fields[1]
+
+	stdout.Reset()
+	stderr.Reset()
+	cmd = &lscmd.Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-recursive", snapshotID}))
+	status, err = cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Empty(t, strings.TrimSpace(stderr.String()))
+
+	return stdout.String()
 }

--- a/utils/ignore_file.go
+++ b/utils/ignore_file.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const unableToOpenExcludesFileError = "unable to open excludes file: %w"
+
+func LoadIgnoreFile(filename string) ([]string, error) {
+	fp, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf(unableToOpenExcludesFileError, err)
+	}
+	defer fp.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(fp)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Trim(line, " \t\r") == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}

--- a/utils/ignore_file_test.go
+++ b/utils/ignore_file_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ignoreFileName          = "ignores"
+	ignoreFileContent       = "# header\n\npat1\npat2\n  \t\n  \t# leading-space comment is NOT stripped\n"
+	ignoreFileMode          = 0o600
+	missingIgnoreFilePath   = "/no/such/file"
+	unableToOpenErrorMarker = "unable to open"
+)
+
+var expectedIgnoreFileLines = []string{"pat1", "pat2", "  \t# leading-space comment is NOT stripped"}
+
+func TestLoadIgnoreFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ignoreFileName)
+	require.NoError(t, os.WriteFile(path, []byte(ignoreFileContent), ignoreFileMode))
+
+	lines, err := LoadIgnoreFile(path)
+	require.NoError(t, err)
+	require.Equal(t, expectedIgnoreFileLines, lines)
+}
+
+func TestLoadIgnoreFileMissing(t *testing.T) {
+	_, err := LoadIgnoreFile(missingIgnoreFilePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), unableToOpenErrorMarker)
+}


### PR DESCRIPTION
## Summary

Fix #1811

- Add `-ignore` and `-ignore-file` options to `plakar ptar` for filesystem sources.
- Apply the same ignore rules to importer options and snapshot source filtering before archiving.
- Move ignore-file parsing into `utils` so `backup` and `ptar` share the behavior, and document the new flags.
- Remove the obsolete `backup.LoadIgnoreFile` wrapper after review; parser coverage now lives with `utils.LoadIgnoreFile`.

## TDD verification

RED check on unmodified `origin/main` with only the new test copied in:

```text
flag provided but not defined: -ignore
Usage: plakar ptar [OPTIONS] -o out.ptar...
FAIL github.com/PlakarKorp/plakar/subcommands/ptar 0.010s
```

GREEN checks on `fix/issue-1811`:

```text
ok github.com/PlakarKorp/plakar/subcommands/ptar 0.188s
ok github.com/PlakarKorp/plakar/subcommands/ptar 10.331s
ok github.com/PlakarKorp/plakar/utils 0.036s
ok github.com/PlakarKorp/plakar/subcommands/backup 9.260s
```

Review follow-up validation:

```text
backup.LoadIgnoreFile removed
ok github.com/PlakarKorp/plakar/utils 0.024s
```

## Full local suite

```text
go build -v ./... -> pass
timeout -s QUIT 15m go test -p 1 ./... -> pass
```

## Files changed

| File | Change |
|------|--------|
| `subcommands/ptar/ptar.go` | Parse and apply ignore rules for ptar filesystem backups. |
| `subcommands/ptar/ptar_test.go` | Cover `-ignore` and `-ignore-file` against archive contents. |
| `utils/ignore_file.go` | Share ignore-file parsing. |
| `utils/ignore_file_test.go` | Cover ignore-file parsing where the shared helper lives. |
| `subcommands/backup/backup.go` | Use the shared parser directly and remove the obsolete wrapper. |
| `subcommands/ptar/plakar-ptar.1`, `subcommands/help/docs/plakar-ptar.md` | Document new flags. |