### PR TITLE
ci: actually propagate tests failure

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,8 +33,8 @@ jobs:
       id: gotest
       continue-on-error: true
       run: |
-        go install github.com/jstemmer/go-junit-report/v2@latest
         set -o pipefail
+        set +e # disable errexit
         # -p 4 caps how many package test binaries run at once. Several
         # packages (api, diag, maintenance) each spin up pebble caches and do
         # real encryption/snapshot work; with the default parallelism they
@@ -42,8 +42,9 @@ jobs:
         # per-test timeout -- which kills the whole package and reports every
         # test in it as failed-to-return to Codecov. Capping concurrency keeps
         # the run both fast and reliable.
-        timeout -s QUIT 5m go test -v -p 4 -coverprofile=coverage.out -covermode=atomic -timeout 2m -json ./... \
-          | "$(go env GOPATH)/bin/go-junit-report" -parser gojson -set-exit-code > junit.xml
+        go install github.com/jstemmer/go-junit-report/v2@latest && \
+          (timeout -s QUIT 5m go test -v -p 4 -coverprofile=coverage.out -covermode=atomic -timeout 2m -json ./... \
+          | "$(go env GOPATH)/bin/go-junit-report" -parser gojson -set-exit-code > junit.xml)
         status=$?
         echo "test_exit=$status" >> "$GITHUB_OUTPUT"
         exit $status


### PR DESCRIPTION
`run` is executed in an environment where `errexit` is set, so if the tests fail, we don't get the chance to execute the rest of the script.

while here, catch the failure also if `go install` fails.

a port of https://github.com/PlakarKorp/kloset/pull/493