### PR TITLE
config: improve restrictions on config names

### DIFF
--- a/subcommands/config/config.go
+++ b/subcommands/config/config.go
@@ -36,11 +36,6 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-const (
-	configNamePathSeparator     = "/"
-	invalidConfigurationNameFmt = "invalid configuration name %q: names cannot contain %q"
-)
-
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &ConfigStoreCmd{} },
 		subcommands.BeforeRepositoryOpen, "store")
@@ -52,15 +47,26 @@ func init() {
 		subcommands.BeforeRepositoryOpen, "policy")
 }
 
-func normalizeName(name string) string {
-	return strings.TrimPrefix(name, "@")
+func validAliasName(name string) bool {
+	if name == "" || name[0] == '-' {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r == '_' || r == '-',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
-func validateConfigName(name string) error {
-	if strings.Contains(name, configNamePathSeparator) {
-		return fmt.Errorf(invalidConfigurationNameFmt, name, configNamePathSeparator)
-	}
-	return nil
+func normalizeName(name string) string {
+	return strings.TrimPrefix(name, "@")
 }
 
 func normalizeLocation(location string) string {
@@ -110,8 +116,8 @@ func dispatchSubcommand(ctx *appcontext.AppContext, cmd string, subcmd string, a
 		}
 
 		name, location := normalizeName(args[0]), normalizeLocation(args[1])
-		if err := validateConfigName(name); err != nil {
-			return err
+		if !validAliasName(name) {
+			return fmt.Errorf("invalid configuration name %q", name)
 		}
 
 		if hasFunc(name) {

--- a/subcommands/config/config_test.go
+++ b/subcommands/config/config_test.go
@@ -26,6 +26,26 @@ func configure(ctx *appcontext.AppContext, cmd string, args []string) error {
 	return nil
 }
 
+func TestValidAliasName(t *testing.T) {
+	suite := map[string]bool{
+		"":         false,
+		"foo":      true,
+		"Fo0_B47":  true,
+		"b@r":      false,
+		"/foo/":    false,
+		"-bar":     false,
+		"b-ar":     true,
+		"s3://foo": false,
+	}
+
+	for name, expect := range suite {
+		got := validAliasName(name)
+		if got != expect {
+			t.Errorf("%s: got %v but expected %v", name, got, expect)
+		}
+	}
+}
+
 func TestConfigEmpty(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)


### PR DESCRIPTION
restrict the valid names to "_a-zA-Z0-9-".