### PR TITLE
restore: add ctime and inode ignore flags

### DIFF
--- a/subcommands/help/docs/plakar-restore.md
+++ b/subcommands/help/docs/plakar-restore.md
@@ -12,6 +12,8 @@ PLAKAR-RESTORE(1) - General Commands Manual
 \[**-job**&nbsp;*job*]
 \[**-name**&nbsp;*name*]
 \[**-perimeter**&nbsp;*perimeter*]
+\[**-ignore-ctime**]
+\[**-ignore-inode**]
 \[**-skip-permissions**]
 \[**-tag**&nbsp;*tag*]
 \[**-to**&nbsp;*directory*]
@@ -71,6 +73,14 @@ The options are as follows:
 
 > Skip restoring file permissions and ownership during restore,
 > defaulting to 0750 for directories and 0640 for files.
+
+**-ignore-ctime**
+
+> Skip restoring stored file timestamps.
+
+**-ignore-inode**
+
+> Skip restoring hardlinks from inode metadata and write separate files instead.
 
 **-to** *directory*
 

--- a/subcommands/restore/plakar-restore.1
+++ b/subcommands/restore/plakar-restore.1
@@ -11,6 +11,8 @@
 .Op Fl job Ar job
 .Op Fl name Ar name
 .Op Fl perimeter Ar perimeter
+.Op Fl ignore-ctime
+.Op Fl ignore-inode
 .Op Fl skip-permissions
 .Op Fl tag Ar tag
 .Op Fl to Ar directory
@@ -55,6 +57,10 @@ Only apply command to snapshots that match
 .It Fl skip-permissions
 Skip restoring file permissions and ownership during restore,
 defaulting to 0750 for directories and 0640 for files.
+.It Fl ignore-ctime
+Skip restoring stored file timestamps.
+.It Fl ignore-inode
+Skip restoring hardlinks from inode metadata and write separate files instead.
 .It Fl to Ar directory
 Specify the base directory to which the files will be restored.
 If omitted, files are restored to the current working directory.

--- a/subcommands/restore/restore.go
+++ b/subcommands/restore/restore.go
@@ -17,6 +17,7 @@
 package restore
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"maps"
@@ -24,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/exporter"
 	"github.com/PlakarKorp/kloset/locate"
 	"github.com/PlakarKorp/kloset/repository"
@@ -31,6 +33,12 @@ import (
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/PlakarKorp/plakar/utils"
+)
+
+const (
+	restoreClearedDeviceID uint64 = 0
+	restoreClearedInodeID  uint64 = 0
+	restoreSingleLinkCount uint16 = 1
 )
 
 type Restore struct {
@@ -43,6 +51,8 @@ type Restore struct {
 	OptJob             string
 	OptTag             string
 	OptSkipPermissions bool
+	OptIgnoreCtime     bool
+	OptIgnoreInode     bool
 	Opts               map[string]string
 
 	Target    string
@@ -76,6 +86,8 @@ func (cmd *Restore) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	flags.StringVar(&pullPath, "to", "", "base directory where pull will restore")
 	flags.BoolVar(&cmd.OptSkipPermissions, "skip-permissions", false, "do not restore file permissions")
+	flags.BoolVar(&cmd.OptIgnoreCtime, "ignore-ctime", false, "do not restore file timestamps")
+	flags.BoolVar(&cmd.OptIgnoreInode, "ignore-inode", false, "do not restore hardlinks from inode metadata")
 	flags.Parse(args)
 
 	if flags.NArg() != 0 {
@@ -173,6 +185,7 @@ func (cmd *Restore) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 		return 1, err
 	}
 	defer exporterInstance.Close(ctx)
+	exporterInstance = newRestoreMetadataExporter(exporterInstance, cmd.OptIgnoreCtime, cmd.OptIgnoreInode, time.Now)
 
 	opts := &snapshot.ExportOptions{}
 	if cmd.OptSkipPermissions {
@@ -202,3 +215,70 @@ func (cmd *Restore) Execute(ctx *appcontext.AppContext, repo *repository.Reposit
 	}
 	return 0, nil
 }
+
+type restoreMetadataExporter struct {
+	exporter.Exporter
+	skipTimes     bool
+	skipHardlinks bool
+	now           func() time.Time
+}
+
+func newRestoreMetadataExporter(exp exporter.Exporter, skipTimes bool, skipHardlinks bool, now func() time.Time) exporter.Exporter {
+	if !skipTimes && !skipHardlinks {
+		return exp
+	}
+	return &restoreMetadataExporter{
+		Exporter:      exp,
+		skipTimes:     skipTimes,
+		skipHardlinks: skipHardlinks,
+		now:           now,
+	}
+}
+
+func (exp *restoreMetadataExporter) Export(ctx context.Context, records <-chan *connectors.Record, results chan<- *connectors.Result) error {
+	filtered := make(chan *connectors.Record)
+	go func() {
+		defer close(filtered)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case record, ok := <-records:
+				if !ok {
+					return
+				}
+
+				select {
+				case <-ctx.Done():
+					return
+				case filtered <- exp.filterRecord(record):
+				}
+			}
+		}
+	}()
+
+	return exp.Exporter.Export(ctx, filtered, results)
+}
+
+func (exp *restoreMetadataExporter) filterRecord(record *connectors.Record) *connectors.Record {
+	if record == nil {
+		return nil
+	}
+
+	filtered := *record
+	fileinfo := filtered.FileInfo
+
+	if exp.skipTimes {
+		fileinfo.LmodTime = exp.now()
+	}
+	if exp.skipHardlinks {
+		fileinfo.Ldev = restoreClearedDeviceID
+		fileinfo.Lino = restoreClearedInodeID
+		fileinfo.Lnlink = restoreSingleLinkCount
+	}
+
+	filtered.FileInfo = fileinfo
+	return &filtered
+}
+
+var _ exporter.Exporter = (*restoreMetadataExporter)(nil)

--- a/subcommands/restore/restore_extra_test.go
+++ b/subcommands/restore/restore_extra_test.go
@@ -1,16 +1,41 @@
 package restore
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/appcontext"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	restoreMetadataFileMode   os.FileMode = 0644
+	restoreMetadataDirMode    os.FileMode = 0755
+	restoreMetadataDeviceID   uint64      = 42
+	restoreMetadataInodeID    uint64      = 9001
+	restoreMetadataHardlinkN  uint16      = 2
+	restoreSnapshotRootPath               = "/metadata"
+	restoreSnapshotFirstPath              = "/metadata/first.txt"
+	restoreSnapshotSecondPath             = "/metadata/second.txt"
+	restoreMetadataRootPath               = "metadata"
+	restoreMetadataFirstPath              = "metadata/first.txt"
+	restoreMetadataSecondPath             = "metadata/second.txt"
+	restoreMetadataContent                = "metadata payload"
+)
+
+var restoreMetadataSnapshotTime = time.Date(2025, time.March, 14, 15, 9, 26, 0, time.UTC)
 
 func mkRestoreDir(t *testing.T) string {
 	t.Helper()
@@ -18,6 +43,40 @@ func mkRestoreDir(t *testing.T) string {
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(dir) })
 	return dir
+}
+
+func generateMetadataSnapshot(t *testing.T) (*repository.Repository, *snapshot.Snapshot, *appcontext.AppContext) {
+	t.Helper()
+
+	repo, ctx := ptesting.GenerateRepository(t, nil, nil, nil)
+	gen := func(records chan<- *connectors.Record) {
+		records <- &connectors.Record{
+			Pathname: restoreSnapshotRootPath,
+			FileInfo: objects.FileInfo{
+				Lname:    filepath.Base(restoreMetadataRootPath),
+				Lmode:    os.ModeDir | restoreMetadataDirMode,
+				LmodTime: restoreMetadataSnapshotTime,
+				Lnlink:   restoreSingleLinkCount,
+			},
+		}
+		for _, pathname := range []string{restoreSnapshotFirstPath, restoreSnapshotSecondPath} {
+			pathname := pathname
+			records <- connectors.NewRecord(pathname, "", objects.FileInfo{
+				Lname:    filepath.Base(pathname),
+				Lsize:    int64(len(restoreMetadataContent)),
+				Lmode:    restoreMetadataFileMode,
+				LmodTime: restoreMetadataSnapshotTime,
+				Ldev:     restoreMetadataDeviceID,
+				Lino:     restoreMetadataInodeID,
+				Lnlink:   restoreMetadataHardlinkN,
+			}, nil, func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader([]byte(restoreMetadataContent))), nil
+			})
+		}
+	}
+
+	snap := ptesting.GenerateSnapshot(t, repo, nil, ptesting.WithGenerator(gen))
+	return repo, snap, ctx
 }
 
 func TestRestoreParseRejectsMultiplePaths(t *testing.T) {
@@ -121,6 +180,70 @@ func TestRestoreSkipPermissionsFlag(t *testing.T) {
 	cmd := &Restore{}
 	require.NoError(t, cmd.Parse(ctx, []string{"-skip-permissions", "-to", "/tmp/x"}))
 	require.True(t, cmd.OptSkipPermissions)
+}
+
+func TestRestoreIgnoreMetadataFlags(t *testing.T) {
+	_, _, ctx := generateSnapshot(t)
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-ignore-ctime", "-ignore-inode", "-to", "/tmp/x"}))
+	require.True(t, cmd.OptIgnoreCtime)
+	require.True(t, cmd.OptIgnoreInode)
+}
+
+func TestRestoreIgnoreCtimeLeavesFreshTimestamps(t *testing.T) {
+	repo, snap, ctx := generateMetadataSnapshot(t)
+	defer snap.Close()
+
+	dir := mkRestoreDir(t)
+	id := snap.Header.GetIndexID()
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-ignore-ctime", "-to", dir, hex.EncodeToString(id[:]) + ":"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	info, err := os.Stat(filepath.Join(dir, restoreMetadataFirstPath))
+	require.NoError(t, err)
+	require.False(t, info.ModTime().Equal(restoreMetadataSnapshotTime), "restore should not preserve snapshot timestamp")
+}
+
+func TestRestorePreservesTimesByDefault(t *testing.T) {
+	repo, snap, ctx := generateMetadataSnapshot(t)
+	defer snap.Close()
+
+	dir := mkRestoreDir(t)
+	id := snap.Header.GetIndexID()
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-to", dir, hex.EncodeToString(id[:]) + ":"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	info, err := os.Stat(filepath.Join(dir, restoreMetadataFirstPath))
+	require.NoError(t, err)
+	require.True(t, info.ModTime().Equal(restoreMetadataSnapshotTime), "restore should preserve snapshot timestamp by default")
+}
+
+func TestRestoreIgnoreInodeWritesSeparateFiles(t *testing.T) {
+	repo, snap, ctx := generateMetadataSnapshot(t)
+	defer snap.Close()
+
+	dir := mkRestoreDir(t)
+	id := snap.Header.GetIndexID()
+	cmd := &Restore{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-ignore-inode", "-to", dir, hex.EncodeToString(id[:]) + ":"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	firstInfo, err := os.Stat(filepath.Join(dir, restoreMetadataFirstPath))
+	require.NoError(t, err)
+	secondInfo, err := os.Stat(filepath.Join(dir, restoreMetadataSecondPath))
+	require.NoError(t, err)
+	require.False(t, os.SameFile(firstInfo, secondInfo), "restore should not recreate hardlinks")
 }
 
 func TestRestoreFilterFlagsAreParsed(t *testing.T) {


### PR DESCRIPTION
Fix #2273

Summary:
- add restore flags `-ignore-ctime` and `-ignore-inode`
- skip restoring stored ctime/lmodtime when requested
- clear hardlink inode metadata when requested so hardlinked entries restore as separate files
- document the new restore flags

RED:
```
go test -buildvcs=false ./subcommands/restore -run "TestRestore(IgnoreMetadataFlags|IgnoreCtimeLeavesFreshTimestamps|PreservesTimesByDefault|IgnoreInodeWritesSeparateFiles)$" -count=1
# github.com/PlakarKorp/plakar/subcommands/restore
restore_extra_test.go: cmd.OptIgnoreCtime undefined
restore_extra_test.go: cmd.OptIgnoreInode undefined
FAIL github.com/PlakarKorp/plakar/subcommands/restore [build failed]
```

GREEN:
```
go test ./subcommands/restore -run "TestRestore(IgnoreMetadataFlags|IgnoreCtimeLeavesFreshTimestamps|PreservesTimesByDefault|IgnoreInodeWritesSeparateFiles)$" -count=1
ok github.com/PlakarKorp/plakar/subcommands/restore 0.744s

go test ./subcommands/restore -count=1
ok github.com/PlakarKorp/plakar/subcommands/restore 3.769s

go build -v ./... && go test -p 4 ./...
# passed
```

Note: one unconstrained `go test ./...` run hit an existing intermittent `task` panic (`send on closed channel`); `go test ./task -count=1` passed on both `origin/main` and this branch, and the CI-style `go test -p 4 ./...` run passed.