### PR TITLE
Surface packfile temp creation failures during backup

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -1,6 +1,9 @@
 package appcontext
 
 import (
+	"context"
+	"errors"
+
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/kcontext"
 	"github.com/PlakarKorp/pkg"
@@ -43,6 +46,15 @@ func NewAppContextFrom(ctx *AppContext) *AppContext {
 // XXX: This needs to go away progressively by migrating to AppContext.
 func (c *AppContext) GetInner() *kcontext.KContext {
 	return c.KContext
+}
+
+func (c *AppContext) ErrorCause(err error) error {
+	if errors.Is(err, context.Canceled) {
+		if cause := context.Cause(c.Context); cause != nil {
+			return cause
+		}
+	}
+	return err
 }
 
 func (c *AppContext) SetSecret(secret []byte) {

--- a/appcontext/appcontext_test.go
+++ b/appcontext/appcontext_test.go
@@ -2,6 +2,8 @@ package appcontext
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +21,25 @@ func TestNewAppContext(t *testing.T) {
 	}
 	if ctx.GetInner() != ctx.KContext {
 		t.Fatal("GetInner did not return the embedded KContext")
+	}
+}
+
+func TestErrorCauseReturnsCancelCause(t *testing.T) {
+	ctx := NewAppContext()
+	cause := errors.New("underlying failure")
+	ctx.Cancel(cause)
+
+	if got := ctx.ErrorCause(context.Canceled); !errors.Is(got, cause) {
+		t.Fatalf("ErrorCause() = %v, want %v", got, cause)
+	}
+}
+
+func TestErrorCauseReturnsOriginalError(t *testing.T) {
+	ctx := NewAppContext()
+	err := errors.New("regular failure")
+
+	if got := ctx.ErrorCause(err); !errors.Is(got, err) {
+		t.Fatalf("ErrorCause() = %v, want %v", got, err)
 	}
 }
 

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -392,6 +392,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		}
 
 		if err := snap.Backup(source); err != nil {
+			err = ctx.ErrorCause(err)
 			if err := executeHook(ctx, cmd.FailHook); err != nil {
 				ctx.GetLogger().Warn("post-backup fail hook failed: %s", err)
 			}
@@ -400,6 +401,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 	}
 
 	if err := snap.Commit(); err != nil {
+		err = ctx.ErrorCause(err)
 		if err := executeHook(ctx, cmd.FailHook); err != nil {
 			ctx.GetLogger().Warn("post-backup fail hook failed: %s", err)
 		}

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -2,6 +2,8 @@ package backup
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,9 +165,6 @@ func TestBackupMultipleIgnoreFileFlags(t *testing.T) {
 	bufErr := bytes.NewBuffer(nil)
 	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
 
-	renderer := stdio.New(ctx)
-	renderer.Run()
-	t.Cleanup(func() { renderer.Wait() })
 	t.Cleanup(ctx.Close)
 	ctx.MaxConcurrency = 1
 
@@ -271,6 +270,27 @@ func TestBackupPackfilesMemory(t *testing.T) {
 	status, err, _, _ := runBackup(t, []string{"-packfiles", "memory"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
+}
+
+func TestBackupPropagatesContextCause(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	cause := errors.New("packfile temp creation failed")
+	ctx.Cancel(cause)
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{tmpBackupDir}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.NotErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, cause)
 }
 
 func TestBackupParsesMultipleIgnoreFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix #2257 by surfacing the real packfile temporary-file creation failure instead of masking it behind `context.Canceled`.

This keeps the default packfile temporary location unchanged (`os.MkdirTemp("", ...)`, normally `/tmp`). When kloset cancels the context with a concrete cause, backup now returns that cause from `snap.Backup()` or `snap.Commit()` failures. The helper lives on `AppContext` so other commands can reuse the same cancellation-cause handling.

## Validation

RED -> GREEN proof:

- RED: with the production helper removed, `go test ./appcontext ./subcommands/backup -run "TestErrorCause|TestBackupPropagatesContextCause" -count=1 -timeout 2m -v` fails because `ctx.ErrorCause` is undefined.
- GREEN: the same targeted command passes with the fix.

Additional local validation:

- `./run-ci.sh` passes in Docker `golang:1.25`.
- `origin/main` full baseline also passes in Docker `golang:1.25`.
