### PR TITLE
backup: clean partial scan cache on create failure

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -68,20 +68,20 @@ type Backup struct {
 	Perimeter           string
 }
 
-const backupScanCacheName = "scan"
+const snapshotWorkCacheName = "scan"
 
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &Backup{} }, 0, "backup")
 }
 
-func cleanupPartialScanCache(ctx *appcontext.AppContext, identifier objects.MAC) {
+func cleanupPartialSnapshotWorkspace(ctx *appcontext.AppContext, identifier objects.MAC) {
 	if ctx.CacheDir == "" || identifier == objects.NilMac {
 		return
 	}
 
-	scanCacheDir := filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, backupScanCacheName, fmt.Sprintf("%x", identifier))
-	if err := os.RemoveAll(scanCacheDir); err != nil {
-		ctx.GetLogger().Warn("failed to remove partial scan cache %s: %s", scanCacheDir, err)
+	snapshotWorkDir := filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, snapshotWorkCacheName, fmt.Sprintf("%x", identifier))
+	if err := os.RemoveAll(snapshotWorkDir); err != nil {
+		ctx.GetLogger().Warn("failed to remove partial snapshot workspace %s: %s", snapshotWorkDir, err)
 	}
 }
 
@@ -321,7 +321,8 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 	snapshotID := objects.RandomMAC()
 	snap, err := snapshot.Create(repo, repository.DefaultType, cmd.PackfileTempStorage, snapshotID, opts)
 	if err != nil {
-		cleanupPartialScanCache(ctx, snapshotID)
+		// snapshot.Create may fail before returning a Builder whose Close cleans this workspace.
+		cleanupPartialSnapshotWorkspace(ctx, snapshotID)
 		ctx.GetLogger().Error("%s", err)
 		return 1, err, objects.MAC{}, nil
 	}

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -22,10 +22,12 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
+	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/connectors/importer"
 	"github.com/PlakarKorp/kloset/events"
@@ -66,8 +68,21 @@ type Backup struct {
 	Perimeter           string
 }
 
+const backupScanCacheName = "scan"
+
 func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &Backup{} }, 0, "backup")
+}
+
+func cleanupPartialScanCache(ctx *appcontext.AppContext, identifier objects.MAC) {
+	if ctx.CacheDir == "" || identifier == objects.NilMac {
+		return
+	}
+
+	scanCacheDir := filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, backupScanCacheName, fmt.Sprintf("%x", identifier))
+	if err := os.RemoveAll(scanCacheDir); err != nil {
+		ctx.GetLogger().Warn("failed to remove partial scan cache %s: %s", scanCacheDir, err)
+	}
 }
 
 type ignoreFlags []string
@@ -303,8 +318,10 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		return 1, fmt.Errorf("pre-backup hook failed: %w", err), objects.MAC{}, nil
 	}
 
-	snap, err := snapshot.Create(repo, repository.DefaultType, cmd.PackfileTempStorage, objects.NilMac, opts)
+	snapshotID := objects.RandomMAC()
+	snap, err := snapshot.Create(repo, repository.DefaultType, cmd.PackfileTempStorage, snapshotID, opts)
 	if err != nil {
+		cleanupPartialScanCache(ctx, snapshotID)
 		ctx.GetLogger().Error("%s", err)
 		return 1, err, objects.MAC{}, nil
 	}

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -19,11 +19,12 @@ import (
 )
 
 const (
-	failingScanCacheMarkerFile  = "partial"
-	failingScanCacheErrMessage  = "scan cache open failed"
-	unexpectedCacheErrMessage   = "unexpected cache constructor call"
-	testPackfileTempStorageMode = "memory"
-	testCacheRootFile           = "cache-root"
+	failingSnapshotWorkspaceMarkerFile = "partial"
+	failingSnapshotWorkspaceErrMessage = "snapshot workspace open failed"
+	unexpectedCacheErrMessage          = "unexpected cache constructor call"
+	testSnapshotWorkCacheName          = "scan"
+	testPackfileTempStorageMode        = "memory"
+	testCacheRootFile                  = "cache-root"
 )
 
 // runBackup is a small wrapper around the standard Parse + Execute flow that
@@ -132,7 +133,7 @@ func TestBackupForcedTimestampInFutureRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "future")
 }
 
-func TestCleanupPartialScanCacheRemovesSnapshotDir(t *testing.T) {
+func TestCleanupPartialSnapshotWorkspaceRemovesSnapshotDir(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 	_, _, ctx := generateFixtures(t, bufOut, bufErr)
@@ -140,29 +141,29 @@ func TestCleanupPartialScanCacheRemovesSnapshotDir(t *testing.T) {
 
 	identifier := objects.RandomMAC()
 	ctx.CacheDir = t.TempDir()
-	scanDir := filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, backupScanCacheName, fmt.Sprintf("%x", identifier))
-	require.NoError(t, os.MkdirAll(scanDir, 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(scanDir, failingScanCacheMarkerFile), []byte(failingScanCacheMarkerFile), 0o600))
+	snapshotWorkDir := filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, snapshotWorkCacheName, fmt.Sprintf("%x", identifier))
+	require.NoError(t, os.MkdirAll(snapshotWorkDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(snapshotWorkDir, failingSnapshotWorkspaceMarkerFile), []byte(failingSnapshotWorkspaceMarkerFile), 0o600))
 
-	cleanupPartialScanCache(ctx, identifier)
+	cleanupPartialSnapshotWorkspace(ctx, identifier)
 
-	_, statErr := os.Stat(scanDir)
-	require.True(t, os.IsNotExist(statErr), "partial scan cache %q should be removed", scanDir)
+	_, statErr := os.Stat(snapshotWorkDir)
+	require.True(t, os.IsNotExist(statErr), "partial snapshot workspace %q should be removed", snapshotWorkDir)
 }
 
-func TestCleanupPartialScanCacheIgnoresUnsetInputs(t *testing.T) {
+func TestCleanupPartialSnapshotWorkspaceIgnoresUnsetInputs(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 	_, _, ctx := generateFixtures(t, bufOut, bufErr)
 	t.Cleanup(ctx.Close)
 
-	cleanupPartialScanCache(ctx, objects.RandomMAC())
+	cleanupPartialSnapshotWorkspace(ctx, objects.RandomMAC())
 
 	ctx.CacheDir = t.TempDir()
-	cleanupPartialScanCache(ctx, objects.NilMac)
+	cleanupPartialSnapshotWorkspace(ctx, objects.NilMac)
 }
 
-func TestCleanupPartialScanCacheWarnsWhenRemovalFails(t *testing.T) {
+func TestCleanupPartialSnapshotWorkspaceWarnsWhenRemovalFails(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 	_, _, ctx := generateFixtures(t, bufOut, bufErr)
@@ -172,29 +173,29 @@ func TestCleanupPartialScanCacheWarnsWhenRemovalFails(t *testing.T) {
 	require.NoError(t, os.WriteFile(cacheRoot, []byte(testCacheRootFile), 0o600))
 	ctx.CacheDir = cacheRoot
 
-	cleanupPartialScanCache(ctx, objects.RandomMAC())
+	cleanupPartialSnapshotWorkspace(ctx, objects.RandomMAC())
 }
 
-func TestBackupCleansPartialScanCacheOnCreateFailure(t *testing.T) {
+func TestBackupCleansPartialSnapshotWorkspaceOnCreateFailure(t *testing.T) {
 	bufOut := bytes.NewBuffer(nil)
 	bufErr := bytes.NewBuffer(nil)
 	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
 	t.Cleanup(ctx.Close)
 
-	scanCacheErr := errors.New(failingScanCacheErrMessage)
+	snapshotWorkspaceErr := errors.New(failingSnapshotWorkspaceErrMessage)
 	cacheRoot := t.TempDir()
-	var scanDir string
+	var snapshotWorkDir string
 
 	ctx.CacheDir = cacheRoot
 	ctx.SetCache(caching.NewManager(func(version, name, repoid string, _ caching.Option) (caching.Cache, error) {
-		if name != backupScanCacheName {
+		if name != testSnapshotWorkCacheName {
 			return nil, errors.New(unexpectedCacheErrMessage)
 		}
 
-		scanDir = filepath.Join(cacheRoot, version, name, filepath.FromSlash(repoid))
-		require.NoError(t, os.MkdirAll(scanDir, 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(scanDir, failingScanCacheMarkerFile), []byte(failingScanCacheMarkerFile), 0o600))
-		return nil, scanCacheErr
+		snapshotWorkDir = filepath.Join(cacheRoot, version, name, filepath.FromSlash(repoid))
+		require.NoError(t, os.MkdirAll(snapshotWorkDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(snapshotWorkDir, failingSnapshotWorkspaceMarkerFile), []byte(failingSnapshotWorkspaceMarkerFile), 0o600))
+		return nil, snapshotWorkspaceErr
 	}))
 
 	cmd := &Backup{}
@@ -202,10 +203,10 @@ func TestBackupCleansPartialScanCacheOnCreateFailure(t *testing.T) {
 
 	status, err := cmd.Execute(ctx, repo)
 	require.Equal(t, 1, status)
-	require.ErrorIs(t, err, scanCacheErr)
+	require.ErrorIs(t, err, snapshotWorkspaceErr)
 
-	_, statErr := os.Stat(scanDir)
-	require.True(t, os.IsNotExist(statErr), "partial scan cache %q should be removed after create failure", scanDir)
+	_, statErr := os.Stat(snapshotWorkDir)
+	require.True(t, os.IsNotExist(statErr), "partial snapshot workspace %q should be removed after create failure", snapshotWorkDir)
 }
 
 func TestBackupTagViaFlag(t *testing.T) {

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/PlakarKorp/kloset/caching"
+	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,7 @@ const (
 	failingScanCacheErrMessage  = "scan cache open failed"
 	unexpectedCacheErrMessage   = "unexpected cache constructor call"
 	testPackfileTempStorageMode = "memory"
+	testCacheRootFile           = "cache-root"
 )
 
 // runBackup is a small wrapper around the standard Parse + Execute flow that
@@ -127,6 +130,49 @@ func TestBackupForcedTimestampInFutureRejected(t *testing.T) {
 	_, err, _, _ := runBackup(t, []string{"-force-timestamp", future}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "future")
+}
+
+func TestCleanupPartialScanCacheRemovesSnapshotDir(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, _, ctx := generateFixtures(t, bufOut, bufErr)
+	t.Cleanup(ctx.Close)
+
+	identifier := objects.RandomMAC()
+	ctx.CacheDir = t.TempDir()
+	scanDir := filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, backupScanCacheName, fmt.Sprintf("%x", identifier))
+	require.NoError(t, os.MkdirAll(scanDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(scanDir, failingScanCacheMarkerFile), []byte(failingScanCacheMarkerFile), 0o600))
+
+	cleanupPartialScanCache(ctx, identifier)
+
+	_, statErr := os.Stat(scanDir)
+	require.True(t, os.IsNotExist(statErr), "partial scan cache %q should be removed", scanDir)
+}
+
+func TestCleanupPartialScanCacheIgnoresUnsetInputs(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, _, ctx := generateFixtures(t, bufOut, bufErr)
+	t.Cleanup(ctx.Close)
+
+	cleanupPartialScanCache(ctx, objects.RandomMAC())
+
+	ctx.CacheDir = t.TempDir()
+	cleanupPartialScanCache(ctx, objects.NilMac)
+}
+
+func TestCleanupPartialScanCacheWarnsWhenRemovalFails(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, _, ctx := generateFixtures(t, bufOut, bufErr)
+	t.Cleanup(ctx.Close)
+
+	cacheRoot := filepath.Join(t.TempDir(), testCacheRootFile)
+	require.NoError(t, os.WriteFile(cacheRoot, []byte(testCacheRootFile), 0o600))
+	ctx.CacheDir = cacheRoot
+
+	cleanupPartialScanCache(ctx, objects.RandomMAC())
 }
 
 func TestBackupCleansPartialScanCacheOnCreateFailure(t *testing.T) {

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -10,9 +10,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	failingScanCacheMarkerFile  = "partial"
+	failingScanCacheErrMessage  = "scan cache open failed"
+	unexpectedCacheErrMessage   = "unexpected cache constructor call"
+	testPackfileTempStorageMode = "memory"
 )
 
 // runBackup is a small wrapper around the standard Parse + Execute flow that
@@ -119,6 +127,39 @@ func TestBackupForcedTimestampInFutureRejected(t *testing.T) {
 	_, err, _, _ := runBackup(t, []string{"-force-timestamp", future}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "future")
+}
+
+func TestBackupCleansPartialScanCacheOnCreateFailure(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+	t.Cleanup(ctx.Close)
+
+	scanCacheErr := errors.New(failingScanCacheErrMessage)
+	cacheRoot := t.TempDir()
+	var scanDir string
+
+	ctx.CacheDir = cacheRoot
+	ctx.SetCache(caching.NewManager(func(version, name, repoid string, _ caching.Option) (caching.Cache, error) {
+		if name != backupScanCacheName {
+			return nil, errors.New(unexpectedCacheErrMessage)
+		}
+
+		scanDir = filepath.Join(cacheRoot, version, name, filepath.FromSlash(repoid))
+		require.NoError(t, os.MkdirAll(scanDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(scanDir, failingScanCacheMarkerFile), []byte(failingScanCacheMarkerFile), 0o600))
+		return nil, scanCacheErr
+	}))
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-packfiles", testPackfileTempStorageMode, "-no-progress", tmpBackupDir}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Equal(t, 1, status)
+	require.ErrorIs(t, err, scanCacheErr)
+
+	_, statErr := os.Stat(scanDir)
+	require.True(t, os.IsNotExist(statErr), "partial scan cache %q should be removed after create failure", scanDir)
 }
 
 func TestBackupTagViaFlag(t *testing.T) {


### PR DESCRIPTION
## Summary
- generate the backup snapshot ID before calling `snapshot.Create` so Plakar can identify the scan cache path for that attempt
- remove only that partial scan cache directory if snapshot creation fails before returning a builder
- add a regression test covering a scan cache constructor that leaves a partial directory before failing

## Testing
- RED before fix: `go test ./subcommands/backup -run TestBackupCleansPartialScanCacheOnCreateFailure -count=1` failed because the partial scan cache directory remained
- GREEN after fix: `go test ./subcommands/backup -run TestBackupCleansPartialScanCacheOnCreateFailure -count=1`
- `go test ./subcommands/backup -count=1`
- `go test ./subcommands/pkg -count=1 && go test ./subcommands/backup -count=1`
- local full runner on patched branch: `go build -v ./...`, `go test -v -p 4 -coverprofile=coverage.out -covermode=atomic -timeout 2m ./...`, `GOOS=windows GOARCH=amd64 go build -v .`

Refs #2254