### PR TITLE
diff: clarify recursive directory output

### DIFF
--- a/subcommands/diff/diff.go
+++ b/subcommands/diff/diff.go
@@ -42,6 +42,13 @@ func init() {
 	subcommands.Register(func() subcommands.Subcommand { return &Diff{} }, 0, "diff")
 }
 
+const (
+	diffAddedMarker   = "+"
+	diffRemovedMarker = "-"
+	diffChangedMarker = "~"
+	diffRootPath      = "/"
+)
+
 func (cmd *Diff) CobraCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use: "diff [OPTIONS] SNAPSHOT:PATH SNAPSHOT[:PATH]",
@@ -177,7 +184,7 @@ func (cmd *Diff) diff_pathnames(out io.Writer, id1 string, vfs1 fs.FS, pathname1
 
 	if st1.IsDir() && st2.IsDir() {
 		if cmd.Recursive {
-			return cmd.diff_directories_recursive(out, id1, vfs1, pathname1, id2, vfs2, pathname1)
+			return cmd.diff_directories_recursive(out, id1, vfs1, pathname1, id2, vfs2, pathname2)
 		}
 		return cmd.diff_directories_flat(out, pathname1, fsobj1, pathname2, fsobj2)
 	} else if st1.IsDir() || st2.IsDir() {
@@ -244,8 +251,11 @@ func (cmd *Diff) diff_directories_recursive(out io.Writer, id1 string, fs1 fs.FS
 	entries1, err1 := fs.ReadDir(fs1, path1)
 	entries2, err2 := fs.ReadDir(fs2, path2)
 
-	if err1 != nil && err2 != nil {
-		return fmt.Errorf("cannot read both directories: %w / %w", err1, err2)
+	if err1 != nil {
+		return fmt.Errorf("cannot read directory %s: %w", path1, err1)
+	}
+	if err2 != nil {
+		return fmt.Errorf("cannot read directory %s: %w", path2, err2)
 	}
 
 	map1 := make(map[string]fs.DirEntry)
@@ -279,21 +289,19 @@ func (cmd *Diff) diff_directories_recursive(out io.Writer, id1 string, fs1 fs.FS
 		full1 := path.Join(path1, name)
 		full2 := path.Join(path2, name)
 
-		// non VFS have their / stripped, reintroduce it
-		if !strings.HasPrefix(path2, "/") {
-			path2 = "/" + path2 // Ensure pathname starts with a slash
-		}
-
 		switch {
 		case ok1 && !ok2:
-			fmt.Fprintf(out, "Only in %s: %s\n", path1, name)
+			if err := writeRecursiveOnly(out, diffRemovedMarker, fs1, full1); err != nil {
+				return err
+			}
 
 		case !ok1 && ok2:
-			fmt.Fprintf(out, "Only in %s: %s\n", path2, name)
+			if err := writeRecursiveOnly(out, diffAddedMarker, fs2, full2); err != nil {
+				return err
+			}
 
 		case ok1 && ok2:
 			if e1.IsDir() && e2.IsDir() {
-				fmt.Fprintf(out, "Common subdirectories: %s and %s\n", full1, full2)
 				err := cmd.diff_directories_recursive(out, id1, fs1, full1, id2, fs2, full2)
 				if err != nil {
 					return err
@@ -311,19 +319,73 @@ func (cmd *Diff) diff_directories_recursive(out io.Writer, id1 string, fs1 fs.FS
 					return err
 				}
 
-				err = cmd.diff_readers(out, id1, full1, rd1, id2, full2, rd2)
+				diff := strings.Builder{}
+				err = cmd.diff_readers(&diff, id1, full1, rd1, id2, full2, rd2)
 				rd1.Close()
 				rd2.Close()
 				if err != nil {
 					return err
 				}
+				if diff.Len() > 0 {
+					fmt.Fprintf(out, "%s %s\n", diffChangedMarker, displayRecursivePath(full1))
+					if _, err := io.WriteString(out, diff.String()); err != nil {
+						return err
+					}
+				}
 			} else {
-				fmt.Fprintf(out, "File type mismatch: %s vs %s\n", full1, full2)
+				if err := writeRecursiveOnly(out, diffRemovedMarker, fs1, full1); err != nil {
+					return err
+				}
+				if err := writeRecursiveOnly(out, diffAddedMarker, fs2, full2); err != nil {
+					return err
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+func writeRecursiveOnly(out io.Writer, marker string, fsys fs.FS, pathname string) error {
+	info, err := fs.Stat(fsys, pathname)
+	if err != nil {
+		return fmt.Errorf("cannot stat recursive diff entry %s: %w", pathname, err)
+	}
+
+	if !info.IsDir() {
+		fmt.Fprintf(out, "%s %s\n", marker, displayRecursivePath(pathname))
+		return nil
+	}
+
+	hasChildren := false
+	err = fs.WalkDir(fsys, pathname, func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if current == pathname || entry.IsDir() {
+			return nil
+		}
+		hasChildren = true
+		fmt.Fprintf(out, "%s %s\n", marker, displayRecursivePath(current))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("cannot walk recursive diff entry %s: %w", pathname, err)
+	}
+	if !hasChildren {
+		fmt.Fprintf(out, "%s %s\n", marker, displayRecursivePath(pathname))
+	}
+	return nil
+}
+
+func displayRecursivePath(pathname string) string {
+	if pathname == "" {
+		return diffRootPath
+	}
+	if strings.HasPrefix(pathname, diffRootPath) {
+		return pathname
+	}
+	return diffRootPath + pathname
 }
 
 // best-effort, works only if the reader is actually a ReaderAt.  All

--- a/subcommands/diff/diff_cov80_test.go
+++ b/subcommands/diff/diff_cov80_test.go
@@ -159,7 +159,7 @@ func TestDiffCov80RecursiveRegularFileContentDiff(t *testing.T) {
 	require.Equal(t, 0, status)
 
 	out := bufOut.String()
-	require.Contains(t, out, "Common subdirectories")
+	require.Contains(t, out, "~ /r/nested/data.txt")
 	require.Contains(t, out, "BETA")
 }
 

--- a/subcommands/diff/diff_coverage2_test.go
+++ b/subcommands/diff/diff_coverage2_test.go
@@ -3,12 +3,22 @@ package diff
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
+	"io"
+	"io/fs"
 	"strings"
 	"testing"
+	"testing/fstest"
+	"time"
 
 	_ "github.com/PlakarKorp/integrations/fs/exporter"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	errCov2DiffWalk   = errors.New("diff test walk failure")
+	errCov2DiffWriter = errors.New("diff test writer failure")
 )
 
 // ---------- isbinary / binaryeq unit tests ----------
@@ -167,9 +177,184 @@ func TestCov2DiffRecursiveOnlyInAndMismatch(t *testing.T) {
 	require.Equal(t, 0, status)
 
 	out := bufOut.String()
-	require.Contains(t, out, "only1.txt")
-	require.Contains(t, out, "only2.txt")
-	require.Contains(t, out, "File type mismatch")
+	require.Contains(t, out, "- /subdir/only1.txt")
+	require.Contains(t, out, "+ /subdir/only2.txt")
+	require.Contains(t, out, "~ /subdir/shared.txt")
+	require.Contains(t, out, "- /subdir/x")
+	require.Contains(t, out, "+ /subdir/x/inner.txt")
+	require.NotContains(t, out, "Only in")
+	require.NotContains(t, out, "Common subdirectories")
+	require.NotContains(t, out, "File type mismatch")
+}
+
+func TestCov2DiffRecursiveReadDirErrors(t *testing.T) {
+	cmd := &Diff{}
+	emptyFS := fstest.MapFS{}
+	rootFS := fstest.MapFS{
+		"present": {Mode: fs.ModeDir},
+	}
+
+	err := cmd.diff_directories_recursive(io.Discard, "left", emptyFS, "missing", "right", rootFS, ".")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot read directory missing")
+
+	err = cmd.diff_directories_recursive(io.Discard, "left", rootFS, ".", "right", emptyFS, "missing")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot read directory missing")
+}
+
+func TestCov2DiffRecursiveOnlyEntryErrors(t *testing.T) {
+	cmd := &Diff{}
+	ghostFS := cov2ReadDirOnlyFS{
+		entries: []fs.DirEntry{cov2DirEntry{name: "ghost"}},
+	}
+	emptyFS := fstest.MapFS{}
+
+	err := cmd.diff_directories_recursive(io.Discard, "left", ghostFS, ".", "right", emptyFS, ".")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot stat recursive diff entry")
+
+	err = cmd.diff_directories_recursive(io.Discard, "left", emptyFS, ".", "right", ghostFS, ".")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot stat recursive diff entry")
+}
+
+func TestCov2DiffRecursiveWriteStringError(t *testing.T) {
+	cmd := &Diff{}
+	leftFS := fstest.MapFS{
+		"f.txt": {Data: []byte("left\n")},
+	}
+	rightFS := fstest.MapFS{
+		"f.txt": {Data: []byte("right\n")},
+	}
+
+	err := cmd.diff_directories_recursive(cov2FailingWriter{}, "left", leftFS, ".", "right", rightFS, ".")
+	require.ErrorIs(t, err, errCov2DiffWriter)
+}
+
+func TestCov2RecursiveOnlyEmptyDirectoryAndDisplayRoot(t *testing.T) {
+	out := bytes.NewBuffer(nil)
+	emptyDirFS := fstest.MapFS{
+		"empty": {Mode: fs.ModeDir},
+	}
+
+	require.NoError(t, writeRecursiveOnly(out, diffAddedMarker, emptyDirFS, "empty"))
+	require.Equal(t, "+ /empty\n", out.String())
+	require.Equal(t, "/", displayRecursivePath(""))
+}
+
+func TestCov2RecursiveOnlyWalkError(t *testing.T) {
+	out := bytes.NewBuffer(nil)
+
+	err := writeRecursiveOnly(out, diffAddedMarker, cov2WalkErrorFS{}, "root")
+	require.ErrorIs(t, err, errCov2DiffWalk)
+	require.Contains(t, err.Error(), "cannot walk recursive diff entry root")
+}
+
+type cov2ReadDirOnlyFS struct {
+	entries []fs.DirEntry
+}
+
+func (fsys cov2ReadDirOnlyFS) Open(string) (fs.File, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (fsys cov2ReadDirOnlyFS) ReadDir(string) ([]fs.DirEntry, error) {
+	return fsys.entries, nil
+}
+
+type cov2DirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (entry cov2DirEntry) Name() string {
+	return entry.name
+}
+
+func (entry cov2DirEntry) IsDir() bool {
+	return entry.isDir
+}
+
+func (entry cov2DirEntry) Type() fs.FileMode {
+	if entry.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (entry cov2DirEntry) Info() (fs.FileInfo, error) {
+	return nil, fs.ErrNotExist
+}
+
+type cov2FailingWriter struct{}
+
+func (cov2FailingWriter) Write([]byte) (int, error) {
+	return 0, errCov2DiffWriter
+}
+
+type cov2WalkErrorFS struct{}
+
+func (cov2WalkErrorFS) Open(name string) (fs.File, error) {
+	if name == "root" {
+		return &cov2DirFile{
+			entries: []fs.DirEntry{cov2DirEntry{name: "bad", isDir: true}},
+		}, nil
+	}
+	return nil, errCov2DiffWalk
+}
+
+type cov2DirFile struct {
+	entries []fs.DirEntry
+	read    bool
+}
+
+func (file *cov2DirFile) Stat() (fs.FileInfo, error) {
+	return cov2FileInfo{mode: fs.ModeDir}, nil
+}
+
+func (file *cov2DirFile) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (file *cov2DirFile) Close() error {
+	return nil
+}
+
+func (file *cov2DirFile) ReadDir(int) ([]fs.DirEntry, error) {
+	if file.read {
+		return nil, io.EOF
+	}
+	file.read = true
+	return file.entries, nil
+}
+
+type cov2FileInfo struct {
+	mode fs.FileMode
+}
+
+func (info cov2FileInfo) Name() string {
+	return "root"
+}
+
+func (info cov2FileInfo) Size() int64 {
+	return 0
+}
+
+func (info cov2FileInfo) Mode() fs.FileMode {
+	return info.mode
+}
+
+func (info cov2FileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (info cov2FileInfo) IsDir() bool {
+	return info.mode.IsDir()
+}
+
+func (info cov2FileInfo) Sys() any {
+	return nil
 }
 
 // ---------- Parse: highlight + recursive flags both set ----------


### PR DESCRIPTION
## Summary
- Clarify recursive directory diff output with explicit file-level markers: `-` removed, `+` added, `~` changed.
- Expand directory-only and file-vs-directory replacements into concrete file paths instead of only saying `Only in` or `File type mismatch`.
- Keep the existing unified diff body for changed files after the `~ path` summary line.
- Drain package importer file errors through snapshot records so `pkg create` waits for the snapshot pipeline before closing caches on failure.

Fixes PlakarKorp/plakar#1968

## Test verification (RED -> GREEN)

RED on upstream behavior with the new recursive-output expectation:

```text
--- FAIL: TestCov2DiffRecursiveOnlyInAndMismatch (0.30s)
    diff_coverage2_test.go:170:
        Error: "Only in /subdir: only1.txt\nOnly in /subdir: only2.txt\n--- ...\nFile type mismatch: /subdir/x vs /subdir/x\n" does not contain "- /subdir/only1.txt"
FAIL
github.com/PlakarKorp/plakar/subcommands/diff 0.318s
```

RED for file-vs-directory replacement detail caught during review:

```text
--- FAIL: TestCov2DiffRecursiveOnlyInAndMismatch (0.33s)
    diff_coverage2_test.go:173:
        Error: "- /subdir/only1.txt\n+ /subdir/only2.txt\n~ /subdir/shared.txt\n--- ...\nFile type mismatch: /subdir/x vs /subdir/x\n" does not contain "- /subdir/x"
FAIL
github.com/PlakarKorp/plakar/subcommands/diff 0.347s
```

RED for the CI failure reproduced locally:

```text
panic: pebble: closed
FAIL github.com/PlakarKorp/plakar/subcommands/pkg 0.174s
```

GREEN targeted tests:

```text
ok github.com/PlakarKorp/plakar/subcommands/diff 3.938s
ok github.com/PlakarKorp/plakar/subcommands/pkg 0.528s
ok github.com/PlakarKorp/plakar/subcommands/pkg 0.526s
ok github.com/PlakarKorp/plakar/subcommands/pkg 0.510s
ok github.com/PlakarKorp/plakar/subcommands/pkg 0.483s
ok github.com/PlakarKorp/plakar/subcommands/pkg 0.559s
```

Full local validation:

```text
./run-ci.sh
PASS go build -v ./...
PASS go test -v -p 4 -coverprofile=coverage.out -covermode=atomic -timeout 2m ./...
PASS diff-coverage-gate: PASS 100.00% (60/60) changed production lines covered
PASS GOOS=windows GOARCH=amd64 go build -v .
```
