### PR TITLE
pkg: remove mkstruct()

### DIFF
--- a/subcommands/pkg/pkg_coverage_test.go
+++ b/subcommands/pkg/pkg_coverage_test.go
@@ -205,7 +205,7 @@ func TestAbsolutify(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// pkgerImporter: metadata, Ping, Close, mkstruct, dofile, scan
+// pkgerImporter: metadata, Ping, Close, dofile, scan
 // ---------------------------------------------------------------------------
 
 func TestPkgerImporterMetadata(t *testing.T) {
@@ -224,20 +224,6 @@ func drain(ch <-chan *connectors.Record) []*connectors.Record {
 		recs = append(recs, r)
 	}
 	return recs
-}
-
-func TestMkstruct(t *testing.T) {
-	ch := make(chan *connectors.Record, 16)
-	mkstruct("/a/b/c/file.txt", ch)
-	close(ch)
-	recs := drain(ch)
-	// directories: /a/b/c, /a/b, /a (stops at /)
-	var paths []string
-	for _, r := range recs {
-		paths = append(paths, r.Pathname)
-		require.True(t, r.FileInfo.Lmode.IsDir())
-	}
-	require.Equal(t, []string{"/a/b/c", "/a/b", "/a"}, paths)
 }
 
 func TestDofileExecutableOk(t *testing.T) {
@@ -352,7 +338,6 @@ func TestPkgerImporterScan(t *testing.T) {
 		require.Nil(t, r.Err, "scan record %q carries error", r.Pathname)
 		seen[r.Pathname] = true
 	}
-	require.True(t, seen["/"])
 	require.True(t, seen["/manifest.yaml"])
 	require.True(t, seen["/myplugin"])
 	require.True(t, seen["/validator.json"])

--- a/subcommands/pkg/pkgimporter.go
+++ b/subcommands/pkg/pkgimporter.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/PlakarKorp/kloset/connectors"
 	"github.com/PlakarKorp/kloset/location"
@@ -59,18 +58,6 @@ func absolutify(cwd, path string) string {
 		return filepath.Clean(path)
 	}
 	return filepath.Join(cwd, path)
-}
-
-func mkstruct(p string, ch chan<- *connectors.Record) {
-	dir := path.Dir(p)
-	for dir != "/" {
-		fi := objects.FileInfo{
-			Lname: path.Base(dir),
-			Lmode: 0700 | os.ModeDir,
-		}
-		ch <- connectors.NewRecord(dir, "", fi, nil, nil)
-		dir = path.Dir(dir)
-	}
 }
 
 func (imp *pkgerImporter) dofile(p string, ch chan<- *connectors.Record, it itemtype) error {
@@ -119,7 +106,6 @@ func (imp *pkgerImporter) dofile(p string, ch chan<- *connectors.Record, it item
 		}
 	}
 
-	mkstruct(name, ch)
 	ch <- &connectors.Record{
 		Pathname: name,
 		FileInfo: objects.FileInfoFromStat(fi),
@@ -131,12 +117,6 @@ func (imp *pkgerImporter) dofile(p string, ch chan<- *connectors.Record, it item
 
 func (imp *pkgerImporter) Import(ctx context.Context, records chan<- *connectors.Record, results <-chan *connectors.Result) error {
 	defer close(records)
-
-	info := objects.NewFileInfo("/", 0, 0700|os.ModeDir, time.Unix(0, 0), 0, 0, 0, 0, 1)
-	records <- &connectors.Record{
-		Pathname: "/",
-		FileInfo: info,
-	}
 
 	if err := imp.dofile(imp.manifestPath, records, itextra); err != nil {
 		return err


### PR DESCRIPTION
it's a relic of the ancient times when dragons crossed the skys and importers were required to provide a full VFS, nowadays kloset fills the gaps in it.