### PR TITLE
mount: set a valid modification time on the root directory

### DIFF
--- a/subcommands/mount/fuse/plakarfs/dir.go
+++ b/subcommands/mount/fuse/plakarfs/dir.go
@@ -70,6 +70,17 @@ func NewDirectory(pfs *plakarFS, vfs fs.FS, parent *Dir, pathname string) (*Dir,
 		}
 		if parent == nil {
 			dir.parent = dir
+			// The root has no backing snapshot entry, so its timestamps would
+			// otherwise stay at the zero value and show up as an invalid date.
+			// Use the mounted directory's time when mounting a single snapshot,
+			// and fall back to the mount time for the snapshot lister.
+			ts := time.Now()
+			if vfs != nil {
+				if st, err := fs.Stat(vfs, "."); err == nil {
+					ts = st.ModTime()
+				}
+			}
+			dir.attr.Ctime, dir.attr.Mtime, dir.attr.Atime = ts, ts, ts
 		}
 		if parent != nil {
 			dir.snapKey = parent.snapKey


### PR DESCRIPTION
The root directory of a mount has no backing snapshot entry, so its timestamps were left at the zero value and showed up as an invalid date (`Aug 30 1754` in #2091).

This sets them from the mounted directory's time when mounting a single snapshot, and falls back to the mount time for the snapshot lister.

Verified by mounting a store:
- lister root now shows the mount time instead of `1754`
- single-snapshot mount (`mount <id>`) root now matches the snapshot's root time from `ls`

Existing subdirectory timestamps were already correct and are unchanged. `go test ./subcommands/mount/...` passes.

Fixes #2091