### PR TITLE
ls: report the errors recorded in a snapshot

### DIFF
--- a/subcommands/ls/ls.go
+++ b/subcommands/ls/ls.go
@@ -21,6 +21,8 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
+	"iter"
+	gopath "path"
 	"strings"
 	"time"
 
@@ -150,8 +152,17 @@ func (cmd *Ls) list_snapshot(ctx *appcontext.AppContext, repo *repository.Reposi
 		return err
 	}
 
+	// Errors recorded during the backup are kept aside from the entries
+	// themselves; list them on stderr, interleaved with the listing.
+	var errs *errorLister
+	defer func() {
+		if errs != nil {
+			errs.close()
+		}
+	}()
+
 	resolved := false
-	return pvfs.WalkDir(pathname, func(path string, d *vfs.Entry, err error) error {
+	err = pvfs.WalkDir(pathname, func(path string, d *vfs.Entry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -165,9 +176,14 @@ func (cmd *Ls) list_snapshot(ctx *appcontext.AppContext, repo *repository.Reposi
 			// right physical path and do our logic on it.
 			resolved = true
 			pathname = d.Path()
+			errs = newErrorLister(pvfs, pathname)
 		}
 		if d.IsDir() && path == pathname {
 			return nil
+		}
+
+		if err := errs.flush(ctx, recursive, pathname, path); err != nil {
+			return err
 		}
 
 		sb, err := d.Info()
@@ -212,4 +228,76 @@ func (cmd *Ls) list_snapshot(ctx *appcontext.AppContext, repo *repository.Reposi
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	if errs == nil {
+		// the walk yielded nothing, so the lister was never set up
+		errs = newErrorLister(pvfs, pathname)
+	}
+	// entries are exhausted, whatever is left only sorts after them
+	return errs.flush(ctx, recursive, pathname, "")
+}
+
+// errorLister walks the errors recorded in a snapshot, which are sorted by
+// pathname, so that they can be merged into the listing of a directory.
+type errorLister struct {
+	next func() (*vfs.ErrorItem, error, bool)
+	stop func()
+
+	item *vfs.ErrorItem
+	err  error
+}
+
+func newErrorLister(pvfs *vfs.Filesystem, beneath string) *errorLister {
+	next, stop := iter.Pull2(pvfs.Errors(beneath))
+	el := &errorLister{next: next, stop: stop}
+	el.advance()
+	return el
+}
+
+func (el *errorLister) close() {
+	el.stop()
+}
+
+func (el *errorLister) advance() {
+	item, err, ok := el.next()
+	switch {
+	case !ok:
+		el.item = nil
+	case err != nil:
+		el.item, el.err = nil, err
+	default:
+		el.item = item
+	}
+}
+
+// flush reports every error that sorts before upto, or all the remaining ones
+// when upto is empty.  Unless the listing is recursive, errors below beneath
+// are skipped: they belong to entries that are not listed either.
+func (el *errorLister) flush(ctx *appcontext.AppContext, recursive bool, beneath, upto string) error {
+	for el.err == nil && el.item != nil {
+		if upto != "" && el.item.Name >= upto {
+			return nil
+		}
+
+		name := el.item.Name
+		if !recursive {
+			if gopath.Dir(name) != beneath {
+				el.advance()
+				continue
+			}
+			name = gopath.Base(name)
+		}
+
+		fmt.Fprintf(ctx.Stderr, "%s: %s\n", utils.SanitizeText(name),
+			utils.SanitizeText(el.item.Error))
+		el.advance()
+	}
+
+	if el.err != nil {
+		return fmt.Errorf("ls: failed to scan errors: %w", el.err)
+	}
+	return nil
 }

--- a/subcommands/ls/ls_test.go
+++ b/subcommands/ls/ls_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -208,4 +210,108 @@ func TestExecuteCmdLsFilterUuid(t *testing.T) {
 	indexId := snap.Header.GetIndexID()
 	require.Equal(t, hex.EncodeToString(indexId[:]), fields[1])
 	require.Equal(t, snap.Header.GetSource(0).Importer.Directory, fields[len(fields)-1])
+}
+
+// errorSnapshot builds a snapshot holding two files whose readers fail during
+// the backup, one directly under /d and one further below, so that the listing
+// of /d has a recorded error both at and below its level.
+func errorSnapshot(t *testing.T) (*repository.Repository, *appcontext.AppContext, *bytes.Buffer, *bytes.Buffer, string) {
+	t.Helper()
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	var mtime time.Time
+	dir := func(pathname, name string) *connectors.Record {
+		return &connectors.Record{
+			Pathname: pathname,
+			FileInfo: objects.NewFileInfo(name, 0, 0700|os.ModeDir, mtime, 0, 0, 0, 0, 1),
+		}
+	}
+	denied := func(pathname, name string) *connectors.Record {
+		return connectors.NewRecord(pathname, "",
+			objects.NewFileInfo(name, 3, 0000, mtime, 0, 0, 0, 0, 1), nil,
+			func() (io.ReadCloser, error) { return nil, os.ErrPermission })
+	}
+
+	gen := func(ch chan<- *connectors.Record) {
+		ch <- dir("/", "/")
+		ch <- dir("/d", "d")
+		ch <- dir("/d/sub", "sub")
+		ch <- connectors.NewRecord("/d/readable.txt", "",
+			objects.NewFileInfo("readable.txt", 5, 0644, mtime, 0, 0, 0, 0, 1), nil,
+			func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("hello")), nil })
+		ch <- denied("/d/denied.txt", "denied.txt")
+		ch <- denied("/d/sub/nested.txt", "nested.txt")
+	}
+
+	snap := ptesting.GenerateSnapshot(t, repo, nil, ptesting.WithGenerator(gen))
+	t.Cleanup(func() { snap.Close() })
+
+	indexID := snap.Header.GetIndexID()
+	bufOut.Reset()
+	bufErr.Reset()
+	return repo, ctx, bufOut, bufErr, hex.EncodeToString(indexID[:])
+}
+
+func TestLsListSnapshotErrors(t *testing.T) {
+	// A plain listing reports the errors of the directory it lists on stderr,
+	// by base name, and leaves out the ones recorded below it.
+	repo, ctx, bufOut, bufErr, id := errorSnapshot(t)
+
+	cmd := &Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{id + ":/d"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.Contains(t, bufOut.String(), "readable.txt")
+
+	errout := bufErr.String()
+	require.Contains(t, errout, "denied.txt: ")
+	require.Contains(t, errout, "permission denied")
+	require.NotContains(t, errout, "nested.txt")
+}
+
+func TestLsListSnapshotErrorsRecursive(t *testing.T) {
+	// A recursive listing reports the errors recorded below the directory too,
+	// by full path, like the entries themselves.
+	repo, ctx, _, bufErr, id := errorSnapshot(t)
+
+	cmd := &Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-recursive", id + ":/d"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	errout := bufErr.String()
+	require.Contains(t, errout, "/d/denied.txt: ")
+	require.Contains(t, errout, "/d/sub/nested.txt: ")
+}
+
+func TestLsListSnapshotNoErrors(t *testing.T) {
+	// A snapshot without recorded errors leaves stderr untouched.
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+	})
+	defer snap.Close()
+	bufOut.Reset()
+	bufErr.Reset()
+
+	cmd := &Ls{}
+	require.NoError(t, cmd.Parse(ctx, []string{hex.EncodeToString(snap.Header.GetIndexShortID()) + ":/subdir"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.Contains(t, bufOut.String(), "dummy.txt")
+	require.Empty(t, bufErr.String())
 }

--- a/subcommands/ls/plakar-ls.1
+++ b/subcommands/ls/plakar-ls.1
@@ -18,6 +18,16 @@ displays the contents of
 .Ar path
 in a specified snapshot.
 .Pp
+Files that could not be read when the snapshot was made are missing
+from the listing.
+When listing the contents of a snapshot,
+.Nm plakar ls
+reports the errors recorded for them on standard error, interleaved
+with the listing.
+Errors recorded below the listed directory are only reported when
+.Fl recursive
+is given.
+.Pp
 In addition to the flags described below,
 .Nm plakar ls
 supports the location flags documented in


### PR DESCRIPTION
`plakar ls SNAPSHOT:PATH` lists the entries of a snapshot, but files that could not be read when the backup ran are simply absent from it, with nothing saying why. The errors recorded for them were only reachable through a separate command, `plakar info -errors`.

This lists them on stderr, merged into the listing on stdout.

`vfs.Errors(beneath)` yields items sorted by pathname, so they merge into the `WalkDir` output directly: before printing an entry, drain every error that sorts before it, then drain what is left once the walk is done.

Errors below the listed directory are only reported for a recursive listing, matching the entries themselves. Names follow the same convention as the listing too: base name for a plain listing, full path for a recursive one.

```
$ plakar ls SNAP:/d
0001-01-01T00:00:00Z -rw-r--r--  0  0  5 B readable.txt
0001-01-01T00:00:00Z drwx------  0  0  0 B sub
denied.txt: permission denied

$ plakar ls -recursive SNAP:/d
0001-01-01T00:00:00Z -rw-r--r--  0  0  5 B /d/readable.txt
0001-01-01T00:00:00Z drwx------  0  0  0 B /d/sub
/d/denied.txt: permission denied
/d/sub/nested.txt: permission denied
```

(`denied.txt` is absent from stdout in both: the file failed during the backup, so it never made it into the vfs.)

The issue also says the `errors` subcommand should go away once this is done. I left that out: it removes user-facing surface that now lives under `plakar info -errors`, and it seemed better to have your call on it than to bundle it here. Happy to follow up with it.

Fixes #1268