### PR TITLE
api: treat missing packfiles as internal errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -58,8 +58,6 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		}
 	case errors.Is(err, repository.ErrBlobNotFound):
 		fallthrough
-	case errors.Is(err, repository.ErrPackfileNotFound):
-		fallthrough
 	case errors.Is(err, fs.ErrNotExist):
 		fallthrough
 	case errors.Is(err, snapshot.ErrNotFound):

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,7 +24,7 @@ func TestHandleErrorMapping(t *testing.T) {
 	}{
 		{"not-readable -> 400", repository.ErrNotReadable, http.StatusBadRequest},
 		{"blob-not-found -> 404", repository.ErrBlobNotFound, http.StatusNotFound},
-		{"packfile-not-found -> 404", repository.ErrPackfileNotFound, http.StatusNotFound},
+		{"packfile-not-found -> 500", repository.ErrPackfileNotFound, http.StatusInternalServerError},
 		{"fs-not-exist -> 404", fs.ErrNotExist, http.StatusNotFound},
 		{"snapshot-not-found -> 404", snapshot.ErrNotFound, http.StatusNotFound},
 		{"non-wrapped fs-not-exist -> 500", errors.New("boom: " + fs.ErrNotExist.Error()), http.StatusInternalServerError},


### PR DESCRIPTION
## Summary
- stop mapping `repository.ErrPackfileNotFound` through the API `not-found` branch
- keep missing snapshots and missing files mapped to HTTP 404
- cover the packfile-not-found mapping in the existing API error table

Fix #1043

## Prior attempt checked
The prior closed attempt was stopped because `ErrPackfileNotFound` could also appear while looking up an unknown snapshot. This patch keeps `snapshot.ErrNotFound` as HTTP 404 and only lets the packfile corruption error fall through to the existing internal-error handler.

## Test verification (RED -> GREEN)
RED on upstream behavior after changing only the expected status in the table test:

```text
--- FAIL: TestHandleErrorMapping (0.00s)
    --- FAIL: TestHandleErrorMapping/packfile-not-found_->_500 (0.00s)
        api_test.go:39:
            	Error:      	Not equal:
            	            	expected: 500
            	            	actual  : 404
FAIL
FAIL	github.com/PlakarKorp/plakar/api	0.014s
```

GREEN targeted after the fix:

```text
ok  	github.com/PlakarKorp/plakar/api	0.014s
```

Full local CI replay:

```text
origin/main baseline: PASS ./run-ci.sh
patched branch:       PASS ./run-ci.sh
patched api package:  ok github.com/PlakarKorp/plakar/api 15.623s
```
