### PR TITLE
api: keep partial vfs search with mime filters

### DIFF
--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -771,9 +771,7 @@ type DownloadQuery struct {
 }
 
 const (
-	mediaTypeSeparator          = "/"
-	mediaTypeParameterSeparator = ";"
-	mediaSubtypeWildcard        = "*"
+	mediaTypeSeparator = "/"
 )
 
 func searchMIMEFilterMatches(filters []string, contentType string) bool {
@@ -783,7 +781,7 @@ func searchMIMEFilterMatches(filters []string, contentType string) bool {
 
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		mediaType = strings.TrimSpace(strings.SplitN(contentType, mediaTypeParameterSeparator, 2)[0])
+		mediaType = strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
 	}
 	targetType, targetSubtype, ok := strings.Cut(mediaType, mediaTypeSeparator)
 	if !ok {
@@ -798,7 +796,7 @@ func searchMIMEFilterMatches(filters []string, contentType string) bool {
 			}
 			continue
 		}
-		if filterType == targetType && (filterSubtype == mediaSubtypeWildcard || filterSubtype == targetSubtype) {
+		if filterType == targetType && (filterSubtype == "*" || filterSubtype == targetSubtype) {
 			return true
 		}
 	}

--- a/api/api_snapshot.go
+++ b/api/api_snapshot.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"mime"
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/PlakarKorp/kloset/caching/lru"
@@ -617,18 +619,32 @@ func (ui *uiserver) snapshotVFSSearch(w http.ResponseWriter, r *http.Request) er
 		path = "/"
 	}
 
+	mimes := r.URL.Query()["mime"]
+	filterMimesAfterSearch := pattern != "" && len(mimes) > 0
+	searchMimes := mimes
+	searchOffset := offset
+	searchLimit := limit
+	if filterMimesAfterSearch {
+		searchMimes = nil
+		searchOffset = 0
+		searchLimit = 0
+	}
+
 	// for pagination: fetch one more item so we know
 	// whether there's a next page of results.
 	limit++
+	if !filterMimesAfterSearch {
+		searchLimit = limit
+	}
 
 	searchOpts := snapshot.SearchOpts{
 		Recursive:  r.URL.Query().Get("recursive") == "true",
-		Mimes:      r.URL.Query()["mime"],
+		Mimes:      searchMimes,
 		Prefix:     path,
 		NameFilter: pattern,
 
-		Offset: offset,
-		Limit:  limit,
+		Offset: searchOffset,
+		Limit:  searchLimit,
 	}
 
 	items := ItemsPage[*vfs.Entry]{
@@ -640,6 +656,7 @@ func (ui *uiserver) snapshotVFSSearch(w http.ResponseWriter, r *http.Request) er
 		return err
 	}
 
+	var filteredOffset int
 	for entry, err := range it {
 		if err != nil {
 			if err == context.Canceled {
@@ -648,7 +665,20 @@ func (ui *uiserver) snapshotVFSSearch(w http.ResponseWriter, r *http.Request) er
 			return err
 		}
 
+		if filterMimesAfterSearch {
+			if !searchMIMEFilterMatches(mimes, entry.GetContentType()) {
+				continue
+			}
+			if filteredOffset < offset {
+				filteredOffset++
+				continue
+			}
+		}
+
 		items.Items = append(items.Items, entry)
+		if filterMimesAfterSearch && len(items.Items) >= limit {
+			break
+		}
 	}
 
 	if limit == len(items.Items) {
@@ -738,6 +768,41 @@ type DownloadQuery struct {
 	Name   string         `json:"name"`
 	Items  []DownloadItem `json:"items"`
 	Rebase bool           `json:"rebase,omitempty"`
+}
+
+const (
+	mediaTypeSeparator          = "/"
+	mediaTypeParameterSeparator = ";"
+	mediaSubtypeWildcard        = "*"
+)
+
+func searchMIMEFilterMatches(filters []string, contentType string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.SplitN(contentType, mediaTypeParameterSeparator, 2)[0])
+	}
+	targetType, targetSubtype, ok := strings.Cut(mediaType, mediaTypeSeparator)
+	if !ok {
+		return false
+	}
+
+	for _, filter := range filters {
+		filterType, filterSubtype, ok := strings.Cut(filter, mediaTypeSeparator)
+		if !ok {
+			if filterType == targetType {
+				return true
+			}
+			continue
+		}
+		if filterType == targetType && (filterSubtype == mediaSubtypeWildcard || filterSubtype == targetSubtype) {
+			return true
+		}
+	}
+	return false
 }
 
 func (ui *uiserver) snapshotVFSDownloader(w http.ResponseWriter, r *http.Request) error {

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -74,6 +74,12 @@ func TestSnapshot(t *testing.T) {
 		require.Contains(t, w.Body.String(), "has_next")
 	})
 
+	t.Run("vfs search mime filter keeps partial name match", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/?recursive=true&pattern=CODE&mime=text/plain&limit=10")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), searchFixtureConductFile)
+	})
+
 	t.Run("vfs search non recursive", func(t *testing.T) {
 		// non-recursive search of a directory.
 		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=10")

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -77,7 +77,7 @@ func TestSnapshot(t *testing.T) {
 	t.Run("vfs search mime filter keeps partial name match", func(t *testing.T) {
 		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/?recursive=true&pattern=CODE&mime=text/plain&limit=10")
 		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		require.Contains(t, w.Body.String(), searchFixtureConductFile)
+		require.Contains(t, w.Body.String(), "CODE_OF_CONDUCT")
 	})
 
 	t.Run("vfs search non recursive", func(t *testing.T) {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const searchFixtureConductFile = "CODE_OF_CONDUCT"
+
 // server builds a real repository with a richer snapshot than newAPIServer
 // (nested dirs, multiple files) and wires SetupRoutes with norefresh=true.
 // Distinct name to avoid clashing with the team's newAPIServer helper.
@@ -31,6 +33,7 @@ func server(t *testing.T, token string) (*http.ServeMux, *repository.Repository,
 		ptesting.NewMockDir("subdir/nested"),
 		ptesting.NewMockFile("subdir/nested/deep.txt", 0644, "deep content"),
 		ptesting.NewMockFile("top.txt", 0644, "top level"),
+		ptesting.NewMockFile(searchFixtureConductFile, 0644, "project conduct"),
 	})
 	mux := http.NewServeMux()
 	SetupRoutes(mux, repo, ctx, token, true /* norefresh */)

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const searchFixtureConductFile = "CODE_OF_CONDUCT"
-
 // server builds a real repository with a richer snapshot than newAPIServer
 // (nested dirs, multiple files) and wires SetupRoutes with norefresh=true.
 // Distinct name to avoid clashing with the team's newAPIServer helper.
@@ -33,7 +31,7 @@ func server(t *testing.T, token string) (*http.ServeMux, *repository.Repository,
 		ptesting.NewMockDir("subdir/nested"),
 		ptesting.NewMockFile("subdir/nested/deep.txt", 0644, "deep content"),
 		ptesting.NewMockFile("top.txt", 0644, "top level"),
-		ptesting.NewMockFile(searchFixtureConductFile, 0644, "project conduct"),
+		ptesting.NewMockFile("CODE_OF_CONDUCT", 0644, "project conduct"),
 	})
 	mux := http.NewServeMux()
 	SetupRoutes(mux, repo, ctx, token, true /* norefresh */)


### PR DESCRIPTION
## Summary
- preserve partial filename matching for `/api/snapshot/vfs/search` when a MIME filter is also present
- bypass the MIME-index search path only for `pattern + mime`, then apply MIME filtering in the API before pagination
- add a regression fixture and test for `CODE` matching `CODE_OF_CONDUCT` with `mime=text/plain`

Fix #1304

## Test verification (RED -> GREEN)
RED on upstream behavior with the new API regression test:

```text
--- FAIL: TestSnapshotVFSSearchMimeFilterKeepsPartialNameMatch (0.19s)
    api_snapshot_test.go:117:
        	Error:      	"{\"has_next\":false,\"items\":[]}\n" does not contain "CODE_OF_CONDUCT"
FAIL
FAIL	github.com/PlakarKorp/plakar/api	0.208s
```

GREEN targeted after the fix:

```text
ok  	github.com/PlakarKorp/plakar/api	0.200s
```

Package and full local CI replay:

```text
go test ./api -count=1
ok  	github.com/PlakarKorp/plakar/api	13.599s

origin/main baseline at 693723b4: build, vet, and full tests PASS
patched branch at a9606108:      build, vet, and full tests PASS
local replay note: both trees report the same pre-existing gofmt file list
patched focused regression:      ok github.com/PlakarKorp/plakar/api 0.157s
```