### PR TITLE
api: list repository sources

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -197,6 +197,7 @@ func SetupRoutes(server *http.ServeMux, repo *repository.Repository, ctx *appcon
 	server.Handle("GET /api/repository/snapshots", authToken(JSONAPIView(ui.repositorySnapshots)))
 	server.Handle("GET /api/repository/locate-pathname", authToken(JSONAPIView(ui.repositoryLocatePathname)))
 	server.Handle("GET /api/repository/importer-types", authToken(JSONAPIView(ui.repositoryImporterTypes)))
+	server.Handle("GET /api/repository/sources", authToken(JSONAPIView(ui.repositorySources)))
 
 	server.Handle("GET /api/snapshot/{snapshot}", authToken(JSONAPIView(ui.snapshotHeader)))
 	server.Handle("GET /api/snapshot/reader/{snapshot_path...}", urlSigner.VerifyMiddleware(APIView(ui.snapshotReader)))

--- a/api/api_repository.go
+++ b/api/api_repository.go
@@ -36,6 +36,12 @@ type RepositoryInfoResponse struct {
 	Browsable     bool                    `json:"browsable"`
 }
 
+type RepositorySource struct {
+	Type      string `json:"type"`
+	Origin    string `json:"origin"`
+	Directory string `json:"directory"`
+}
+
 func getNSnapshotsPerDay(repo *repository.Repository, ndays int) ([]int, error) {
 	nSnapshotsPerDay := make([]int, ndays)
 	for snapshotID, err := range repo.ListSnapshots() {
@@ -253,6 +259,55 @@ func (ui *uiserver) repositoryImporterTypes(w http.ResponseWriter, r *http.Reque
 	}
 
 	return json.NewEncoder(w).Encode(items)
+}
+
+func (ui *uiserver) repositorySources(w http.ResponseWriter, r *http.Request) error {
+	if !ui.norefresh {
+		if _, err := cached.RebuildStateFromStore(ui.ctx, ui.repository.Configuration().RepositoryID, ui.ctx.StoreConfig, false); err != nil {
+			return err
+		}
+	}
+
+	sourcesMap := make(map[RepositorySource]struct{})
+	for snapshotID, err := range ui.repository.ListSnapshots() {
+		if err != nil {
+			// XXX - temporarily ignore errors in List snapshots iteration, it is safe here
+			continue
+		}
+
+		snap, err := snapshot.Load(ui.repository, snapshotID)
+		if err != nil {
+			return err
+		}
+
+		for _, source := range snap.Header.Sources {
+			sourcesMap[RepositorySource{
+				Type:      source.Importer.Type,
+				Origin:    source.Importer.Origin,
+				Directory: source.Importer.Directory,
+			}] = struct{}{}
+		}
+		snap.Close()
+	}
+
+	sources := make([]RepositorySource, 0, len(sourcesMap))
+	for source := range sourcesMap {
+		sources = append(sources, source)
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		if sources[i].Type != sources[j].Type {
+			return sources[i].Type < sources[j].Type
+		}
+		if sources[i].Origin != sources[j].Origin {
+			return sources[i].Origin < sources[j].Origin
+		}
+		return sources[i].Directory < sources[j].Directory
+	})
+
+	return json.NewEncoder(w).Encode(Items[RepositorySource]{
+		Total: len(sources),
+		Items: sources,
+	})
 }
 
 type TimelineLocation struct {

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"testing"
 
+	"github.com/PlakarKorp/kloset/caching"
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/kloset/resources"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +25,7 @@ func TestRepositoryEmpty(t *testing.T) {
 		for _, path := range []string{
 			"/api/repository/snapshots",
 			"/api/repository/importer-types",
+			"/api/repository/sources",
 			"/api/repository/locate-pathname",
 			"/api/repository/info",
 		} {
@@ -67,6 +73,94 @@ func TestRepository(t *testing.T) {
 		var items Items[map[string]string]
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
 		require.Equal(t, items.Total, len(items.Items))
+	})
+
+	t.Run("sources", func(t *testing.T) {
+		repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+		snap := ptesting.GenerateSnapshot(t, repo, nil)
+		defer snap.Close()
+		secondSnap := ptesting.GenerateSnapshot(t, repo, nil, ptesting.WithName("second"))
+		defer secondSnap.Close()
+		baseSource := snap.Header.Sources[0]
+		sortByType := baseSource
+		sortByType.Importer.Type = "a"
+		sortByType.Importer.Origin = "z"
+		sortByType.Importer.Directory = "z"
+		sortByOrigin := sortByType
+		sortByOrigin.Importer.Origin = "a"
+		sortByDirectory := sortByOrigin
+		sortByDirectory.Importer.Directory = "a"
+		snap.Header.Sources = append(snap.Header.Sources, sortByType, sortByOrigin, sortByDirectory)
+		serializedHeader, err := snap.Header.Serialize()
+		require.NoError(t, err)
+		cache, err := repo.AppContext().GetCache().Repository(repo.Configuration().RepositoryID)
+		require.NoError(t, err)
+		require.NoError(t, cache.PutSnapshot(snap.Header.Identifier, serializedHeader))
+
+		mux := http.NewServeMux()
+		SetupRoutes(mux, repo, ctx, "", true)
+
+		w := get(t, mux, "/api/repository/sources")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var items Items[RepositorySource]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.Equal(t, []RepositorySource{
+			{Type: "a", Origin: "a", Directory: "a"},
+			{Type: "a", Origin: "a", Directory: "z"},
+			{Type: "a", Origin: "z", Directory: "z"},
+			{Type: baseSource.Importer.Type, Origin: baseSource.Importer.Origin, Directory: baseSource.Importer.Directory},
+		}, items.Items)
+		require.Equal(t, len(items.Items), items.Total)
+	})
+
+	t.Run("sources refresh error", func(t *testing.T) {
+		repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+		mux := http.NewServeMux()
+		SetupRoutes(mux, repo, ctx, "", false)
+
+		w := get(t, mux, "/api/repository/sources")
+		require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("sources snapshot load error", func(t *testing.T) {
+		repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+		snap := ptesting.GenerateSnapshot(t, repo, nil)
+		packfiles, err := snap.ListPackfiles()
+		require.NoError(t, err)
+		packfile, err := func() (objects.MAC, error) {
+			for packfile, err := range packfiles {
+				return packfile, err
+			}
+			return objects.MAC{}, nil
+		}()
+		require.NoError(t, err)
+		require.NotEqual(t, objects.MAC{}, packfile)
+		cache, err := repo.AppContext().GetCache().Repository(repo.Configuration().RepositoryID)
+		require.NoError(t, err)
+		require.NoError(t, cache.DelSnapshot(snap.Header.Identifier))
+		require.NoError(t, repo.Store().Delete(repo.AppContext(), storage.StorageResourcePackfile, packfile))
+		require.NoError(t, snap.Close())
+
+		mux := http.NewServeMux()
+		SetupRoutes(mux, repo, ctx, "", true)
+		w := get(t, mux, "/api/repository/sources")
+		require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("sources snapshot list error", func(t *testing.T) {
+		repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
+		snap := ptesting.GenerateSnapshot(t, repo, nil)
+		require.NoError(t, snap.Close())
+		stateCache, err := caching.NewSQLState(filepath.Join(ctx.CacheDir, caching.CACHE_VERSION, "store", repo.Configuration().RepositoryID.String()), false)
+		require.NoError(t, err)
+		require.NoError(t, stateCache.PutDelta(resources.RT_SNAPSHOT, objects.MAC{1}, objects.MAC{2}, []byte("invalid delta")))
+
+		mux := http.NewServeMux()
+		SetupRoutes(mux, repo, ctx, "", true)
+		w := get(t, mux, "/api/repository/sources")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), `"total":1`)
 	})
 
 	t.Run("snapshots", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `GET /api/repository/sources`.
- Return the distinct snapshot source triplets as `{type, origin, directory}` entries.
- Keep the response shape consistent with the other repository list endpoints: `total` plus `items`.
- Endpoint and test values are inlined, as requested in review — the diff introduces no named constant.
- Covers refresh, iterator, load-error, deduplication and ordering paths.

Rebased onto current `main` and squashed into a single commit, so the PR diff is the whole change.

| Q | A |
| --- | --- |
| Issues | Fix #1223 |
| Tests | `go test ./api -run TestRepository -count=1`; full local replay of `go.yml` + `go-windows.yml` |

## Test verification (RED -> GREEN)

RED — probe on unmodified `origin/main`, the route does not exist:

```text
=== RUN   TestRepositorySourcesRED
    Error:      	Not equal:
    	            	expected: 200
    	            	actual  : 404
    	Messages:   	body={"error":{"code":"not-found","message":"API endpoint not found"}}
--- FAIL: TestRepositorySourcesRED (0.14s)
FAIL	github.com/PlakarKorp/plakar/api	0.162s
```

GREEN — with this change:

```text
--- PASS: TestRepository/sources (0.26s)
--- PASS: TestRepository/sources_refresh_error (0.07s)
--- PASS: TestRepository/sources_snapshot_load_error (0.18s)
--- PASS: TestRepository/sources_snapshot_list_error (0.14s)
ok  	github.com/PlakarKorp/plakar/api	0.881s
```

Full local CI replay (`go build -v ./...`, `go build tool`, `GOOS=windows` build, `go vet`, `timeout -s QUIT 5m go test -p 4 -coverprofile -covermode=atomic ./...`) on the upstream baseline and on this commit:

```text
baseline (origin/main): 1289 passed, 0 failed
final   (this commit):  1293 passed, 0 failed
diff-coverage-gate: PASS 100.00% (39/39) changed production lines covered
```

## Open point

Left the snapshot cap out on purpose: it changes what the endpoint reports, and the bound depends on what the dashboard actually needs — happy to add it once @brmzkw / @decarheil weigh in on the format.
