### PR TITLE
login: report auth rate limits as 429

### DIFF
--- a/api/api_authentication.go
+++ b/api/api_authentication.go
@@ -40,7 +40,7 @@ func (ui *uiserver) servicesLoginGithub(w http.ResponseWriter, r *http.Request) 
 
 	redirectURL, err := lf.RunUI("github", parameters)
 	if err != nil {
-		return fmt.Errorf("failed to run login flow: %w", err)
+		return loginFlowError(err)
 	}
 
 	ret := struct {
@@ -70,7 +70,7 @@ func (ui *uiserver) servicesLoginEmail(w http.ResponseWriter, r *http.Request) e
 
 	redirectURL, err := lf.RunUI("email", parameters)
 	if err != nil {
-		return fmt.Errorf("failed to run login flow: %w", err)
+		return loginFlowError(err)
 	}
 
 	ret := struct {
@@ -79,6 +79,18 @@ func (ui *uiserver) servicesLoginEmail(w http.ResponseWriter, r *http.Request) e
 		URL: redirectURL,
 	}
 	return json.NewEncoder(w).Encode(ret)
+}
+
+func loginFlowError(err error) error {
+	var statusErr *login.HTTPStatusError
+	if errors.As(err, &statusErr) && statusErr.RateLimited() {
+		return &ApiError{
+			HttpCode: http.StatusTooManyRequests,
+			ErrCode:  "rate-limited",
+			Message:  "Rate limit reached. Please retry later.",
+		}
+	}
+	return fmt.Errorf("failed to run login flow: %w", err)
 }
 
 func (ui *uiserver) servicesLogout(w http.ResponseWriter, r *http.Request) error {

--- a/api/api_authentication.go
+++ b/api/api_authentication.go
@@ -82,8 +82,7 @@ func (ui *uiserver) servicesLoginEmail(w http.ResponseWriter, r *http.Request) e
 }
 
 func loginFlowError(err error) error {
-	var statusErr *login.HTTPStatusError
-	if errors.As(err, &statusErr) && statusErr.RateLimited() {
+	if errors.Is(err, login.ErrRateLimited) {
 		return &ApiError{
 			HttpCode: http.StatusTooManyRequests,
 			ErrCode:  "rate-limited",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -4,20 +4,19 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	_ "github.com/PlakarKorp/integrations/fs/exporter"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/plakar/login"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
-
-const loginLimitReachedResponse = `{"error":"OpError[limit-reached] Limit reached"}`
 
 func TestHandleErrorMapping(t *testing.T) {
 	cases := []struct {
@@ -124,25 +123,19 @@ func TestApiInfoAuthenticated(t *testing.T) {
 	require.NotEmpty(t, resp.RepositoryId)
 }
 
-func TestServicesLoginEmailRateLimitReturnsTooManyRequests(t *testing.T) {
-	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/auth/login/email", r.URL.Path)
-		w.WriteHeader(http.StatusInternalServerError)
-		_, err := w.Write([]byte(loginLimitReachedResponse))
-		require.NoError(t, err)
-	}))
-	defer authServer.Close()
+func TestLoginFlowErrorMapsRateLimitTo429(t *testing.T) {
+	err := loginFlowError(fmt.Errorf("failed to run login flow: %w", login.ErrRateLimited))
 
-	t.Setenv("PLAKAR_API_URL", authServer.URL)
+	var apiErr *ApiError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusTooManyRequests, apiErr.HttpCode)
+	require.Equal(t, "rate-limited", apiErr.ErrCode)
+}
 
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+func TestLoginFlowErrorPassesThroughOtherErrors(t *testing.T) {
+	err := loginFlowError(errors.New("boom"))
 
-	req, err := http.NewRequest("POST", "/api/authentication/login/email", strings.NewReader(`{"email":"user@example.com"}`))
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusTooManyRequests, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "rate-limited")
+	var apiErr *ApiError
+	require.False(t, errors.As(err, &apiErr), "non-rate-limit error must not be mapped to an ApiError")
+	require.ErrorContains(t, err, "boom")
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	_ "github.com/PlakarKorp/integrations/fs/exporter"
@@ -15,6 +16,8 @@ import (
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
+
+const loginLimitReachedResponse = `{"error":"OpError[limit-reached] Limit reached"}`
 
 func TestHandleErrorMapping(t *testing.T) {
 	cases := []struct {
@@ -119,4 +122,27 @@ func TestApiInfoAuthenticated(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.True(t, resp.Authenticated)
 	require.NotEmpty(t, resp.RepositoryId)
+}
+
+func TestServicesLoginEmailRateLimitReturnsTooManyRequests(t *testing.T) {
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/auth/login/email", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err := w.Write([]byte(loginLimitReachedResponse))
+		require.NoError(t, err)
+	}))
+	defer authServer.Close()
+
+	t.Setenv("PLAKAR_API_URL", authServer.URL)
+
+	mux, _, snap, _ := server(t, "")
+	defer snap.Close()
+
+	req, err := http.NewRequest("POST", "/api/authentication/login/email", strings.NewReader(`{"email":"user@example.com"}`))
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusTooManyRequests, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "rate-limited")
 }

--- a/login/login.go
+++ b/login/login.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -38,6 +39,23 @@ type TokenResponse struct {
 // (via the baseURL field) so tests can point the login flow at a local server.
 const defaultBaseURL = "https://api.plakar.io"
 
+const plakarAPIURLEnv = "PLAKAR_API_URL"
+
+const rateLimitErrorMarker = "limit-reached"
+
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (err *HTTPStatusError) Error() string {
+	return fmt.Sprintf("unexpected status code: %d : %s", err.StatusCode, err.Body)
+}
+
+func (err *HTTPStatusError) RateLimited() bool {
+	return err.StatusCode == http.StatusTooManyRequests || strings.Contains(err.Body, rateLimitErrorMarker)
+}
+
 type loginFlow struct {
 	appCtx  *appcontext.AppContext
 	noSpawn bool
@@ -45,12 +63,29 @@ type loginFlow struct {
 }
 
 func NewLoginFlow(appCtx *appcontext.AppContext, noSpawn bool) (*loginFlow, error) {
+	baseURL := defaultBaseURL
+	if envURL := os.Getenv(plakarAPIURLEnv); envURL != "" {
+		baseURL = envURL
+	}
+
 	flow := &loginFlow{
 		appCtx:  appCtx,
 		noSpawn: noSpawn,
-		baseURL: defaultBaseURL,
+		baseURL: baseURL,
 	}
 	return flow, nil
+}
+
+func unexpectedStatusError(resp *http.Response) error {
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read error response body: %w", err)
+	}
+	return &HTTPStatusError{
+		StatusCode: resp.StatusCode,
+		Body:       string(data),
+	}
 }
 
 func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, progressCb func()) (string, error) {
@@ -71,20 +106,22 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 			if err != nil {
 				return "", fmt.Errorf("the /auth/login/github/poll API endpoint failed: %w", err)
 			}
-			// leaking resp for now
 			switch resp.StatusCode {
 			case http.StatusOK:
+				defer resp.Body.Close()
 				var tokenResponse TokenResponse
 				if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
 					return "", fmt.Errorf("failed to decode response JSON: %v", err)
 				}
 				return tokenResponse.Token, nil
 			case http.StatusNotFound:
+				resp.Body.Close()
 				return "", fmt.Errorf("unknown ID")
 			case http.StatusAccepted:
+				resp.Body.Close()
 				progressCb()
 			default:
-				return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+				return "", unexpectedStatusError(resp)
 			}
 		}
 		tick = time.After(delay)
@@ -115,12 +152,11 @@ func (flow *loginFlow) Run(provider string, parameters map[string]string) (strin
 	if err != nil {
 		return "", fmt.Errorf("unable to get the login URL: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		data, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("unexpected status code: %d : %s", resp.StatusCode, data)
+		return "", unexpectedStatusError(resp)
 	}
+	defer resp.Body.Close()
 
 	switch provider {
 	case "github":
@@ -192,12 +228,11 @@ func (flow *loginFlow) RunUI(provider string, parameters map[string]string) (str
 	if err != nil {
 		return "", fmt.Errorf("unable to get the login URL: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		data, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("unexpected status code: %d : %s", resp.StatusCode, data)
+		return "", unexpectedStatusError(resp)
 	}
+	defer resp.Body.Close()
 
 	switch provider {
 	case "github":
@@ -261,7 +296,7 @@ func DeriveToken(ctx *appcontext.AppContext) (string, error) {
 		return "", err
 	}
 
-	base := os.Getenv("PLAKAR_API_URL")
+	base := os.Getenv(plakarAPIURLEnv)
 	if base == "" {
 		base = defaultBaseURL
 	}

--- a/login/login.go
+++ b/login/login.go
@@ -19,6 +19,7 @@ package login
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,22 +40,12 @@ type TokenResponse struct {
 // (via the baseURL field) so tests can point the login flow at a local server.
 const defaultBaseURL = "https://api.plakar.io"
 
-const plakarAPIURLEnv = "PLAKAR_API_URL"
-
 const rateLimitErrorMarker = "limit-reached"
 
-type HTTPStatusError struct {
-	StatusCode int
-	Body       string
-}
-
-func (err *HTTPStatusError) Error() string {
-	return fmt.Sprintf("unexpected status code: %d : %s", err.StatusCode, err.Body)
-}
-
-func (err *HTTPStatusError) RateLimited() bool {
-	return err.StatusCode == http.StatusTooManyRequests || strings.Contains(err.Body, rateLimitErrorMarker)
-}
+// ErrRateLimited marks a login failure caused by the auth API rate limiting the
+// caller. It is wrapped into the returned error so callers can react to it with
+// errors.Is without depending on a concrete error type or HTTP status code.
+var ErrRateLimited = errors.New("rate limited")
 
 type loginFlow struct {
 	appCtx  *appcontext.AppContext
@@ -63,29 +54,28 @@ type loginFlow struct {
 }
 
 func NewLoginFlow(appCtx *appcontext.AppContext, noSpawn bool) (*loginFlow, error) {
-	baseURL := defaultBaseURL
-	if envURL := os.Getenv(plakarAPIURLEnv); envURL != "" {
-		baseURL = envURL
-	}
-
 	flow := &loginFlow{
 		appCtx:  appCtx,
 		noSpawn: noSpawn,
-		baseURL: baseURL,
+		baseURL: defaultBaseURL,
 	}
 	return flow, nil
 }
 
+// unexpectedStatusError reads resp.Body to build a descriptive error for a
+// non-OK response. It does not close resp.Body; the caller owns closing it.
+// When the response signals rate limiting, the returned error wraps
+// ErrRateLimited so callers can detect it via errors.Is.
 func unexpectedStatusError(resp *http.Response) error {
-	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read error response body: %w", err)
 	}
-	return &HTTPStatusError{
-		StatusCode: resp.StatusCode,
-		Body:       string(data),
+	statusErr := fmt.Errorf("unexpected status code: %d : %s", resp.StatusCode, data)
+	if resp.StatusCode == http.StatusTooManyRequests || strings.Contains(string(data), rateLimitErrorMarker) {
+		return fmt.Errorf("%w: %w", ErrRateLimited, statusErr)
 	}
+	return statusErr
 }
 
 func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, progressCb func()) (string, error) {
@@ -108,10 +98,11 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 			}
 			switch resp.StatusCode {
 			case http.StatusOK:
-				defer resp.Body.Close()
 				var tokenResponse TokenResponse
-				if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
-					return "", fmt.Errorf("failed to decode response JSON: %v", err)
+				decodeErr := json.NewDecoder(resp.Body).Decode(&tokenResponse)
+				resp.Body.Close()
+				if decodeErr != nil {
+					return "", fmt.Errorf("failed to decode response JSON: %v", decodeErr)
 				}
 				return tokenResponse.Token, nil
 			case http.StatusNotFound:
@@ -121,7 +112,9 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 				resp.Body.Close()
 				progressCb()
 			default:
-				return "", unexpectedStatusError(resp)
+				statusErr := unexpectedStatusError(resp)
+				resp.Body.Close()
+				return "", statusErr
 			}
 		}
 		tick = time.After(delay)
@@ -152,11 +145,11 @@ func (flow *loginFlow) Run(provider string, parameters map[string]string) (strin
 	if err != nil {
 		return "", fmt.Errorf("unable to get the login URL: %w", err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", unexpectedStatusError(resp)
 	}
-	defer resp.Body.Close()
 
 	switch provider {
 	case "github":
@@ -228,11 +221,11 @@ func (flow *loginFlow) RunUI(provider string, parameters map[string]string) (str
 	if err != nil {
 		return "", fmt.Errorf("unable to get the login URL: %w", err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", unexpectedStatusError(resp)
 	}
-	defer resp.Body.Close()
 
 	switch provider {
 	case "github":
@@ -296,7 +289,7 @@ func DeriveToken(ctx *appcontext.AppContext) (string, error) {
 		return "", err
 	}
 
-	base := os.Getenv(plakarAPIURLEnv)
+	base := os.Getenv("PLAKAR_API_URL")
 	if base == "" {
 		base = defaultBaseURL
 	}

--- a/login/login_ratelimit_test.go
+++ b/login/login_ratelimit_test.go
@@ -1,0 +1,62 @@
+package login
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// rateLimitBody mirrors the auth API payload from issue #1656: a 500 whose body
+// carries the "limit-reached" marker instead of a 429 status code.
+const rateLimitBody = `{"error":"OpError[limit-reached] Limit reached"}`
+
+func TestRunWrapsErrRateLimitedFromBodyMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(rateLimitBody))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.Run("email", map[string]string{"email": "user@example.com"})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want wrapping ErrRateLimited", err)
+	}
+}
+
+func TestRunWrapsErrRateLimitedFromStatusCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.Run("email", map[string]string{"email": "user@example.com"})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want wrapping ErrRateLimited", err)
+	}
+}
+
+func TestRunOtherErrorIsNotRateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	_, err := flow.Run("email", map[string]string{"email": "user@example.com"})
+	if err == nil {
+		t.Fatal("err = nil, want a non-nil error")
+	}
+	if errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, unexpectedly wraps ErrRateLimited", err)
+	}
+}


### PR DESCRIPTION
Fix #1656

## Summary
When the auth API rate-limits a login attempt it replies `500` with a body
containing `limit-reached` (see the issue). The CLI/UI previously surfaced this
as an opaque `unexpected status code: 500 : {...}` error. This maps that
condition to a `429` `rate-limited` API response.

Per review, the mechanism is a package-level sentinel rather than an exported
HTTP-shaped error type:

- `login.ErrRateLimited` is wrapped into the returned error when a login
  response is rate-limited (429 status, or a body containing `limit-reached`).
- The API layer detects it with `errors.Is(err, login.ErrRateLimited)` and
  returns a `429` `rate-limited` `ApiError`.
- Response bodies are now closed on every `Poll` branch, and the `Run`/`RunUI`
  `defer resp.Body.Close()` calls are back in their original position;
  `unexpectedStatusError` only reads the body and leaves closing to the caller.

The earlier `NewLoginFlow` `PLAKAR_API_URL` change has been reverted — it only
existed to point an integration test at a local server. The behaviour is now
covered by focused unit tests that need no such override.

## Test verification (RED -> GREEN)

RED — with the rate-limit detection/mapping removed, the new tests fail,
reproducing the issue's exact payload:

```text
--- FAIL: TestRunWrapsErrRateLimitedFromBodyMarker
    login_ratelimit_test.go:26: err = unexpected status code: 500 : {"error":"OpError[limit-reached] Limit reached"}, want wrapping ErrRateLimited
--- FAIL: TestRunWrapsErrRateLimitedFromStatusCode
    login_ratelimit_test.go:41: err = unexpected status code: 429 : , want wrapping ErrRateLimited
--- FAIL: TestLoginFlowErrorMapsRateLimitTo429
    api_test.go:130: Should be in error chain: expected *api.ApiError
```

GREEN — with the fix:

```text
ok  github.com/PlakarKorp/plakar/login
ok  github.com/PlakarKorp/plakar/api
```

Full local CI (`go build -v ./...` and
`go test -p 4 -coverprofile=coverage.txt -covermode=atomic ./...`) is
iso-baseline with `main`.
