### PR TITLE
ptar: allow filtering the snapshots pulled from a kloset

### DIFF
--- a/subcommands/ptar/plakar-ptar.1
+++ b/subcommands/ptar/plakar-ptar.1
@@ -40,6 +40,18 @@ flag is given,
 .Nm plakar ptar
 refuses to replace an existing archive.
 .Pp
+In addition to the flags described below,
+.Nm plakar ptar
+supports the location flags documented in
+.Xr plakar-query 7
+to precisely select which snapshots of the
+.Fl k
+klosets are bundled.
+Without any of them every snapshot is included.
+They do not affect the
+.Ar path
+arguments, which are always backed up in full.
+.Pp
 The options are as follows:
 .Bl -tag -width Ds
 .It Fl plaintext
@@ -66,6 +78,7 @@ May be specified multiple times.
 .It Fl k Ar location , Fl kloset Ar location
 Add a kloset repository to include in the archive.
 May be specified multiple times to bundle several repositories.
+The location flags apply to each of them.
 .It Fl o Ar file.ptar
 Path of the archive to create.
 This option is required.

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -60,6 +60,8 @@ type Ptar struct {
 	SyncSecrets   [][]byte
 	BackupTargets listFlag
 	Excludes      []string
+
+	LocateOptions *locate.LocateOptions
 }
 
 func init() {
@@ -82,6 +84,7 @@ func (l *listFlag) Set(value string) error {
 
 func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 	cmd.KlosetUUID = uuid.Must(uuid.NewRandom())
+	cmd.LocateOptions = locate.NewDefaultLocateOptions()
 	var optIgnoreFiles listFlag
 	var optIgnore listFlag
 	excludes := []string{}
@@ -102,6 +105,7 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 	flags.Var(&optIgnoreFiles, "ignore-file", "path to a file containing newline-separated gitignore patterns, treated as -ignore; can be specified multiple times")
 	flags.Var(&optIgnore, "ignore", "gitignore pattern to exclude files, can be specified multiple times to add several exclusion patterns")
 	flags.StringVar(&cmd.KlosetPath, "o", "", "name of the ptar archive to create")
+	cmd.LocateOptions.InstallLocateFlags(flags)
 	flags.Parse(args)
 
 	if cmd.KlosetPath == "" {
@@ -410,8 +414,7 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 }
 
 func (cmd *Ptar) synchronize(ctx *appcontext.AppContext, srcRepository *repository.Repository, dstRepository *repository.RepositoryWriter) error {
-	srcLocateOptions := locate.NewDefaultLocateOptions()
-	srcSnapshotIDs, err := locate.LocateSnapshotIDs(srcRepository, srcLocateOptions)
+	srcSnapshotIDs, err := locate.LocateSnapshotIDs(srcRepository, cmd.LocateOptions)
 	if err != nil {
 		return err
 	}

--- a/subcommands/ptar/ptar_test.go
+++ b/subcommands/ptar/ptar_test.go
@@ -2,6 +2,7 @@ package ptar
 
 import (
 	"bytes"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,6 +116,101 @@ func TestExecuteCmdPtarWithSync(t *testing.T) {
 	status, err := subcommand.Execute(ctx, dstRepo)
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
+}
+
+func TestExecuteCmdPtarSyncFiltersSnapshots(t *testing.T) {
+	// The locate flags select which snapshots of a -k kloset are pulled in.
+	srcRepo, _ := ptesting.GenerateRepository(t, nil, nil, nil)
+	kept := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockDir("kept"),
+		ptesting.NewMockFile("kept/file.txt", 0644, "keep me"),
+	}, ptesting.WithName("keep-me"))
+	defer kept.Close()
+	dropped := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockDir("dropped"),
+		ptesting.NewMockFile("dropped/file.txt", 0644, "drop me"),
+	}, ptesting.WithName("drop-me"))
+	defer dropped.Close()
+
+	dstRepo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	out := filepath.Join(t.TempDir(), "filtered.ptar")
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-plaintext", "-o", out, "-k", srcRepo.Root(), "-name", "keep-me",
+	}))
+
+	status, err := cmd.Execute(ctx, dstRepo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	ids := listPtarSnapshotIDs(t, ctx, out)
+	require.Equal(t, []string{hex.EncodeToString(kept.Header.GetIndexShortID())}, ids)
+}
+
+func TestExecuteCmdPtarSyncKeepsEverySnapshotByDefault(t *testing.T) {
+	// Without a filter the whole kloset is still pulled in.
+	srcRepo, _ := ptesting.GenerateRepository(t, nil, nil, nil)
+	first := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockDir("one"),
+		ptesting.NewMockFile("one/file.txt", 0644, "first"),
+	}, ptesting.WithName("first"))
+	defer first.Close()
+	second := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockDir("two"),
+		ptesting.NewMockFile("two/file.txt", 0644, "second"),
+	}, ptesting.WithName("second"))
+	defer second.Close()
+
+	dstRepo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	out := filepath.Join(t.TempDir(), "everything.ptar")
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-plaintext", "-o", out, "-k", srcRepo.Root(),
+	}))
+
+	status, err := cmd.Execute(ctx, dstRepo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	ids := listPtarSnapshotIDs(t, ctx, out)
+	require.ElementsMatch(t, []string{
+		hex.EncodeToString(first.Header.GetIndexShortID()),
+		hex.EncodeToString(second.Header.GetIndexShortID()),
+	}, ids)
+}
+
+// listPtarSnapshotIDs returns the short id of every snapshot held in a ptar.
+func listPtarSnapshotIDs(t *testing.T, ctx *appcontext.AppContext, path string) []string {
+	t.Helper()
+
+	storeConfig := map[string]string{"location": "ptar://" + path}
+	st, serializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
+	require.NoError(t, err)
+	defer st.Close(ctx.GetInner())
+
+	repo, err := repository.New(ctx.GetInner(), nil, st, serializedConfig)
+	require.NoError(t, err)
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	ctx.Stdout = stdout
+	ctx.Stderr = stderr
+	cmd := &lscmd.Ls{}
+	require.NoError(t, cmd.Parse(ctx, nil))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+	require.Empty(t, strings.TrimSpace(stderr.String()))
+
+	ids := []string{}
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if fields := strings.Fields(line); len(fields) >= 2 {
+			ids = append(ids, fields[1])
+		}
+	}
+	return ids
 }
 
 func listPtarContents(t *testing.T, ctx *appcontext.AppContext, path string) string {


### PR DESCRIPTION
`ptar -k` synchronizes a kloset in full: `synchronize()` builds its own `locate.NewDefaultLocateOptions()`, so there is no way to bundle only part of what a source kloset holds.

This installs the standard location flags on the subcommand and hands them to the lookup instead, so the selectors the other subcommands already accept narrow what a kloset contributes to the archive:

```
plakar ptar -o out.ptar -k @peer -name nightly -since 2026-07-01
```

They apply to every `-k` target, leave the `path` arguments alone, and without any of them the whole kloset is still included, as before.

### On the syntax

In #1914 I suggested `-k @peer:<snapshot-prefix>`. I did not go that way in the end: a kloset location can itself contain a colon (`s3://…`, `sftp://…`), so splitting on one means guessing where the location stops and the selector starts. Reusing the location flags avoids that entirely and keeps `ptar` consistent with `ls`, `mount` and the rest, at the cost of applying to every `-k` target rather than to one. If you would rather have the per-target form I am happy to switch, it just needs a separator that cannot occur in a location.

### Scope

This is the snapshot-filtering half of #1914. Selecting individual files within a snapshot is not covered here, so I have left the issue open rather than closing it.

### Testing

- `TestExecuteCmdPtarSyncFiltersSnapshots` — two snapshots in the source kloset, `-name` selects one, only that one lands in the ptar.
- `TestExecuteCmdPtarSyncKeepsEverySnapshotByDefault` — with no filter both are still pulled in.

Checked that the first test fails without the `synchronize()` change (it pulls both snapshots), so it is actually exercising the fix. `go test ./...` passes, `gofmt` and `go vet` are clean, and `mandoc -Tlint -Wstyle` over the man pages exits 0.
