### PR TITLE
cached: unblock the state rebuild when the context is cancelled

### DIFF
--- a/cached/cached.go
+++ b/cached/cached.go
@@ -1,6 +1,7 @@
 package cached
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -52,18 +53,24 @@ func rebuildStateRequest(ctx *appcontext.AppContext, req *RequestPkt) (int, erro
 	}
 	defer client.Close()
 
+	// Closing the connection is what makes the Decode below return: without
+	// it a cancelled context leaves us parked on a response that never comes.
+	// The returned func unregisters the hook once the request is done.
+	stopCloseOnCancel := context.AfterFunc(ctx, func() { _ = client.Close() })
+	defer stopCloseOnCancel()
+
 	if err := client.enc.Encode(req); err != nil {
 		return 1, err
 	}
 
 	response := &ResponsePkt{}
 	if err := client.dec.Decode(response); err != nil {
+		if err := ctx.Err(); err != nil {
+			return 1, err
+		}
 		// The server closed the connection without a response packet.
 		if err == io.EOF {
 			return 0, nil
-		}
-		if err := ctx.Err(); err != nil {
-			return 1, err
 		}
 		return 1, fmt.Errorf("failed to decode response: %w", err)
 	}

--- a/cached/cached_test.go
+++ b/cached/cached_test.go
@@ -67,6 +67,10 @@ type serverBehavior struct {
 
 	// onRequest, if set, receives every decoded request packet.
 	onRequest func(*RequestPkt)
+
+	// waitForClientClose leaves the request unanswered until the client closes
+	// the connection.
+	waitForClientClose bool
 }
 
 // startFakeServer listens on <cacheDir>/cached.sock and serves connections
@@ -151,6 +155,11 @@ func serveConn(conn net.Conn, b serverBehavior) {
 	}
 	if b.onRequest != nil {
 		b.onRequest(pkt)
+	}
+	if b.waitForClientClose {
+		var buf [1]byte
+		_, _ = conn.Read(buf[:])
+		return
 	}
 
 	if b.closeAfterRequest {
@@ -340,6 +349,35 @@ func TestRebuildStateContextCancelled(t *testing.T) {
 	}
 	if code != 1 {
 		t.Errorf("exit code = %d, want 1", code)
+	}
+}
+
+func TestRebuildStateCancellationInterruptsResponseWait(t *testing.T) {
+	const cancellationTimeout = time.Second
+
+	ctx := newTestContext(t)
+	requestReceived := make(chan struct{})
+	startFakeServer(t, ctx, serverBehavior{
+		onRequest:          func(*RequestPkt) { close(requestReceived) },
+		waitForClientClose: true,
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := RebuildStateFromStore(ctx, uuid.New(), nil, false)
+		errCh <- err
+	}()
+
+	<-requestReceived
+	ctx.Cancel(nil)
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected cancellation error")
+		}
+	case <-time.After(cancellationTimeout):
+		t.Fatal("state rebuild did not stop after context cancellation")
 	}
 }
 


### PR DESCRIPTION
`rebuildStateRequest` blocks in `dec.Decode()` waiting for cached's answer, and
nothing was watching the context there. A cancelled run stayed parked on that
read until the daemon replied, so the deferred cleanup never got to run.

A `context.AfterFunc` now closes the client connection on cancellation: the
pending `Decode` returns, `ctx.Err()` is reported to the caller, and the
deferred cleanup runs.

## Scope — issue #2303 is **not** solved by this

This was opened against #2303, and @mathieu-plak is right that it does not
resolve it: that issue wedges gRPC on the socket from both sides, which closing
the `cached` client cannot unstick. The closing link to that issue is removed
rather than left to imply something this PR does not deliver.

What remains is a standalone robustness fix in `cached`: a cancelled context
should not leave the caller blocked forever on a response that will never
arrive. Happy to close this if you would rather not carry an unrelated
hardening change — just say the word.

## Test verification (RED → GREEN)

RED — on unmodified `main`, with only the new test applied:

```
=== RUN   TestRebuildStateCancellationInterruptsResponseWait
    cached_test.go:380: state rebuild did not stop after context cancellation
--- FAIL: TestRebuildStateCancellationInterruptsResponseWait (1.00s)
FAIL	github.com/PlakarKorp/plakar/cached	1.010s
```

The fake server accepts the request and then never answers, so the RED run sits
on `Decode` until the test's own timeout fires.

GREEN — with the fix:

```
--- PASS: TestRebuildStateCancellationInterruptsResponseWait (0.00s)
ok  	github.com/PlakarKorp/plakar/cached	0.172s
```

## Full local suite

Replaying `.github/workflows/go.yml` and `go-windows.yml` locally:

```
go build -v ./...                                     ok
GOOS=windows GOARCH=amd64 go build -v .               ok
gofmt -l cached                                       clean
go vet ./...                                          clean
timeout -s QUIT 5m go test -v -p 4 -coverprofile=coverage.out \
  -covermode=atomic -timeout 2m ./...                 1115 passed, 0 failed
```

Coverage on the changed production lines of `cached/cached.go`: **100%**.
