### PR TITLE
more api test cleanup

### DIFF
--- a/api/api_integrations_test.go
+++ b/api/api_integrations_test.go
@@ -11,57 +11,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegrationsInstallBadBody(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	// Malformed body fails the JSON decode before any package manager call.
-	// The handler still encodes a (failed) IntegrationsResponse with 200.
-	req, _ := http.NewRequest("POST", "/api/integrations/install", bytes.NewBufferString("{not-json"))
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	var resp IntegrationsResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, "pkg_install", resp.Type)
-	require.Equal(t, "failed", resp.Status)
-	require.NotEmpty(t, resp.Messages)
-}
-
-func TestIntegrationsUninstall(t *testing.T) {
+// TestIntegrations drives the integration install/uninstall endpoints against a
+// single fixture server.
+func TestIntegrations(t *testing.T) {
 	mux, _, snap, ctx := server(t, "")
 	defer snap.Close()
-	attachPkgManager(t, ctx)
 
-	req, _ := http.NewRequest("DELETE", "/api/integrations/some-plugin", nil)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	t.Run("install bad body", func(t *testing.T) {
+		// Malformed body fails the JSON decode before any package manager call.
+		// The handler still encodes a (failed) IntegrationsResponse with 200.
+		req, _ := http.NewRequest("POST", "/api/integrations/install", bytes.NewBufferString("{not-json"))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	var resp IntegrationsResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, "pkg_uninstall", resp.Type)
-	require.NotEmpty(t, resp.Messages)
-}
+		var resp IntegrationsResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "pkg_install", resp.Type)
+		require.Equal(t, "failed", resp.Status)
+		require.NotEmpty(t, resp.Messages)
+	})
 
-func TestCov3IntegrationsResponseHelpers(t *testing.T) {
-	resp := NewIntegrationsResponse("pkg_install")
-	require.Equal(t, "pkg_install", resp.Type)
-	require.Equal(t, "completed", resp.Status)
-	require.False(t, resp.StartedAt.IsZero())
-	require.Empty(t, resp.Messages)
+	t.Run("uninstall", func(t *testing.T) {
+		attachPkgManager(t, ctx)
 
-	resp.AddMessage("first")
-	resp.AddMessage("second")
-	require.Len(t, resp.Messages, 2)
-	require.Equal(t, "first", resp.Messages[0].Message)
-	require.Equal(t, "second", resp.Messages[1].Message)
-	require.False(t, resp.Messages[0].Date.IsZero())
+		req, _ := http.NewRequest("DELETE", "/api/integrations/some-plugin", nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	// The struct round-trips through JSON (the handlers encode it to the wire).
-	b, err := json.Marshal(resp)
-	require.NoError(t, err)
-	require.Contains(t, string(b), "pkg_install")
-	require.Contains(t, string(b), "first")
+		var resp IntegrationsResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "pkg_uninstall", resp.Type)
+		require.NotEmpty(t, resp.Messages)
+	})
+
+	t.Run("response helpers", func(t *testing.T) {
+		resp := NewIntegrationsResponse("pkg_install")
+		require.Equal(t, "pkg_install", resp.Type)
+		require.Equal(t, "completed", resp.Status)
+		require.False(t, resp.StartedAt.IsZero())
+		require.Empty(t, resp.Messages)
+
+		resp.AddMessage("first")
+		resp.AddMessage("second")
+		require.Len(t, resp.Messages, 2)
+		require.Equal(t, "first", resp.Messages[0].Message)
+		require.Equal(t, "second", resp.Messages[1].Message)
+		require.False(t, resp.Messages[0].Date.IsZero())
+
+		// The struct round-trips through JSON (the handlers encode it to the wire).
+		b, err := json.Marshal(resp)
+		require.NoError(t, err)
+		require.Contains(t, string(b), "pkg_install")
+		require.Contains(t, string(b), "first")
+	})
 }

--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -10,70 +10,83 @@ import (
 )
 
 func TestPathParamToID(t *testing.T) {
-	req, err := http.NewRequest("GET", "/path/{id}", nil)
-	req.Pattern = "/path/{id}"
+	t.Run("valid", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/path/{id}", nil)
+		req.Pattern = "/path/{id}"
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	req.SetPathValue("id", "7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c")
+		req.SetPathValue("id", "7e0e6e24a6e29faf11d022dca77826fe8b8a000aff5ea27e16650d03acefc93c")
 
-	id, err := PathParamToID(req, "id")
-	if err != nil {
-		t.Errorf("PathParamToID returned error: %v", err)
-	}
+		id, err := PathParamToID(req, "id")
+		if err != nil {
+			t.Errorf("PathParamToID returned error: %v", err)
+		}
 
-	expectedID := [32]uint8{
-		0x7e, 0xe, 0x6e, 0x24, 0xa6, 0xe2, 0x9f, 0xaf,
-		0x11, 0xd0, 0x22, 0xdc, 0xa7, 0x78, 0x26, 0xfe,
-		0x8b, 0x8a, 0x0, 0xa, 0xff, 0x5e, 0xa2, 0x7e,
-		0x16, 0x65, 0xd, 0x3, 0xac, 0xef, 0xc9, 0x3c,
-	}
+		expectedID := [32]uint8{
+			0x7e, 0xe, 0x6e, 0x24, 0xa6, 0xe2, 0x9f, 0xaf,
+			0x11, 0xd0, 0x22, 0xdc, 0xa7, 0x78, 0x26, 0xfe,
+			0x8b, 0x8a, 0x0, 0xa, 0xff, 0x5e, 0xa2, 0x7e,
+			0x16, 0x65, 0xd, 0x3, 0xac, 0xef, 0xc9, 0x3c,
+		}
 
-	if id != expectedID {
-		t.Errorf("PathParamToID returned unexpected ID: %v", id)
-	}
-}
+		if id != expectedID {
+			t.Errorf("PathParamToID returned unexpected ID: %v", id)
+		}
+	})
 
-func TestPathParamToID_Invalid(t *testing.T) {
-	tests := []struct {
-		name string
-		id   string
-		err  string
-	}{
-		{
-			name: "empty id",
-			id:   "",
-			err:  "invalid_params: Invalid parameter",
-		},
-		{
-			name: "wrong format",
-			id:   "0",
-			err:  "invalid_params: Invalid parameter",
-		},
-		{
-			name: "wrong length",
-			id:   "67",
-			err:  "invalid_params: Invalid parameter",
-		},
-	}
+	// The same success branch, expressed as a hex round-trip.
+	t.Run("round-trips to hex", func(t *testing.T) {
+		const hexID = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+		req, _ := http.NewRequest("GET", "/path/{id}", nil)
+		req.SetPathValue("id", hexID)
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/path/{id}", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+		id, err := PathParamToID(req, "id")
+		require.NoError(t, err)
+		require.Equal(t, hexID, hex.EncodeToString(id[:]))
+	})
 
-			req.SetPathValue("id", test.id)
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name string
+			id   string
+			err  string
+		}{
+			{
+				name: "empty id",
+				id:   "",
+				err:  "invalid_params: Invalid parameter",
+			},
+			{
+				name: "wrong format",
+				id:   "0",
+				err:  "invalid_params: Invalid parameter",
+			},
+			{
+				name: "wrong length",
+				id:   "67",
+				err:  "invalid_params: Invalid parameter",
+			},
+		}
 
-			_, err = PathParamToID(req, "id")
-			if err.Error() != test.err {
-				t.Errorf("wrong error, expected: %v, got: %v", err, test.err)
-			}
-		})
-	}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				req, err := http.NewRequest("GET", "/path/{id}", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				req.SetPathValue("id", test.id)
+
+				_, err = PathParamToID(req, "id")
+				if err.Error() != test.err {
+					t.Errorf("wrong error, expected: %v, got: %v", err, test.err)
+				}
+			})
+		}
+	})
 }
 
 func TestQueryParamToUint32(t *testing.T) {
@@ -271,16 +284,4 @@ func TestQueryParamToString(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.Empty(t, v)
-}
-
-// TestPathParamToIDValid covers the success branch of PathParamToID
-// with a well-formed 32-byte hex id.
-func TestPathParamToIDValid(t *testing.T) {
-	const hexID = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
-	req, _ := http.NewRequest("GET", "/path/{id}", nil)
-	req.SetPathValue("id", hexID)
-
-	id, err := PathParamToID(req, "id")
-	require.NoError(t, err)
-	require.Equal(t, hexID, hex.EncodeToString(id[:]))
 }

--- a/api/api_params_test.go
+++ b/api/api_params_test.go
@@ -78,46 +78,40 @@ func TestPathParamToID_Invalid(t *testing.T) {
 
 func TestQueryParamToUint32(t *testing.T) {
 	tests := []struct {
-		name       string
-		param      string
-		want       uint32
-		wantErr    bool
-		wantExists bool
+		name    string
+		param   string
+		want    uint32
+		wantErr bool
 	}{
 		{
-			name:       "empty param",
-			param:      "",
-			want:       0,
-			wantErr:    false,
-			wantExists: false,
+			name:    "empty param",
+			param:   "",
+			want:    0,
+			wantErr: false,
 		},
 		{
-			name:       "valid param",
-			param:      "123",
-			want:       123,
-			wantErr:    false,
-			wantExists: true,
+			name:    "valid param",
+			param:   "123",
+			want:    123,
+			wantErr: false,
 		},
 		{
-			name:       "invalid param",
-			param:      "abc",
-			want:       0,
-			wantErr:    true,
-			wantExists: true,
+			name:    "invalid param",
+			param:   "abc",
+			want:    0,
+			wantErr: true,
 		},
 		{
-			name:       "negative param",
-			param:      "-1",
-			want:       0,
-			wantErr:    true,
-			wantExists: true,
+			name:    "negative param",
+			param:   "-1",
+			want:    0,
+			wantErr: true,
 		},
 		{
-			name:       "out of range param",
-			param:      "4294967296",
-			want:       0,
-			wantErr:    true,
-			wantExists: true,
+			name:    "out of range param",
+			param:   "4294967296",
+			want:    0,
+			wantErr: true,
 		},
 	}
 

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -10,64 +10,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProxyAlertingGetUnauthorized(t *testing.T) {
+// TestProxy drives the services-proxy endpoints. servicesProxy reads
+// PLAKAR_SERVICE_ENDPOINT per request, so the endpoint-error cases can use
+// t.Setenv against the shared mux instead of rebuilding it.
+func TestProxy(t *testing.T) {
 	mux, _, snap, _ := server(t, "")
 	defer snap.Close()
 
-	// No auth token in the cookie jar -> handler returns a 401 JSON body.
-	w := get(t, mux, "/api/proxy/v1/account/services/alerting")
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+	t.Run("alerting get unauthorized", func(t *testing.T) {
+		// No auth token in the cookie jar -> handler returns a 401 JSON body.
+		w := get(t, mux, "/api/proxy/v1/account/services/alerting")
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
 
-	var resp map[string]string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, "authorization_error", resp["error"])
-}
+		var resp map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "authorization_error", resp["error"])
+	})
 
-func TestProxyAlertingSetUnauthorized(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+	t.Run("alerting set unauthorized", func(t *testing.T) {
+		body := `{"enabled":true,"email_report":true}`
+		req, _ := http.NewRequest("PUT", "/api/proxy/v1/account/services/alerting", bytes.NewBufferString(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
 
-	body := `{"enabled":true,"email_report":true}`
-	req, _ := http.NewRequest("PUT", "/api/proxy/v1/account/services/alerting", bytes.NewBufferString(body))
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+		var resp map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "authorization_error", resp["error"])
+	})
 
-	var resp map[string]string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, "authorization_error", resp["error"])
-}
+	t.Run("integration path not implemented", func(t *testing.T) {
+		w := get(t, mux, "/api/proxy/v1/integration/some-id/some/path")
+		// Returns a plain error -> mapped to 500 by handleError.
+		require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	})
 
-func TestProxyIntegrationPathNotImplemented(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+	t.Run("bad endpoint", func(t *testing.T) {
+		// An unparseable endpoint URL exercises the
+		// `targetBase, err := url.Parse(...); if err != nil` branch.
+		t.Setenv("PLAKAR_SERVICE_ENDPOINT", "://this is not a url")
 
-	w := get(t, mux, "/api/proxy/v1/integration/some-id/some/path")
-	// Returns a plain error -> mapped to 500 by handleError.
-	require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
-}
+		w := get(t, mux, "/api/proxy/v1/account/me")
+		require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	})
 
-// TestServicesProxyBadEndpoint points the proxy at an unparseable
-// endpoint URL, exercising the `targetBase, err := url.Parse(...); if
-// err != nil` branch of servicesProxy.
-func TestProxyBadEndpoint(t *testing.T) {
-	t.Setenv("PLAKAR_SERVICE_ENDPOINT", "://this is not a url")
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+	t.Run("unreachable", func(t *testing.T) {
+		// A closed local port makes the outbound http.DefaultClient.Do fail with
+		// connection-refused, exercising the `if err != nil` branch after it.
+		// Hermetic: nothing listens on port 1.
+		t.Setenv("PLAKAR_SERVICE_ENDPOINT", "http://127.0.0.1:1")
 
-	w := get(t, mux, "/api/proxy/v1/account/me")
-	require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
-}
-
-// TestServicesProxyUnreachable points the proxy at a closed local port so
-// the outbound http.DefaultClient.Do fails with connection-refused, exercising
-// the `resp, err := http.DefaultClient.Do(req); if err != nil` branch. Hermetic:
-// nothing listens on 127.0.0.1:0-equivalent unreachable port.
-func TestProxyUnreachable(t *testing.T) {
-	t.Setenv("PLAKAR_SERVICE_ENDPOINT", "http://127.0.0.1:1")
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/proxy/v1/account/me")
-	require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+		w := get(t, mux, "/api/proxy/v1/account/me")
+		require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
+	})
 }

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -10,18 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProxyAlertingGetNoAuth covers the no-auth-token 401 branch of
-// servicesGetAlertingServiceConfiguration (no network access
-// required).
-func TestProxyAlertingGetNoAuth(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/proxy/v1/account/services/alerting")
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "authorization_error")
-}
-
 // TestAlertingSetNoAuth covers the no-auth-token 401 branch of
 // servicesSetAlertingServiceConfiguration.
 func TestAlertingSetNoAuth(t *testing.T) {

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -10,19 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAlertingSetNoAuth covers the no-auth-token 401 branch of
-// servicesSetAlertingServiceConfiguration.
-func TestAlertingSetNoAuth(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	req, err := http.NewRequest("PUT", "/api/proxy/v1/account/services/alerting", bytes.NewBufferString(`{"enabled":true}`))
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-}
-
 func TestProxyAlertingGetUnauthorized(t *testing.T) {
 	mux, _, snap, _ := server(t, "")
 	defer snap.Close()

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -30,14 +30,6 @@ func TestRepositoryEmptyStateOK(t *testing.T) {
 	}
 }
 
-func TestAPIRepositoryLocatePathname(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
 func TestRepositoryLocatePathnameExactWindow(t *testing.T) {
 	mux, _, snap, _ := server(t, "")
 	defer snap.Close()

--- a/api/api_repository_test.go
+++ b/api/api_repository_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -11,240 +10,196 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRepositoryEmptyStateOK confirms the snapshot-listing handlers
-// serve an empty result (200) over a valid but empty repository,
-// exercising the no-snapshot loop tails.
-func TestRepositoryEmptyStateOK(t *testing.T) {
+// TestRepositoryEmpty checks some basic things on an empty kloset.
+func TestRepositoryEmpty(t *testing.T) {
 	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
 	mux := http.NewServeMux()
 	SetupRoutes(mux, repo, ctx, "", true)
 
-	for _, path := range []string{
-		"/api/repository/snapshots",
-		"/api/repository/importer-types",
-		"/api/repository/locate-pathname",
-		"/api/repository/info",
-	} {
-		w := get(t, mux, path)
-		require.Equal(t, http.StatusOK, w.Code, "path=%s body=%s", path, w.Body.String())
-	}
+	t.Run("empty repository serves 200", func(t *testing.T) {
+		for _, path := range []string{
+			"/api/repository/snapshots",
+			"/api/repository/importer-types",
+			"/api/repository/locate-pathname",
+			"/api/repository/info",
+		} {
+			w := get(t, mux, path)
+			require.Equal(t, http.StatusOK, w.Code, "path=%s body=%s", path, w.Body.String())
+		}
+	})
+
+	t.Run("info empty efficiency", func(t *testing.T) {
+		// A repository with no snapshots has logicalSize == 0, which drives the
+		// efficiency = -1 branch in repositoryInfo.
+		w := get(t, mux, "/api/repository/info")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var resp Item[RepositoryInfoResponse]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, float64(-1), resp.Item.Snapshots.Efficiency)
+		require.Equal(t, 0, resp.Item.Snapshots.Total)
+		require.Len(t, resp.Item.Snapshots.SnapshotsPerDay, 30)
+	})
 }
 
-func TestRepositoryLocatePathnameExactWindow(t *testing.T) {
+// TestRepository drives the repository endpoints against a single populated
+// repository.
+func TestRepository(t *testing.T) {
 	mux, _, snap, _ := server(t, "")
 	defer snap.Close()
 
-	// A resource that resolves in the single snapshot. With limit=1 and offset=0,
-	// offset+limit == len(locations), exercising the exact-window slice branch
-	// (locations[offset:offset+limit]) rather than the tail branch.
-	w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&limit=1&offset=0")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.GreaterOrEqual(t, items.Total, 1)
-}
+	t.Run("info", func(t *testing.T) {
+		// The populated-efficiency branch (logicalSize > 0).
+		w := get(t, mux, "/api/repository/info")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-func TestRepositoryLocatePathnameDefaultSortAsc(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		var resp Item[RepositoryInfoResponse]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.GreaterOrEqual(t, resp.Item.Snapshots.Total, 1)
+		require.NotEmpty(t, resp.Item.OS)
+		require.NotEmpty(t, resp.Item.Arch)
+		require.True(t, resp.Item.Browsable)
+	})
 
-	// No explicit sort -> default ascending Timestamp sortFunc branch.
-	w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
-}
+	t.Run("importer types", func(t *testing.T) {
+		w := get(t, mux, "/api/repository/importer-types")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[map[string]string]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.Equal(t, items.Total, len(items.Items))
+	})
 
-func TestRepositoryLocatePathnameFilters(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+	t.Run("snapshots", func(t *testing.T) {
+		w := get(t, mux, "/api/repository/snapshots")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
+	})
 
-	// Resource that exists in the snapshot.
-	w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=-Timestamp")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
+	t.Run("snapshots exact window", func(t *testing.T) {
+		// limit=1 with a single snapshot drives offset+limit == len(headers), the
+		// exact-window slice branch of repositorySnapshots.
+		w := get(t, mux, "/api/repository/snapshots?limit=1&offset=0")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.GreaterOrEqual(t, items.Total, 1)
+	})
 
-	// importerType filter that matches nothing.
-	w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerType=nope")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	t.Run("snapshots importer match", func(t *testing.T) {
+		// First find the actual importer type via the header.
+		importer := snap.Header.GetSource(0).Importer.Type
 
-	// importerOrigin filter that matches nothing.
-	w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerOrigin=nope")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		w := get(t, mux, "/api/repository/snapshots?importer="+importer)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.GreaterOrEqual(t, items.Total, 1)
 
-	// importerDirectory filter that matches nothing.
-	w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerDirectory=nope")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		// since in the past -> snapshot is kept.
+		w = get(t, mux, "/api/repository/snapshots?since=2000-01-01T00:00:00Z")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
 
-	// Resource that does not resolve in any snapshot -> empty result, 200.
-	w = get(t, mux, "/api/repository/locate-pathname?resource=/no/such/file")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	t.Run("snapshots filters", func(t *testing.T) {
+		// importer filter that matches nothing -> total counts only matching ones.
+		w := get(t, mux, "/api/repository/snapshots?importer=nonexistent")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	// invalid sort key -> 400.
-	w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=Bogus")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+		// since in the future -> no matching snapshots but still 200.
+		w = get(t, mux, "/api/repository/snapshots?since=2999-01-01T00:00:00Z")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	// offset beyond results.
-	w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&offset=1000")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
+		// descending sort.
+		w = get(t, mux, "/api/repository/snapshots?sort=-Timestamp")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-// TestRepositorySnapshotsParamErrors covers the parameter-validation error
-// returns in repositorySnapshots (offset/limit/since/sort) which short-circuit
-// before any storage access.
-func TestRepositorySnapshotsParamErrors(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		// offset beyond the number of headers -> empty items.
+		w = get(t, mux, "/api/repository/snapshots?offset=1000")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	cases := []struct {
-		name   string
-		query  string
-		status int
-	}{
-		{"bad offset", "offset=abc", http.StatusBadRequest},
-		{"bad limit", "limit=abc", http.StatusBadRequest},
-		{"bad since", "since=not-a-date", http.StatusBadRequest},
-		{"bad sort", "sort=NoSuchKey", http.StatusBadRequest},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			w := get(t, mux, fmt.Sprintf("/api/repository/snapshots?%s", c.query))
-			require.Equal(t, c.status, w.Code, "body=%s", w.Body.String())
-		})
-	}
-}
+		// invalid sort key -> 400.
+		w = get(t, mux, "/api/repository/snapshots?sort=Bogus")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 
-// TestRepositoryLocatePathnameParamErrors covers the parameter-validation
-// error returns in repositoryLocatePathname.
-func TestRepositoryLocatePathnameParamErrors(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		// invalid offset -> error.
+		w = get(t, mux, "/api/repository/snapshots?offset=abc")
+		require.NotEqual(t, http.StatusOK, w.Code)
+	})
 
-	for _, q := range []string{"offset=abc", "limit=abc", "sort=NoSuchKey"} {
-		t.Run(q, func(t *testing.T) {
-			w := get(t, mux, "/api/repository/locate-pathname?"+q)
-			require.GreaterOrEqual(t, w.Code, 400, "body=%s", w.Body.String())
-		})
-	}
-}
+	// The parameter-validation errors in repositorySnapshots short-circuit
+	// before any storage access.
+	t.Run("snapshots param errors", func(t *testing.T) {
+		for _, c := range []struct {
+			name  string
+			query string
+		}{
+			{"bad offset", "offset=abc"},
+			{"bad limit", "limit=abc"},
+			{"bad since", "since=not-a-date"},
+			{"bad sort", "sort=NoSuchKey"},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				w := get(t, mux, "/api/repository/snapshots?"+c.query)
+				require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			})
+		}
+	})
 
-func TestRepositorySnapshots(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+	t.Run("locate-pathname exact window", func(t *testing.T) {
+		// A resource that resolves in the single snapshot. With limit=1 and offset=0,
+		// offset+limit == len(locations), exercising the exact-window slice branch
+		// (locations[offset:offset+limit]) rather than the tail branch.
+		w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&limit=1&offset=0")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.GreaterOrEqual(t, items.Total, 1)
+	})
 
-	w := get(t, mux, "/api/repository/snapshots")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
-}
+	t.Run("locate-pathname default sort asc", func(t *testing.T) {
+		// No explicit sort -> default ascending Timestamp sortFunc branch.
+		w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
+	})
 
-func TestAPIRepositorySnapshotsBadSince(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+	t.Run("locate-pathname filters", func(t *testing.T) {
+		// Resource that exists in the snapshot.
+		w := get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=-Timestamp")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
 
-	w := get(t, mux, "/api/repository/snapshots?since=not-a-date")
-	require.Equal(t, http.StatusBadRequest, w.Code)
-}
+		// importerType filter that matches nothing.
+		w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerType=nope")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-func TestRepositorySnapshotsExactWindow(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		// importerOrigin filter that matches nothing.
+		w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerOrigin=nope")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	// limit=1 with a single snapshot drives offset+limit == len(headers), the
-	// exact-window slice branch of repositorySnapshots.
-	w := get(t, mux, "/api/repository/snapshots?limit=1&offset=0")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.GreaterOrEqual(t, items.Total, 1)
-}
+		// importerDirectory filter that matches nothing.
+		w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&importerDirectory=nope")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-func TestRepositorySnapshotsImporterMatch(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		// Resource that does not resolve in any snapshot -> empty result, 200.
+		w = get(t, mux, "/api/repository/locate-pathname?resource=/no/such/file")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	// First find the actual importer type via the header.
-	importer := snap.Header.GetSource(0).Importer.Type
+		// invalid sort key -> 400.
+		w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&sort=Bogus")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 
-	w := get(t, mux, "/api/repository/snapshots?importer="+importer)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.GreaterOrEqual(t, items.Total, 1)
+		// offset beyond results.
+		w = get(t, mux, "/api/repository/locate-pathname?resource=/subdir/dummy.txt&offset=1000")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
 
-	// since in the past -> snapshot is kept.
-	w = get(t, mux, "/api/repository/snapshots?since=2000-01-01T00:00:00Z")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestCovRepositorySnapshotsFilters(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	// importer filter that matches nothing -> total counts only matching ones.
-	w := get(t, mux, "/api/repository/snapshots?importer=nonexistent")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// since in the future -> no matching snapshots but still 200.
-	w = get(t, mux, "/api/repository/snapshots?since=2999-01-01T00:00:00Z")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// descending sort.
-	w = get(t, mux, "/api/repository/snapshots?sort=-Timestamp")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// offset beyond the number of headers -> empty items.
-	w = get(t, mux, "/api/repository/snapshots?offset=1000")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// invalid sort key -> 400.
-	w = get(t, mux, "/api/repository/snapshots?sort=Bogus")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-
-	// invalid offset -> error.
-	w = get(t, mux, "/api/repository/snapshots?offset=abc")
-	require.NotEqual(t, http.StatusOK, w.Code)
-}
-
-// TestRepositoryInfo exercises the populated-efficiency
-// branch (logicalSize > 0) and asserts the response shape.
-func TestRepositoryInfo(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/repository/info")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	var resp Item[RepositoryInfoResponse]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.GreaterOrEqual(t, resp.Item.Snapshots.Total, 1)
-	require.NotEmpty(t, resp.Item.OS)
-	require.NotEmpty(t, resp.Item.Arch)
-	require.True(t, resp.Item.Browsable)
-}
-
-func TestRepositoryInfoEmptyEfficiency(t *testing.T) {
-	// A repository with no snapshots has logicalSize == 0, which drives the
-	// efficiency = -1 branch in repositoryInfo.
-	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
-	mux := http.NewServeMux()
-	SetupRoutes(mux, repo, ctx, "", true)
-
-	w := get(t, mux, "/api/repository/info")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	var resp Item[RepositoryInfoResponse]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, float64(-1), resp.Item.Snapshots.Efficiency)
-	require.Equal(t, 0, resp.Item.Snapshots.Total)
-	require.Len(t, resp.Item.Snapshots.SnapshotsPerDay, 30)
-}
-
-func TestRepositoryImporterTypes(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/repository/importer-types")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[map[string]string]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.Equal(t, items.Total, len(items.Items))
+	t.Run("locate-pathname param errors", func(t *testing.T) {
+		for _, q := range []string{"offset=abc", "limit=abc", "sort=NoSuchKey"} {
+			t.Run(q, func(t *testing.T) {
+				w := get(t, mux, "/api/repository/locate-pathname?"+q)
+				require.GreaterOrEqual(t, w.Code, 400, "body=%s", w.Body.String())
+			})
+		}
+	})
 }

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -14,671 +14,382 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSnapshotPathParamMissingID(t *testing.T) {
-	_, repo, snap, _ := server(t, "")
-	defer snap.Close()
-
-	req, _ := http.NewRequest("GET", "/x/{snapshot_path}", nil)
-	req.SetPathValue("snapshot_path", "")
-	_, _, err := SnapshotPathParam(req, repo, "snapshot_path")
-	require.Error(t, err)
-	apierr, ok := err.(*ApiError)
-	require.True(t, ok)
-	require.Equal(t, http.StatusBadRequest, apierr.HttpCode)
-}
-
-func TestSnapshotHeader(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	id := snap.Header.GetIndexID()
-	w := get(t, mux, "/api/snapshot/"+hex.EncodeToString(id[:]))
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotHeaderBadID(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/snapshot/nothexnothex")
-	require.NotEqual(t, http.StatusOK, w.Code)
-}
-
-func TestSnapshotHeaderNotFound(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	// mangle the snapid so that it does not match
-	snapid := snap.Header.GetIndexID()
-
-	// cheating a bit, but the meaning here is to just mangle the
-	// id to generate a non-existent one.
-	if snapid[1] = snapid[1] + 1; snapid[1] > '9' {
-		snapid[1] = '0'
-	}
-
-	// Valid hex, valid length, but no such snapshot -> 404.
-	w := get(t, mux, "/api/snapshot/"+hex.EncodeToString(snapid[:]))
-	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotHeaderBadParam(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	w := get(t, mux, "/api/snapshot/zz")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotVFSSearch(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotVFSSearchHasNext(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
+// TestSnapshot drives most snapshot endpoints against a single repository.
+func TestSnapshot(t *testing.T) {
+	mux, repo, snap, _ := server(t, "")
 	defer snap.Close()
 	id := snapid(snap)
 
-	// "d" holds four .txt files; recursive search with limit=1 forces the
-	// "one extra item -> HasNext" branch (limit is incremented internally).
-	w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&limit=1&pattern=txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	var page ItemsPage[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &page))
-	require.True(t, page.HasNext)
-	require.Len(t, page.Items, 1)
-}
-
-func TestSnapshotVFSSearchMimeFilter(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// A single mime filter exercises the Mimes pass-through (not the >20 cap).
-	w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&mime=text/plain")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "has_next")
-}
-
-func TestSnapshotVFSSearchNonRecursive(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// non-recursive search of a directory.
-	w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=10")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "has_next")
-
-	// limit<=0 is normalized to 50 (covers that branch).
-	w = get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=0")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotVFSSearchTooManyMimes(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// More than 20 mime params -> 400.
-	url := "/api/snapshot/vfs/search/" + id + ":/subdir?"
-	for i := range 21 {
-		if i > 0 {
-			url += "&"
-		}
-		url += "mime=text/plain"
-	}
-	w := get(t, mux, url)
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotVFSSearchVariants(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// recursive search with offset/limit and a name pattern.
-	w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&offset=0&limit=1&pattern=txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "has_next")
-
-	// bad offset -> 400.
-	w = get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?offset=abc")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-
-	// bad limit -> 400.
-	w = get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=abc")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSDownloaderSignedDefaultName(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
-	req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var resp struct {
-		Id string `json:"id"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.NotEmpty(t, resp.Id)
-
-	// No name query param -> handler synthesizes "snapshot-<id>-<ts>" + ext.
-	w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+resp.Id+"?format=zip")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Header().Get("Content-Disposition"), "snapshot-")
-	require.Contains(t, w.Header().Get("Content-Disposition"), ".zip")
-}
-
-func TestVFSDownloaderBadSnapshotID(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	// Empty snapshot id segment -> SnapshotPathParam returns a 400.
-	body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
-	req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/:/subdir", bytes.NewBufferString(body))
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSChildrenDescSort(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=-Name&offset=0&limit=2")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.Greater(t, len(items.Items), 0)
-}
-
-func TestVFSBrowseRootAndFile(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// Root directory (path empty -> "/").
-	w := get(t, mux, "/api/snapshot/vfs/"+id+":/")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// directory -> loadEntrySummaries path runs.
-	w = get(t, mux, "/api/snapshot/vfs/"+id+":/subdir")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// A regular file entry.
-	w = get(t, mux, "/api/snapshot/vfs/"+id+":/top.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// Non-existent path -> error (not 200).
-	w = get(t, mux, "/api/snapshot/vfs/"+id+":/does/not/exist")
-	require.NotEqual(t, http.StatusOK, w.Code)
-}
-
-func TestVFSBrowseUnknownPrefix(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	// A well-formed but unmatched snapshot prefix -> LocateSnapshotByPrefix
-	// error surfaced as a 400 invalid_params.
-	w := get(t, mux, "/api/snapshot/vfs/deadbeef:/subdir")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSChildrenSecondPage(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// offset>0 takes the branch that decrements offset for the implicit "..".
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=5")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-}
-
-func TestVFSChildrenLimitDecrementToZero(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// On a non-root directory, page 0 prepends "..", which decrements limit. With
-	// limit=1 this drives limit to 0 and hits the "replace with child count"
-	// branch in snapshotVFSChildren.
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=0&limit=1")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.GreaterOrEqual(t, len(items.Items), 1)
-}
-
-// TestVFSChildrenRootNoParent exercises the root-directory path where
-// no ".." entry is prepended (fsinfo.Path() == "/").
-func TestVFSChildrenRoot(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.Greater(t, len(items.Items), 0)
-}
-
-func TestSnapshotVFSChildren(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSChildrenPaging(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// Default listing of a directory with several entries.
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var items Items[json.RawMessage]
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-	require.Greater(t, len(items.Items), 0)
-
-	// offset>0 path: exercises the ".." offset-decrement branch.
-	w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=2")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// Explicit sort key.
-	w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=Name")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSChildrenErrors(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// children of a regular file -> 400 "not a directory".
-	w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/top.txt")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-
-	// invalid sort key -> 400.
-	w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=Bogus")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-
-	// invalid offset -> error.
-	w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=abc")
-	require.NotEqual(t, http.StatusOK, w.Code)
-}
-
-func TestSnapshotVFSErrors(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSErrorsWindowBreak(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// offset 0 / limit 1 over a clean directory exercises the i>=offset+limit
-	// break path in the error iterator window arithmetic.
-	w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
-}
-
-func TestVFSErrorsPaging(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// Exercise the offset/limit window arithmetic on a clean (no-error) dir.
-	w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// bad offset -> error from QueryParamToInt64.
-	w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=-1")
-	require.NotEqual(t, http.StatusOK, w.Code)
-
-	// errors on a missing dir -> 404.
-	w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/no-such-dir")
-	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
-}
-
-func TestVFSErrorsSortAndPaging(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// explicit Name sort + a paging window over an error-free directory.
-	w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?sort=Name&offset=0&limit=5")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
-}
-
-func TestVFSErrorsHandler(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// happy path on a dir.
-	w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=10")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// invalid sort key -> 400.
-	w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=Bogus")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-
-	// -Name sort key is accepted.
-	w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=-Name")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	// errors of a regular file -> 400 not a directory.
-	w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/top.txt")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderSignedReaderValid(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	sig := signReader(t, mux, token, id+":/subdir/dummy.txt")
-
-	// A valid signature lets the (otherwise token-protected) reader through.
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "hello dummy")
-}
-
-func TestSnapshotReaderSignedReaderTamperedPathAndSnapshot(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	sig := signReader(t, mux, token, id+":/subdir/dummy.txt")
-
-	// Same valid signature but requesting a different path -> rejected.
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/top.txt?signature="+sig)
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderSignedReaderBadSignature(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	// Garbage signature -> JWT parse failure -> 401.
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature=not-a-jwt")
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderSignedReaderExpired(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	// Hand-craft an already-expired token signed with the right key.
-	now := time.Now().Add(-3 * time.Hour)
-	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, SnapshotSignedURLClaims{
-		SnapshotID: id,
-		Path:       "/subdir/dummy.txt",
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(now.Add(1 * time.Hour)),
-			IssuedAt:  jwt.NewNumericDate(now),
-			Issuer:    "plakar-api",
-		},
+	t.Run("path param missing id", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/x/{snapshot_path}", nil)
+		req.SetPathValue("snapshot_path", "")
+		_, _, err := SnapshotPathParam(req, repo, "snapshot_path")
+		require.Error(t, err)
+		apierr, ok := err.(*ApiError)
+		require.True(t, ok)
+		require.Equal(t, http.StatusBadRequest, apierr.HttpCode)
 	})
-	sig, err := jwtToken.SignedString([]byte(token))
-	require.NoError(t, err)
 
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "expired")
-}
-
-func TestSnapshotReaderSignedReaderWrongSigningMethod(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	// A token with the "none" alg should be rejected by the method check.
-	jwtToken := jwt.NewWithClaims(jwt.SigningMethodNone, SnapshotSignedURLClaims{
-		SnapshotID: id,
-		Path:       "/subdir/dummy.txt",
-	})
-	sig, err := jwtToken.SignedString(jwt.UnsafeAllowNoneSignatureType)
-	require.NoError(t, err)
-
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderNoSignatureRequiresToken(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	// No signature and no Authorization header -> token middleware rejects.
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
-	require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
-
-	// With the correct Bearer token it succeeds.
-	req, _ := http.NewRequest("GET", "/api/snapshot/reader/"+id+":/subdir/dummy.txt", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	w = httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderSignURL(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	req, err := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+id+":/subdir/dummy.txt", nil)
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	var resp map[string]map[string]string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.NotEmpty(t, resp["item"]["signature"])
-}
-
-func TestSnapshotReaderSignReaderNonexistentPath(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-	id := snapid(snap)
-
-	// Signing a path that does not exist in the snapshot returns an error.
-	req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+id+":/no/such/file", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.NotEqual(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderSignReaderBadSnapshotID(t *testing.T) {
-	const token = "verify-token"
-	mux, _, snap, _ := server(t, token)
-	defer snap.Close()
-
-	// Empty snapshot id segment -> SnapshotPathParam missing-arg error.
-	req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/:/subdir/dummy.txt", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderMissingFileNotFound(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	// GetEntry on a missing path bubbles up an fs.ErrNotExist which handleError
-	// maps to a 404.
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/missing.txt")
-	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotReaderRenderVariants(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	base := "/api/snapshot/reader/" + id + ":"
-
-	for _, render := range []string{"", "auto", "text", "text_styled", "code"} {
-		u := base + "/subdir/dummy.txt"
-		if render != "" {
-			u += "?render=" + render
-		}
-		w := get(t, mux, u)
-		require.Equal(t, http.StatusOK, w.Code, "render=%s body=%s", render, w.Body.String())
-
-		switch render {
-		case "", "auto":
-			require.Contains(t, w.Header().Get("Content-type"), "text/plain")
-			require.Contains(t, w.Body.String(), "hello dummy")
-		case "text":
-			require.Contains(t, w.Header().Get("Content-type"), "text/plain")
-			require.Contains(t, w.Body.String(), "hello dummy")
-		case "text_styled":
-			require.Contains(t, w.Header().Get("Content-type"), "text/html")
-			require.Contains(t, w.Body.String(), "<pre>")
-		case "code":
-			require.Contains(t, w.Header().Get("Content-type"), "text/html")
-			require.Contains(t, w.Body.String(), "<!DOCTYPE html>")
-		}
-
-		// "noext" has no file extension
-		w = get(t, mux, strings.Replace(u, "dummy.txt", "noext", 1))
+	t.Run("header", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/"+id)
 		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	}
+	})
 
-	base += "/subdir/dummy.txt"
+	t.Run("header bad id", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/nothexnothex")
+		require.NotEqual(t, http.StatusOK, w.Code)
+	})
 
-	// download=true sets a Content-Disposition attachment header.
-	w := get(t, mux, base+"?download=true")
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	t.Run("header not found", func(t *testing.T) {
+		// mangle the snapid so that it does not match
+		snapid := snap.Header.GetIndexID()
 
-	// an invalid render value is rejected.
-	w = get(t, mux, base+"?render=bogus")
-	require.Equal(t, http.StatusBadRequest, w.Code)
-}
+		// cheating a bit, but the meaning here is to just mangle the
+		// id to generate a non-existent one.
+		if snapid[1] = snapid[1] + 1; snapid[1] > '9' {
+			snapid[1] = '0'
+		}
 
-func TestSnapshotReaderRenderAuto(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
+		// Valid hex, valid length, but no such snapshot -> 404.
+		w := get(t, mux, "/api/snapshot/"+hex.EncodeToString(snapid[:]))
+		require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
 
-	// No render param defaults to "auto".
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "hello dummy")
-}
+	t.Run("header bad param", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/zz")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
 
-// TestSnapshotReaderDownloadDisposition exercises the download=true branch which
-// sets a Content-Disposition attachment header.
-func TestSnapshotReaderDownloadDisposition(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
+	t.Run("vfs search", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
 
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?download=true")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
-	require.Contains(t, w.Header().Get("Content-Disposition"), "dummy.txt")
-}
+	t.Run("vfs search has next", func(t *testing.T) {
+		// "d" holds four .txt files; recursive search with limit=1 forces the
+		// "one extra item -> HasNext" branch (limit is incremented internally).
+		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&limit=1&pattern=txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-func TestSnapshotReaderInvalidRender(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
+		var page ItemsPage[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &page))
+		require.True(t, page.HasNext)
+		require.Len(t, page.Items, 1)
+	})
 
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=invalid")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	t.Run("vfs search mime filter", func(t *testing.T) {
+		// A single mime filter exercises the Mimes pass-through (not the >20 cap).
+		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&mime=text/plain")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "has_next")
+	})
 
-	// code render path.
-	w = get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=code")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	t.Run("vfs search non recursive", func(t *testing.T) {
+		// non-recursive search of a directory.
+		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=10")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "has_next")
 
-	// reader for a non-existent file -> error.
-	w = get(t, mux, "/api/snapshot/reader/"+id+":/nope.txt")
-	require.NotEqual(t, http.StatusOK, w.Code)
-}
+		// limit<=0 is normalized to 50 (covers that branch).
+		w = get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=0")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
 
-func TestSnapshotDownloaderSignedCustomName(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
+	t.Run("vfs search too many mimes", func(t *testing.T) {
+		// More than 20 mime params -> 400.
+		url := "/api/snapshot/vfs/search/" + id + ":/subdir?"
+		for i := range 21 {
+			if i > 0 {
+				url += "&"
+			}
+			url += "mime=text/plain"
+		}
+		w := get(t, mux, url)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
 
-	body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
-	req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	var resp struct {
-		Id string `json:"id"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	t.Run("vfs search variants", func(t *testing.T) {
+		// recursive search with offset/limit and a name pattern.
+		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true&offset=0&limit=1&pattern=txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "has_next")
 
-	// name already carries an extension -> the ext-appending branch is skipped.
-	w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+resp.Id+"?format=zip&name=custom.zip")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Header().Get("Content-Disposition"), "custom.zip")
-}
+		// bad offset -> 400.
+		w = get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?offset=abc")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 
-func TestSnapshotDownloaderSignedNotFound(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		// bad limit -> 400.
+		w = get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?limit=abc")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
 
-	// Unknown download id -> 404.
-	w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/does-not-exist?format=zip")
-	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
-}
+	t.Run("vfs browse root and file", func(t *testing.T) {
+		// Root directory (path empty -> "/").
+		w := get(t, mux, "/api/snapshot/vfs/"+id+":/")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-func TestSnapshotDownloaderFormats(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
+		// directory -> loadEntrySummaries path runs.
+		w = get(t, mux, "/api/snapshot/vfs/"+id+":/subdir")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 
-	post := func() string {
+		// A regular file entry.
+		w = get(t, mux, "/api/snapshot/vfs/"+id+":/top.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// Non-existent path -> error (not 200).
+		w = get(t, mux, "/api/snapshot/vfs/"+id+":/does/not/exist")
+		require.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("vfs browse unknown prefix", func(t *testing.T) {
+		// A well-formed but unmatched snapshot prefix -> LocateSnapshotByPrefix
+		// error surfaced as a 400 invalid_params.
+		w := get(t, mux, "/api/snapshot/vfs/deadbeef:/subdir")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs children", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs children root", func(t *testing.T) {
+		// The root directory prepends no ".." entry (fsinfo.Path() == "/").
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.Greater(t, len(items.Items), 0)
+	})
+
+	t.Run("vfs children desc sort", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=-Name&offset=0&limit=2")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.Greater(t, len(items.Items), 0)
+	})
+
+	t.Run("vfs children second page", func(t *testing.T) {
+		// offset>0 takes the branch that decrements offset for the implicit "..".
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=5")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+	})
+
+	t.Run("vfs children limit decrement to zero", func(t *testing.T) {
+		// On a non-root directory, page 0 prepends "..", which decrements limit. With
+		// limit=1 this drives limit to 0 and hits the "replace with child count"
+		// branch in snapshotVFSChildren.
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=0&limit=1")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.GreaterOrEqual(t, len(items.Items), 1)
+	})
+
+	t.Run("vfs children paging", func(t *testing.T) {
+		// Default listing of a directory with several entries.
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		var items Items[json.RawMessage]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
+		require.Greater(t, len(items.Items), 0)
+
+		// offset>0 path: exercises the ".." offset-decrement branch.
+		w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=2")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// Explicit sort key.
+		w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=Name")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs children errors", func(t *testing.T) {
+		// children of a regular file -> 400 "not a directory".
+		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/top.txt")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+		// invalid sort key -> 400.
+		w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=Bogus")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+		// invalid offset -> error.
+		w = get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=abc")
+		require.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("vfs errors", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs errors window break", func(t *testing.T) {
+		// offset 0 / limit 1 over a clean directory exercises the i>=offset+limit
+		// break path in the error iterator window arithmetic.
+		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
+	})
+
+	t.Run("vfs errors paging", func(t *testing.T) {
+		// Exercise the offset/limit window arithmetic on a clean (no-error) dir.
+		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// bad offset -> error from QueryParamToInt64.
+		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=-1")
+		require.NotEqual(t, http.StatusOK, w.Code)
+
+		// errors on a missing dir -> 404.
+		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/no-such-dir")
+		require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs errors sort and paging", func(t *testing.T) {
+		// explicit Name sort + a paging window over an error-free directory.
+		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?sort=Name&offset=0&limit=5")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
+	})
+
+	t.Run("vfs errors handler", func(t *testing.T) {
+		// happy path on a dir.
+		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=10")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// invalid sort key -> 400.
+		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=Bogus")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+		// -Name sort key is accepted.
+		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=-Name")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// errors of a regular file -> 400 not a directory.
+		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/top.txt")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs chunks", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs chunks offset", func(t *testing.T) {
+		// offset beyond the chunk count -> empty Items but valid Total.
+		w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?offset=1000&limit=10")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
+
+		// chunks on a missing path returns 200 with empty body (early nil return).
+		w = get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/dir/missing.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("vfs chunks paging", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?offset=0&limit=10")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
+
+		// bad limit -> error.
+		w = get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?limit=abc")
+		require.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reader render variants", func(t *testing.T) {
+		base := "/api/snapshot/reader/" + id + ":"
+
+		for _, render := range []string{"", "auto", "text", "text_styled", "code"} {
+			u := base + "/subdir/dummy.txt"
+			if render != "" {
+				u += "?render=" + render
+			}
+			w := get(t, mux, u)
+			require.Equal(t, http.StatusOK, w.Code, "render=%s body=%s", render, w.Body.String())
+
+			switch render {
+			case "", "auto":
+				require.Contains(t, w.Header().Get("Content-type"), "text/plain")
+				require.Contains(t, w.Body.String(), "hello dummy")
+			case "text":
+				require.Contains(t, w.Header().Get("Content-type"), "text/plain")
+				require.Contains(t, w.Body.String(), "hello dummy")
+			case "text_styled":
+				require.Contains(t, w.Header().Get("Content-type"), "text/html")
+				require.Contains(t, w.Body.String(), "<pre>")
+			case "code":
+				require.Contains(t, w.Header().Get("Content-type"), "text/html")
+				require.Contains(t, w.Body.String(), "<!DOCTYPE html>")
+			}
+
+			// "noext" has no file extension
+			w = get(t, mux, strings.Replace(u, "dummy.txt", "noext", 1))
+			require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		}
+
+		base += "/subdir/dummy.txt"
+
+		// download=true sets a Content-Disposition attachment header.
+		w := get(t, mux, base+"?download=true")
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+
+		// an invalid render value is rejected.
+		w = get(t, mux, base+"?render=bogus")
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("reader render auto", func(t *testing.T) {
+		// No render param defaults to "auto".
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "hello dummy")
+	})
+
+	t.Run("reader download disposition", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?download=true")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+		require.Contains(t, w.Header().Get("Content-Disposition"), "dummy.txt")
+	})
+
+	t.Run("reader invalid render", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=invalid")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+
+		// code render path.
+		w = get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=code")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// reader for a non-existent file -> error.
+		w = get(t, mux, "/api/snapshot/reader/"+id+":/nope.txt")
+		require.NotEqual(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("reader missing file not found", func(t *testing.T) {
+		// GetEntry on a missing path bubbles up an fs.ErrNotExist which handleError
+		// maps to a 404.
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/missing.txt")
+		require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("reader sign url", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+id+":/subdir/dummy.txt", nil)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var resp map[string]map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.NotEmpty(t, resp["item"]["signature"])
+	})
+
+	// postDownload registers a download bundle and returns its (single-use) id.
+	postDownload := func(t *testing.T) string {
+		t.Helper()
 		body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
 		req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
 		w := httptest.NewRecorder()
@@ -692,119 +403,177 @@ func TestSnapshotDownloaderFormats(t *testing.T) {
 		return resp.Id
 	}
 
-	// tar format.
-	w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+post()+"?format=tar")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Header().Get("Content-Type"), "tar")
+	t.Run("downloader signed default name", func(t *testing.T) {
+		// No name query param -> handler synthesizes "snapshot-<id>-<ts>" + ext.
+		w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t)+"?format=zip")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Header().Get("Content-Disposition"), "snapshot-")
+		require.Contains(t, w.Header().Get("Content-Disposition"), ".zip")
+	})
 
-	// tarball format.
-	w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+post()+"?format=tarball")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	t.Run("downloader signed custom name", func(t *testing.T) {
+		// name already carries an extension -> the ext-appending branch is skipped.
+		w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t)+"?format=zip&name=custom.zip")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Header().Get("Content-Disposition"), "custom.zip")
+	})
 
-	// unknown format -> 400.
-	w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+post()+"?format=bogus")
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	t.Run("downloader signed not found", func(t *testing.T) {
+		// Unknown download id -> 404.
+		w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/does-not-exist?format=zip")
+		require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("downloader formats", func(t *testing.T) {
+		// tar format.
+		w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t)+"?format=tar")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Header().Get("Content-Type"), "tar")
+
+		// tarball format.
+		w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t)+"?format=tarball")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// unknown format -> 400.
+		w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t)+"?format=bogus")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("downloader flow", func(t *testing.T) {
+		// Without a format the signed endpoint rejects the request.
+		w := get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		// With a valid archive format it serves the bundle. (Re-POST first, as the
+		// id is single-use once consumed.)
+		w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+postDownload(t)+"?format=zip")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("downloader bad body", func(t *testing.T) {
+		// malformed JSON body -> 400.
+		req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString("{not-json"))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("downloader bad snapshot id", func(t *testing.T) {
+		// Empty snapshot id segment -> SnapshotPathParam returns a 400.
+		body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
+		req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/:/subdir", bytes.NewBufferString(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("handle error passes ApiError", func(t *testing.T) {
+		// An existing *ApiError is forwarded verbatim (its HttpCode and ErrCode
+		// preserved) rather than remapped.
+		req, _ := http.NewRequest("GET", "/x", nil)
+		w := httptest.NewRecorder()
+		handleError(w, req, &ApiError{HttpCode: http.StatusTeapot, ErrCode: "teapot", Message: "short and stout"})
+		require.Equal(t, http.StatusTeapot, w.Code)
+
+		var body ApiErrorRes
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		require.Equal(t, "teapot", body.Error.ErrCode)
+	})
 }
 
-func TestSnapshotDownloaderBadBody(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
+// The signed-reader cases need routes wired with a signing token, which is
+// a property of SetupRoutes and cannot be changed after the fact; hence a
+// second fixture for this group only.
+func TestSignedReader(t *testing.T) {
+	const token = "verify-token"
+	mux, _, snap, _ := server(t, token)
 	defer snap.Close()
 	id := snapid(snap)
 
-	// malformed JSON body -> 400.
-	req, _ := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString("{not-json"))
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-}
+	t.Run("valid signature", func(t *testing.T) {
+		sig := signReader(t, mux, token, id+":/subdir/dummy.txt")
 
-func TestSnapshotDownloaderFlow(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		// A valid signature lets the (otherwise token-protected) reader through.
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "hello dummy")
+	})
 
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
+	t.Run("tampered path", func(t *testing.T) {
+		sig := signReader(t, mux, token, id+":/subdir/dummy.txt")
 
-	// POST a download request describing which files to bundle.
-	body := `{"name":"dl","items":[{"pathname":"/subdir/dummy.txt"}]}`
-	req, err := http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		// Same valid signature but requesting a different path -> rejected.
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/top.txt?signature="+sig)
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+	})
 
-	var resp struct {
-		Id string `json:"id"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.NotEmpty(t, resp.Id)
+	t.Run("bad signature", func(t *testing.T) {
+		// Garbage signature -> JWT parse failure -> 401.
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature=not-a-jwt")
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+	})
 
-	// Without a format the signed endpoint rejects the request.
-	w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+resp.Id)
-	require.Equal(t, http.StatusBadRequest, w.Code)
+	t.Run("expired", func(t *testing.T) {
+		// Hand-craft an already-expired token signed with the right key.
+		now := time.Now().Add(-3 * time.Hour)
+		jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, SnapshotSignedURLClaims{
+			SnapshotID: id,
+			Path:       "/subdir/dummy.txt",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(now.Add(1 * time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(now),
+				Issuer:    "plakar-api",
+			},
+		})
+		sig, err := jwtToken.SignedString([]byte(token))
+		require.NoError(t, err)
 
-	// With a valid archive format it serves the bundle. (Re-POST first, as the
-	// id is single-use once consumed.)
-	req, err = http.NewRequest("POST", "/api/snapshot/vfs/downloader/"+id+":/subdir", bytes.NewBufferString(body))
-	require.NoError(t, err)
-	w = httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "expired")
+	})
 
-	w = get(t, mux, "/api/snapshot/vfs/downloader-sign-url/"+resp.Id+"?format=zip")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
+	t.Run("wrong signing method", func(t *testing.T) {
+		// A token with the "none" alg should be rejected by the method check.
+		jwtToken := jwt.NewWithClaims(jwt.SigningMethodNone, SnapshotSignedURLClaims{
+			SnapshotID: id,
+			Path:       "/subdir/dummy.txt",
+		})
+		sig, err := jwtToken.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		require.NoError(t, err)
 
-func TestSnapshotVFSChunks(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?signature="+sig)
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
+	})
 
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
+	t.Run("no signature requires token", func(t *testing.T) {
+		// No signature and no Authorization header -> token middleware rejects.
+		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
+		require.Equal(t, http.StatusUnauthorized, w.Code, "body=%s", w.Body.String())
 
-func TestSnapshotVFSChunksOffset(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
+		// With the correct Bearer token it succeeds.
+		req, _ := http.NewRequest("GET", "/api/snapshot/reader/"+id+":/subdir/dummy.txt", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w = httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
 
-	// offset beyond the chunk count -> empty Items but valid Total.
-	w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?offset=1000&limit=10")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
+	t.Run("sign nonexistent path", func(t *testing.T) {
+		// Signing a path that does not exist in the snapshot returns an error.
+		req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/"+id+":/no/such/file", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.NotEqual(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
 
-	// chunks on a missing path returns 200 with empty body (early nil return).
-	w = get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/dir/missing.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-}
-
-func TestSnapshotVFSChunksPaging(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-	id := snapid(snap)
-
-	w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?offset=0&limit=10")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "total")
-
-	// bad limit -> error.
-	w = get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt?limit=abc")
-	require.NotEqual(t, http.StatusOK, w.Code)
-}
-
-// TestHandleErrorPassesApiError verifies an existing *ApiError is
-// forwarded verbatim (its HttpCode and ErrCode preserved) rather than
-// remapped.
-func TestHandleErrorPassesApiError(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/x", nil)
-	w := httptest.NewRecorder()
-	handleError(w, req, &ApiError{HttpCode: http.StatusTeapot, ErrCode: "teapot", Message: "short and stout"})
-	require.Equal(t, http.StatusTeapot, w.Code)
-
-	var body ApiErrorRes
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	require.Equal(t, "teapot", body.Error.ErrCode)
+	t.Run("sign bad snapshot id", func(t *testing.T) {
+		// Empty snapshot id segment -> SnapshotPathParam missing-arg error.
+		req, _ := http.NewRequest("POST", "/api/snapshot/reader-sign-url/:/subdir/dummy.txt", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
 }

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -35,11 +35,6 @@ func TestSnapshot(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	})
 
-	t.Run("header bad id", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/nothexnothex")
-		require.NotEqual(t, http.StatusOK, w.Code)
-	})
-
 	t.Run("header not found", func(t *testing.T) {
 		// mangle the snapid so that it does not match
 		snapid := snap.Header.GetIndexID()
@@ -58,11 +53,6 @@ func TestSnapshot(t *testing.T) {
 	t.Run("header bad param", func(t *testing.T) {
 		w := get(t, mux, "/api/snapshot/zz")
 		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-	})
-
-	t.Run("vfs search", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/vfs/search/"+id+":/subdir?recursive=true")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	})
 
 	t.Run("vfs search has next", func(t *testing.T) {
@@ -148,11 +138,6 @@ func TestSnapshot(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 	})
 
-	t.Run("vfs children", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	})
-
 	t.Run("vfs children root", func(t *testing.T) {
 		// The root directory prepends no ".." entry (fsinfo.Path() == "/").
 		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/")
@@ -160,22 +145,6 @@ func TestSnapshot(t *testing.T) {
 		var items Items[json.RawMessage]
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
 		require.Greater(t, len(items.Items), 0)
-	})
-
-	t.Run("vfs children desc sort", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?sort=-Name&offset=0&limit=2")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		var items Items[json.RawMessage]
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
-		require.Greater(t, len(items.Items), 0)
-	})
-
-	t.Run("vfs children second page", func(t *testing.T) {
-		// offset>0 takes the branch that decrements offset for the implicit "..".
-		w := get(t, mux, "/api/snapshot/vfs/children/"+id+":/subdir?offset=1&limit=5")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		var items Items[json.RawMessage]
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &items))
 	})
 
 	t.Run("vfs children limit decrement to zero", func(t *testing.T) {
@@ -220,19 +189,6 @@ func TestSnapshot(t *testing.T) {
 		require.NotEqual(t, http.StatusOK, w.Code)
 	})
 
-	t.Run("vfs errors", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	})
-
-	t.Run("vfs errors window break", func(t *testing.T) {
-		// offset 0 / limit 1 over a clean directory exercises the i>=offset+limit
-		// break path in the error iterator window arithmetic.
-		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		require.Contains(t, w.Body.String(), "total")
-	})
-
 	t.Run("vfs errors paging", func(t *testing.T) {
 		// Exercise the offset/limit window arithmetic on a clean (no-error) dir.
 		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=1")
@@ -247,17 +203,11 @@ func TestSnapshot(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
 	})
 
-	t.Run("vfs errors sort and paging", func(t *testing.T) {
-		// explicit Name sort + a paging window over an error-free directory.
-		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?sort=Name&offset=0&limit=5")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		require.Contains(t, w.Body.String(), "total")
-	})
-
 	t.Run("vfs errors handler", func(t *testing.T) {
-		// happy path on a dir.
+		// happy path on a dir, with a paging window.
 		w := get(t, mux, "/api/snapshot/vfs/errors/"+id+":/subdir?offset=0&limit=10")
 		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+		require.Contains(t, w.Body.String(), "total")
 
 		// invalid sort key -> 400.
 		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/?sort=Bogus")
@@ -270,11 +220,6 @@ func TestSnapshot(t *testing.T) {
 		// errors of a regular file -> 400 not a directory.
 		w = get(t, mux, "/api/snapshot/vfs/errors/"+id+":/top.txt")
 		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-	})
-
-	t.Run("vfs chunks", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/vfs/chunks/"+id+":/subdir/dummy.txt")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	})
 
 	t.Run("vfs chunks offset", func(t *testing.T) {
@@ -331,41 +276,15 @@ func TestSnapshot(t *testing.T) {
 
 		base += "/subdir/dummy.txt"
 
-		// download=true sets a Content-Disposition attachment header.
+		// download=true sets a Content-Disposition attachment header naming the file.
 		w := get(t, mux, base+"?download=true")
 		require.Equal(t, http.StatusOK, w.Code)
 		require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+		require.Contains(t, w.Header().Get("Content-Disposition"), "dummy.txt")
 
 		// an invalid render value is rejected.
 		w = get(t, mux, base+"?render=bogus")
 		require.Equal(t, http.StatusBadRequest, w.Code)
-	})
-
-	t.Run("reader render auto", func(t *testing.T) {
-		// No render param defaults to "auto".
-		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		require.Contains(t, w.Body.String(), "hello dummy")
-	})
-
-	t.Run("reader download disposition", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?download=true")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-		require.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
-		require.Contains(t, w.Header().Get("Content-Disposition"), "dummy.txt")
-	})
-
-	t.Run("reader invalid render", func(t *testing.T) {
-		w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=invalid")
-		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
-
-		// code render path.
-		w = get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt?render=code")
-		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-		// reader for a non-existent file -> error.
-		w = get(t, mux, "/api/snapshot/reader/"+id+":/nope.txt")
-		require.NotEqual(t, http.StatusOK, w.Code)
 	})
 
 	t.Run("reader missing file not found", func(t *testing.T) {

--- a/api/api_snapshot_test.go
+++ b/api/api_snapshot_test.go
@@ -400,19 +400,6 @@ func TestVFSErrorsHandler(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 }
 
-func TestSnapshotReader(t *testing.T) {
-	// The reader endpoint serves file content. With an empty token, the URL
-	// signer's VerifyMiddleware falls through to the (no-op) token auth.
-	mux, _, snap, _ := server(t, "")
-	defer snap.Close()
-
-	indexID := snap.Header.GetIndexID()
-	id := hex.EncodeToString(indexID[:])
-	w := get(t, mux, "/api/snapshot/reader/"+id+":/subdir/dummy.txt")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Contains(t, w.Body.String(), "hello dummy")
-}
-
 func TestSnapshotReaderSignedReaderValid(t *testing.T) {
 	const token = "verify-token"
 	mux, _, snap, _ := server(t, token)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,56 +13,89 @@ import (
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
 	"github.com/PlakarKorp/plakar/login"
-	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func TestHandleErrorMapping(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want int
-	}{
-		{"not-readable -> 400", repository.ErrNotReadable, http.StatusBadRequest},
-		{"blob-not-found -> 404", repository.ErrBlobNotFound, http.StatusNotFound},
-		{"packfile-not-found -> 500", repository.ErrPackfileNotFound, http.StatusInternalServerError},
-		{"fs-not-exist -> 404", fs.ErrNotExist, http.StatusNotFound},
-		{"snapshot-not-found -> 404", snapshot.ErrNotFound, http.StatusNotFound},
-		{"non-wrapped fs-not-exist -> 500", errors.New("boom: " + fs.ErrNotExist.Error()), http.StatusInternalServerError},
-		{"unknown -> 500", errors.New("some random failure"), http.StatusInternalServerError},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/whatever", nil)
-			w := httptest.NewRecorder()
-			handleError(w, req, c.err)
-			require.Equal(t, c.want, w.Code)
-
-			var body ApiErrorRes
-			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-			require.NotNil(t, body.Error)
-		})
-	}
-}
-
-func TestUnknownEndpoint(t *testing.T) {
-	mux, _, snap, _ := server(t, "")
+// TestAPI covers routing, error mapping and the /api/info handler. Most cases
+// share one fixture; the two that need routes wired differently (a token, and
+// demo mode, both of which SetupRoutes reads at construction time) build their
+// own inside their subtest.
+func TestAPI(t *testing.T) {
+	mux, _, snap, ctx := server(t, "")
 	defer snap.Close()
 
-	w := get(t, mux, "/api/does-not-exist")
-	require.Equal(t, http.StatusNotFound, w.Code)
+	t.Run("handle error mapping", func(t *testing.T) {
+		for _, c := range []struct {
+			name string
+			err  error
+			want int
+		}{
+			{"not-readable -> 400", repository.ErrNotReadable, http.StatusBadRequest},
+			{"blob-not-found -> 404", repository.ErrBlobNotFound, http.StatusNotFound},
+			{"packfile-not-found -> 500", repository.ErrPackfileNotFound, http.StatusInternalServerError},
+			{"fs-not-exist -> 404", fs.ErrNotExist, http.StatusNotFound},
+			{"snapshot-not-found -> 404", snapshot.ErrNotFound, http.StatusNotFound},
+			{"non-wrapped fs-not-exist -> 500", errors.New("boom: " + fs.ErrNotExist.Error()), http.StatusInternalServerError},
+			{"unknown -> 500", errors.New("some random failure"), http.StatusInternalServerError},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				req, _ := http.NewRequest("GET", "/whatever", nil)
+				w := httptest.NewRecorder()
+				handleError(w, req, c.err)
+				require.Equal(t, c.want, w.Code)
+
+				var body ApiErrorRes
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+				require.NotNil(t, body.Error)
+			})
+		}
+	})
+
+	t.Run("unknown endpoint", func(t *testing.T) {
+		w := get(t, mux, "/api/does-not-exist")
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("info authenticated", func(t *testing.T) {
+		// Drop an auth token into the cookie jar so apiInfo reports authenticated,
+		// and take it back out so the shared fixture stays unauthenticated.
+		require.NoError(t, ctx.GetCookies().PutAuthToken("some-auth-token"))
+		t.Cleanup(func() { _ = ctx.GetCookies().DeleteAuthToken() })
+
+		w := get(t, mux, "/api/info")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var resp struct {
+			Authenticated bool   `json:"authenticated"`
+			RepositoryId  string `json:"repository_id"`
+			Version       string `json:"version"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.True(t, resp.Authenticated)
+		require.NotEmpty(t, resp.RepositoryId)
+	})
+
+	t.Run("login flow error maps rate limit to 429", func(t *testing.T) {
+		err := loginFlowError(fmt.Errorf("failed to run login flow: %w", login.ErrRateLimited))
+
+		var apiErr *ApiError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusTooManyRequests, apiErr.HttpCode)
+		require.Equal(t, "rate-limited", apiErr.ErrCode)
+	})
+
+	t.Run("login flow error passes through other errors", func(t *testing.T) {
+		err := loginFlowError(errors.New("boom"))
+
+		var apiErr *ApiError
+		require.False(t, errors.As(err, &apiErr), "non-rate-limit error must not be mapped to an ApiError")
+		require.ErrorContains(t, err, "boom")
+	})
 }
 
 func TestAuthTokenRequired(t *testing.T) {
-	repo, ctx := ptesting.GenerateRepository(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil), nil)
-	snap := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
-		ptesting.NewMockFile("a.txt", 0644, "a"),
-	})
+	mux, _, snap, _ := server(t, "secret-token")
 	defer snap.Close()
-
-	mux := http.NewServeMux()
-	SetupRoutes(mux, repo, ctx, "secret-token", true)
 
 	// Missing Authorization header -> 401.
 	w := get(t, mux, "/api/info")
@@ -101,41 +133,4 @@ func TestInfoDemoMode(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.True(t, resp.DemoMode)
-}
-
-func TestApiInfoAuthenticated(t *testing.T) {
-	mux, _, snap, ctx := server(t, "")
-	defer snap.Close()
-
-	// Drop an auth token into the cookie jar so apiInfo reports authenticated.
-	require.NoError(t, ctx.GetCookies().PutAuthToken("some-auth-token"))
-
-	w := get(t, mux, "/api/info")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-
-	var resp struct {
-		Authenticated bool   `json:"authenticated"`
-		RepositoryId  string `json:"repository_id"`
-		Version       string `json:"version"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.True(t, resp.Authenticated)
-	require.NotEmpty(t, resp.RepositoryId)
-}
-
-func TestLoginFlowErrorMapsRateLimitTo429(t *testing.T) {
-	err := loginFlowError(fmt.Errorf("failed to run login flow: %w", login.ErrRateLimited))
-
-	var apiErr *ApiError
-	require.ErrorAs(t, err, &apiErr)
-	require.Equal(t, http.StatusTooManyRequests, apiErr.HttpCode)
-	require.Equal(t, "rate-limited", apiErr.ErrCode)
-}
-
-func TestLoginFlowErrorPassesThroughOtherErrors(t *testing.T) {
-	err := loginFlowError(errors.New("boom"))
-
-	var apiErr *ApiError
-	require.False(t, errors.As(err, &apiErr), "non-rate-limit error must not be mapped to an ApiError")
-	require.ErrorContains(t, err, "boom")
 }


### PR DESCRIPTION
drop some duplicate tests, then try to move them under a global top-level per-file test, so fixtures can be generated usually once.  This brings the regress from ~20s down to 3s without affecting coverage at all.  While here, also sneak in some nitpicks.

better read commit by commit with whitespaces disabled =)