### PR TITLE
action: force build of the tools

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,9 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Build
-      run: go build -v ./...
+      run: |
+        go build -v ./...
+        go build -tool
 
     # Produce a coverage profile (Codecov coverage) and a JUnit XML (Codecov
     # Test Analytics) in one run. The `timeout -s QUIT 5m` wrapper is kept so a

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build
       run: |
         go build -v ./...
-        go build -tool
+        go build tool
 
     # Produce a coverage profile (Codecov coverage) and a JUnit XML (Codecov
     # Test Analytics) in one run. The `timeout -s QUIT 5m` wrapper is kept so a


### PR DESCRIPTION
this should at least make it more obvious if go fails at downloading the tools (or their deps) for the test step.