### PR TITLE
fix: correct make install man dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ plakar:
 install:
 	mkdir -p ${DESTDIR}${BINDIR}
 	mkdir -p ${DESTDIR}${MANDIR}/man1
+	mkdir -p ${DESTDIR}${MANDIR}/man7
 	${INSTALL_PROGRAM} plakar ${DESTDIR}${BINDIR}
-	find cmd/plakar -iname \*.1 -exec \
-		${INSTALL_MAN} {} ${DESTDIR}${MANDIR}/man1 \;
+	${INSTALL_MAN} *.1 ${DESTDIR}${MANDIR}/man1
+	${INSTALL_MAN} *.7 ${DESTDIR}${MANDIR}/man7
 
 check: test
 test:


### PR DESCRIPTION
# Issue
`make install` does not work.
The man pages files have been moved to the root directory but the `Makefile` has not been updated.

# This PR
- Updates the `Makefile` to use the correct man pages source
- Ads plakar-query (7) page to installed man pages

# Before (error)

```bash
$ make PREFIX='' DESTDIR=$HOME/.local install
mkdir -p /home/vigand/.local/bin
mkdir -p /home/vigand/.local/man/man1
install -m 0555 plakar /home/vigand/.local/bin
find cmd/plakar -iname \*.1 -exec \
        install -m 0444 {} /home/vigand/.local/man/man1 \;
find: ‘cmd/plakar’: No such file or directory
make: *** [Makefile:21: install] Error 1
```

# After

```bash
$ make PREFIX='' DESTDIR=$HOME/.local install
mkdir -p /home/vigand/.local/bin
mkdir -p /home/vigand/.local/man/man1
mkdir -p /home/vigand/.local/man/man7
install -m 0555 plakar /home/vigand/.local/bin
install -m 0444 *.1 /home/vigand/.local/man/man1
install -m 0444 *.7 /home/vigand/.local/man/man7
```