### PR TITLE
makefile: don't rely on the shell expanding man{1,5,7}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ plakar:
 
 install:
 	mkdir -p ${DESTDIR}${BINDIR}
-	mkdir -p ${DESTDIR}${MANDIR}/man{1,5,7}
+	mkdir -p ${DESTDIR}${MANDIR}/man1
+	mkdir -p ${DESTDIR}${MANDIR}/man5
+	mkdir -p ${DESTDIR}${MANDIR}/man7
 	${INSTALL_PROGRAM} plakar ${DESTDIR}${BINDIR}
 	find . -name \*.1 -exec ${INSTALL_MAN} {} ${DESTDIR}${MANDIR}/man1 \;
 	find . -name \*.5 -exec ${INSTALL_MAN} {} ${DESTDIR}${MANDIR}/man5 \;


### PR DESCRIPTION
posix does not require sh to do so, c.f. IEEE Std 1003.1-2024, Shell & Utilities, Ch. 2.6:

> 2. When the expansion occurs in a context where field splitting will
>    be performed, a word that contains all of the following somewhere
>    within it, before any expansions are applied, in the order
>    specified:
>
>    * an unquoted <left-curly-bracket> ('{') that is not immediately
>      preceded by an unquoted <dollar-sign> ('$')
>
>    * one or more unquoted <comma> (',') characters or a sequence
>      that consists of two adjacent <period> ('.') characters
>      surrounded by other characters (which can also be <period>
>      characters)
>
>    * an unquoted <right-curly-bracket> ('}')
>
>    **may be subject to an additional implementation-defined form of
>    expansion** that can create multiple fields from a single
>    word. This expansion, **if supported**, shall be applied before
>    all the other word expansions are applied. The other expansions
>    shall then be applied to each field that results from this
>    expansion.

(emphasis mine)

https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html