### PR TITLE
subcommands: let create and ptar pick the compression algorithm

### DIFF
--- a/subcommands/create/create.go
+++ b/subcommands/create/create.go
@@ -46,13 +46,14 @@ func (cmd *Create) CobraCommand() *cobra.Command {
 	}
 	c.Flags().BoolVar(&cmd.allowWeak, "weak-passphrase", false, "allow weak passphrase to protect the repository")
 	c.Flags().StringVar(&cmd.Hashing, "hashing", hashing.DEFAULT_HASHING_ALGORITHM, "hashing algorithm to use for digests")
+	c.Flags().StringVar(&cmd.Compression, "compression", compression.DEFAULT_COMPRESSION_ALGORITHM, "compression algorithm to use for transparent compression")
 	c.Flags().BoolVar(&cmd.NoEncryption, "plaintext", false, "disable transparent encryption")
 	c.Flags().BoolVar(&cmd.NoCompression, "no-compression", false, "disable transparent compression")
 	return c
 }
 
 func (cmd *Create) Parse(ctx *appcontext.AppContext, args []string) error {
-	rest, err := subcommands.ParseCobra(cmd, args)
+	rest, flags, err := subcommands.ParseCobraFlags(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -63,6 +64,16 @@ func (cmd *Create) Parse(ctx *appcontext.AppContext, args []string) error {
 
 	if hashing.GetHasher(strings.ToUpper(cmd.Hashing)) == nil {
 		return fmt.Errorf("unknown hashing algorithm")
+	}
+
+	if cmd.NoCompression && flags.Changed("compression") {
+		return fmt.Errorf("--compression and --no-compression are mutually exclusive")
+	}
+
+	if !cmd.NoCompression {
+		if _, err := compression.LookupDefaultConfiguration(strings.ToUpper(cmd.Compression)); err != nil {
+			return err
+		}
 	}
 
 	minEntropBits := 80.
@@ -97,6 +108,7 @@ type Create struct {
 	subcommands.SubcommandBase
 
 	Hashing       string
+	Compression   string
 	NoEncryption  bool
 	NoCompression bool
 
@@ -108,7 +120,11 @@ func (cmd *Create) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 	if cmd.NoCompression {
 		storageConfiguration.Compression = nil
 	} else {
-		storageConfiguration.Compression = compression.NewDefaultConfiguration()
+		compressionConfiguration, err := compression.LookupDefaultConfiguration(strings.ToUpper(cmd.Compression))
+		if err != nil {
+			return 1, err
+		}
+		storageConfiguration.Compression = compressionConfiguration
 	}
 
 	hashingConfiguration, err := hashing.LookupDefaultConfiguration(strings.ToUpper(cmd.Hashing))

--- a/subcommands/create/plakar-create.1
+++ b/subcommands/create/plakar-create.1
@@ -6,6 +6,8 @@
 .Nd Create a new Plakar repository
 .Sh SYNOPSIS
 .Nm plakar create
+.Op Fl compression Ar algorithm
+.Op Fl no-compression
 .Op Fl plaintext
 .Sh DESCRIPTION
 The
@@ -15,6 +17,22 @@ command creates a new Plakar repository at the specified path which defaults to
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl compression Ar algorithm
+Select the algorithm used for transparent compression.
+Supported values are
+.Cm LZ4 ,
+.Cm GZIP
+and
+.Cm ZSTD ,
+and the name is matched case-insensitively.
+Defaults to
+.Cm LZ4 .
+The algorithm is recorded in the repository configuration when it is created and
+cannot be changed afterwards.
+.It Fl no-compression
+Disable transparent compression for the repository.
+Mutually exclusive with
+.Fl compression .
 .It Fl plaintext
 Disable transparent encryption for the repository.
 If specified, the repository will not use encryption.

--- a/subcommands/help/docs/plakar-create.md
+++ b/subcommands/help/docs/plakar-create.md
@@ -7,6 +7,8 @@ PLAKAR-CREATE(1) - General Commands Manual
 # SYNOPSIS
 
 **plakar&nbsp;create**
+\[**-compression**&nbsp;*algorithm*]
+\[**-no-compression**]
 \[**-plaintext**]
 
 # DESCRIPTION
@@ -17,6 +19,26 @@ command creates a new Plakar repository at the specified path which defaults to
 *~/.plakar*.
 
 The options are as follows:
+
+**-compression**&nbsp;*algorithm*
+
+> Select the algorithm used for transparent compression.
+> Supported values are
+> **LZ4**,
+> **GZIP**
+> and
+> **ZSTD**,
+> and the name is matched case-insensitively.
+> Defaults to
+> **LZ4**.
+> The algorithm is recorded in the repository configuration when it is created and
+> cannot be changed afterwards.
+
+**-no-compression**
+
+> Disable transparent compression for the repository.
+> Mutually exclusive with
+> **-compression**.
 
 **-plaintext**
 

--- a/subcommands/help/docs/plakar-ptar.md
+++ b/subcommands/help/docs/plakar-ptar.md
@@ -7,6 +7,8 @@ PLAKAR-PTAR(1) - General Commands Manual
 # SYNOPSIS
 
 **plakar&nbsp;ptar**
+\[**-compression**&nbsp;*algorithm*]
+\[**-no-compression**]
 \[**-plaintext**]
 \[**-overwrite**]
 \[**-ignore**&nbsp;*pattern*]
@@ -44,6 +46,24 @@ flag is given,
 refuses to replace an existing archive.
 
 The options are as follows:
+
+**-compression**&nbsp;*algorithm*
+
+> Select the algorithm used for transparent compression.
+> Supported values are
+> **LZ4**,
+> **GZIP**
+> and
+> **ZSTD**,
+> and the name is matched case-insensitively.
+> Defaults to
+> **LZ4**.
+
+**-no-compression**
+
+> Disable transparent compression of the archive.
+> Mutually exclusive with
+> **-compression**.
 
 **-plaintext**
 

--- a/subcommands/ptar/plakar-ptar.1
+++ b/subcommands/ptar/plakar-ptar.1
@@ -6,6 +6,8 @@
 .Nd generate a self-contained Kloset archive (.ptar)
 .Sh SYNOPSIS
 .Nm plakar ptar
+.Op Fl compression Ar algorithm
+.Op Fl no-compression
 .Op Fl plaintext
 .Op Fl overwrite
 .Op Fl ignore Ar pattern
@@ -54,6 +56,20 @@ arguments, which are always backed up in full.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl compression Ar algorithm
+Select the algorithm used for transparent compression.
+Supported values are
+.Cm LZ4 ,
+.Cm GZIP
+and
+.Cm ZSTD ,
+and the name is matched case-insensitively.
+Defaults to
+.Cm LZ4 .
+.It Fl no-compression
+Disable transparent compression of the archive.
+Mutually exclusive with
+.Fl compression .
 .It Fl plaintext
 Disable transparent encryption of the archive.
 If omitted,

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -52,6 +52,7 @@ type Ptar struct {
 
 	AllowWeak     bool
 	Hashing       string
+	Compression   string
 	NoEncryption  bool
 	NoCompression bool
 	Overwrite     bool
@@ -93,6 +94,7 @@ func (cmd *Ptar) CobraCommand() *cobra.Command {
 		Use: "ptar [OPTIONS] -o out.ptar [@location | path]...",
 	}
 	c.Flags().StringVar(&cmd.Hashing, "hashing", hashing.DEFAULT_HASHING_ALGORITHM, "hashing algorithm to use for digests")
+	c.Flags().StringVar(&cmd.Compression, "compression", compression.DEFAULT_COMPRESSION_ALGORITHM, "compression algorithm to use for transparent compression")
 	c.Flags().BoolVar(&cmd.NoEncryption, "plaintext", false, "disable transparent encryption")
 	c.Flags().BoolVar(&cmd.NoCompression, "no-compression", false, "disable transparent compression")
 	c.Flags().BoolVar(&cmd.Overwrite, "overwrite", false, "overwrite the ptar archive if it already exists")
@@ -106,7 +108,7 @@ func (cmd *Ptar) CobraCommand() *cobra.Command {
 }
 
 func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
-	rest, err := subcommands.ParseCobra(cmd, args)
+	rest, flags, err := subcommands.ParseCobraFlags(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -198,6 +200,16 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 		return fmt.Errorf("unknown hashing algorithm")
 	}
 
+	if cmd.NoCompression && flags.Changed("compression") {
+		return fmt.Errorf("--compression and --no-compression are mutually exclusive")
+	}
+
+	if !cmd.NoCompression {
+		if _, err := compression.LookupDefaultConfiguration(strings.ToUpper(cmd.Compression)); err != nil {
+			return err
+		}
+	}
+
 	if !cmd.NoEncryption {
 		var passphrase []byte
 
@@ -235,7 +247,11 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (
 	if cmd.NoCompression {
 		storageConfiguration.Compression = nil
 	} else {
-		storageConfiguration.Compression = compression.NewDefaultConfiguration()
+		compressionConfiguration, err := compression.LookupDefaultConfiguration(strings.ToUpper(cmd.Compression))
+		if err != nil {
+			return 1, err
+		}
+		storageConfiguration.Compression = compressionConfiguration
 	}
 
 	hashingConfiguration, err := hashing.LookupDefaultConfiguration(strings.ToUpper(cmd.Hashing))

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -127,6 +127,14 @@ func (e ErrUsage) Unwrap() error { return e.err }
 // positional arguments.  Errors come back to the caller instead of cobra
 // printing its own message and usage tree.
 func ParseCobra(cmd Subcommand, args []string) ([]string, error) {
+	rest, _, err := ParseCobraFlags(cmd, args)
+	return rest, err
+}
+
+// ParseCobraFlags is ParseCobra, additionally handing back the flag set it
+// parsed into.  Commands need it to tell an explicitly-passed option from one
+// left at its default value, via flags.Changed().
+func ParseCobraFlags(cmd Subcommand, args []string) ([]string, *pflag.FlagSet, error) {
 	c := cmd.CobraCommand()
 	c.SilenceUsage = true
 	c.SilenceErrors = true
@@ -136,13 +144,13 @@ func ParseCobra(cmd Subcommand, args []string) ([]string, error) {
 
 	rewritten, err := SingleDash(flags, args)
 	if err != nil {
-		return nil, ErrUsage{err}
+		return nil, nil, ErrUsage{err}
 	}
 	if err := flags.Parse(rewritten); err != nil {
-		return nil, ErrUsage{err}
+		return nil, nil, ErrUsage{err}
 	}
 
-	return flags.Args(), nil
+	return flags.Args(), flags, nil
 }
 
 type CmdFactory func() Subcommand


### PR DESCRIPTION
create and ptar could only take the default LZ4 or switch compression off
entirely, so the GZIP that kloset has always supported was unreachable from the
command line, and so is the zstd added in PlakarKorp/kloset#521.

Add -compression next to -hashing, matched case-insensitively and validated in
Parse, so a bad algorithm name fails before anything is created rather than at
the point the configuration is written.  Passing it together with
-no-compression is an error too — one of the two would otherwise silently win.
The default is unchanged, so a plain "plakar create" still gets LZ4.

Telling an option left at its default from one the user actually typed needs the
flag set, which ParseCobra threw away.  ParseCobraFlags returns it and
ParseCobra is now a call to it, so the other sixty-odd commands keep the
signature they have.

While here, document -compression and -no-compression in both manpages; neither
had ever mentioned -no-compression or -hashing.

Depends on PlakarKorp/kloset#521 for DEFAULT_COMPRESSION_ALGORITHM and the ZSTD
case, so this is a draft: the build fails on that one symbol until kloset is
merged and the dependency re-pinned.  Everything else is in place — run against
a local kloset, a zstd repository creates, backs up and restores byte-identical,
GZIP and mixed-case names work, and the bad and conflicting flags exit 1.
