### PR TITLE
Wire pkg add for containerized integrations

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -22,8 +22,11 @@ func setupPkgManager(ctx *appcontext.AppContext, configDir, dataDir, cacheDir st
 
 	backend, err := pkg.NewFlatBackend(ctx.GetInner(), plugdir, cachedir, &pkg.FlatBackendOptions{
 		PreLoadHook: pkgpreloadhook,
-		LoadHook:    pkgloadhook,
-		UnloadHook:  pkgunloadhook,
+		InstallHook: func(m *pkg.Manifest) error {
+			return plugins.EnsureImages(ctx, m, ctx.Stdout, ctx.Stderr)
+		},
+		LoadHook:   pkgloadhook,
+		UnloadHook: pkgunloadhook,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to init the package manager: %w", err)

--- a/plugins/image.go
+++ b/plugins/image.go
@@ -1,0 +1,58 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/PlakarKorp/pkg"
+)
+
+// EnsureImages makes sure the images pinned by a manifest are present in the
+// local docker store: an image already present by ID is used as-is (the
+// self-built case), a missing one is pulled from its registry reference and
+// the pulled ID must match the pin. Pull progress is streamed to stdout and
+// stderr.
+func EnsureImages(ctx context.Context, m *pkg.Manifest, stdout, stderr io.Writer) error {
+	for _, conn := range m.Connectors {
+		if conn.ImageID == "" {
+			continue
+		}
+
+		if _, err := imageID(ctx, conn.ImageID); err == nil {
+			continue
+		}
+
+		if conn.Image == "" {
+			return fmt.Errorf("image %s is not present; rebuild the package with plakar pkg create -container",
+				conn.ImageID)
+		}
+
+		pull := exec.CommandContext(ctx, "docker", "pull", conn.Image)
+		pull.Stdout = stdout
+		pull.Stderr = stderr
+		if err := pull.Run(); err != nil {
+			return fmt.Errorf("failed to pull %s: %w", conn.Image, err)
+		}
+
+		id, err := imageID(ctx, conn.Image)
+		if err != nil {
+			return err
+		}
+		if id != conn.ImageID {
+			return fmt.Errorf("pulled image %s has ID %s, but the package pins %s: refusing to install",
+				conn.Image, id, conn.ImageID)
+		}
+	}
+	return nil
+}
+
+func imageID(ctx context.Context, ref string) (string, error) {
+	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{.Id}}", ref).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect image %s: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/plugins/image_test.go
+++ b/plugins/image_test.go
@@ -1,0 +1,146 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/pkg"
+)
+
+// fakeImageDocker prepends a docker stand-in to PATH that emulates
+// `image inspect` and `pull` against a state dir of present-<ref> files.
+// A pull makes its ref present with the given pullID, or fails when pullID
+// is empty.
+func fakeImageDocker(t *testing.T, pullID string) (statedir string) {
+	t.Helper()
+	statedir = t.TempDir()
+
+	pull := `echo "pull access denied" >&2; exit 1`
+	if pullID != "" {
+		pull = fmt.Sprintf(`key=$(printf %%s "$2" | tr '/:' '__')
+	printf %%s %s > "$STATE/present-$key"
+	exit 0`, pullID)
+	}
+
+	script := fmt.Sprintf(`#!/bin/sh
+STATE=%s
+echo "$@" >> "$STATE/log"
+case "$1" in
+image)
+	# image inspect --format {{.Id}} <ref>
+	key=$(printf %%s "$5" | tr '/:' '__')
+	if [ -f "$STATE/present-$key" ]; then cat "$STATE/present-$key"; exit 0; fi
+	echo "Error: No such image: $5" >&2
+	exit 1;;
+pull)
+	%s;;
+esac
+exit 1
+`, statedir, pull)
+
+	bindir := filepath.Join(statedir, "bin")
+	if err := os.Mkdir(bindir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bindir, "docker"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bindir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return statedir
+}
+
+func markPresent(t *testing.T, statedir, ref, id string) {
+	t.Helper()
+	key := strings.NewReplacer("/", "_", ":", "_").Replace(ref)
+	if err := os.WriteFile(filepath.Join(statedir, "present-"+key), []byte(id), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func dockerLog(t *testing.T, statedir string) string {
+	t.Helper()
+	log, err := os.ReadFile(filepath.Join(statedir, "log"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return string(log)
+}
+
+const imageManifestID = "sha256:1111"
+
+func imageManifest(image string) *pkg.Manifest {
+	return &pkg.Manifest{
+		Connectors: []pkg.ManifestConnector{
+			{Type: "importer", Protocols: []string{"x"}, ImageID: imageManifestID, Image: image},
+		},
+	}
+}
+
+func TestEnsureImagesNativeManifestUntouched(t *testing.T) {
+	statedir := fakeImageDocker(t, "")
+
+	m := &pkg.Manifest{Connectors: []pkg.ManifestConnector{
+		{Type: "importer", Protocols: []string{"x"}, Executable: "noop"},
+	}}
+	if err := EnsureImages(context.Background(), m, io.Discard, io.Discard); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+	if log := dockerLog(t, statedir); log != "" {
+		t.Fatalf("native manifest should not touch docker, got: %s", log)
+	}
+}
+
+func TestEnsureImagesAlreadyPresent(t *testing.T) {
+	statedir := fakeImageDocker(t, "")
+	markPresent(t, statedir, imageManifestID, imageManifestID)
+
+	if err := EnsureImages(context.Background(), imageManifest("reg/img:1"), io.Discard, io.Discard); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+	if log := dockerLog(t, statedir); strings.Contains(log, "pull") {
+		t.Fatalf("present image should not be pulled, got: %s", log)
+	}
+}
+
+func TestEnsureImagesAbsentWithoutRef(t *testing.T) {
+	fakeImageDocker(t, "")
+
+	err := EnsureImages(context.Background(), imageManifest(""), io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "rebuild the package") {
+		t.Fatalf("want a rebuild error, got: %v", err)
+	}
+}
+
+func TestEnsureImagesPullMatches(t *testing.T) {
+	statedir := fakeImageDocker(t, imageManifestID)
+
+	if err := EnsureImages(context.Background(), imageManifest("reg/img:1"), io.Discard, io.Discard); err != nil {
+		t.Fatalf("EnsureImages: %v", err)
+	}
+	if log := dockerLog(t, statedir); !strings.Contains(log, "pull reg/img:1") {
+		t.Fatalf("expected a pull, got: %s", log)
+	}
+}
+
+func TestEnsureImagesPullMismatch(t *testing.T) {
+	fakeImageDocker(t, "sha256:2222")
+
+	err := EnsureImages(context.Background(), imageManifest("reg/img:1"), io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "refusing to install") {
+		t.Fatalf("want an ID-mismatch error, got: %v", err)
+	}
+}
+
+func TestEnsureImagesPullFails(t *testing.T) {
+	fakeImageDocker(t, "")
+
+	err := EnsureImages(context.Background(), imageManifest("reg/img:1"), io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "failed to pull") {
+		t.Fatalf("want a pull error, got: %v", err)
+	}
+}

--- a/subcommands/pkg/add.go
+++ b/subcommands/pkg/add.go
@@ -35,6 +35,7 @@ type PkgAdd struct {
 
 	upgrade       bool
 	allowUnsigned bool
+	container     bool
 	Args          []string
 }
 
@@ -45,6 +46,7 @@ func (cmd *PkgAdd) CobraCommand() *cobra.Command {
 	c.Flags().BoolVar(&cmd.upgrade, "u", false, "Update packages")
 	c.Flags().BoolVar(&cmd.allowUnsigned, "allow-unsigned", false,
 		"Install packages that carry no signature")
+	c.Flags().BoolVar(&cmd.container, "container", false, "Install the container flavor of remote packages")
 	return c
 }
 
@@ -106,6 +108,9 @@ func (cmd *PkgAdd) Execute(ctx *appcontext.AppContext, _ *repository.Repository)
 			Version:       version,
 			Upgrade:       cmd.upgrade,
 		}
+		if cmd.container {
+			addopts.Container = true
+		}
 		if err := pkgmgr.Add(plugin, &addopts); err != nil {
 			if cmd.upgrade && errors.Is(err, pkg.ErrAlreadyInstalled) {
 				continue
@@ -127,6 +132,9 @@ func (cmd *PkgAdd) Execute(ctx *appcontext.AppContext, _ *repository.Repository)
 			addopts := pkg.AddOptions{
 				ImplicitFetch: true,
 				Upgrade:       cmd.upgrade,
+				// Keep whatever flavor is installed rather than
+				// silently switching a container install to native.
+				Container: plugin.OperatingSystem == pkg.OSContainer,
 			}
 
 			if err := pkgmgr.Add(plugin.Name, &addopts); err != nil {

--- a/subcommands/pkg/pkg_container_test.go
+++ b/subcommands/pkg/pkg_container_test.go
@@ -152,6 +152,63 @@ func TestPkgCreateNativeRejectsInvalidConnector(t *testing.T) {
 	require.Contains(t, err.Error(), "exactly one of")
 }
 
+func TestPkgAddContainerRunsInstallHook(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("container packages are linux-only")
+	}
+	fakeContainerCLI(t)
+
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	_, ctx := ptesting.GenerateRepository(t, bufOut, bufErr, nil)
+
+	work := t.TempDir()
+	ctx.CWD = work
+	writeContainerPackage(t, work)
+
+	cmd := &PkgCreate{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-container", "manifest.yaml", "v1.2.3"}))
+	status, err := cmd.Execute(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	newManager := func(hook func(*ppkg.Manifest) error) *ppkg.Manager {
+		base := t.TempDir()
+		backend, err := ppkg.NewFlatBackend(ctx.GetInner(),
+			filepath.Join(base, "plugins"), filepath.Join(base, "cache"),
+			&ppkg.FlatBackendOptions{InstallHook: hook})
+		require.NoError(t, err)
+		mgr, err := ppkg.New(backend, nil)
+		require.NoError(t, err)
+		return mgr
+	}
+
+	// The install hook sees the stamped manifest; a container-flavored
+	// package installs from the local file.
+	var seen []*ppkg.Manifest
+	mgr := newManager(func(m *ppkg.Manifest) error { seen = append(seen, m); return nil })
+	require.NoError(t, mgr.Add(cmd.Out, nil))
+	require.Len(t, seen, 1)
+	require.Equal(t, testImageID, seen[0].Connectors[0].ImageID)
+
+	var installed []*ppkg.Package
+	for p, err := range mgr.List() {
+		require.NoError(t, err)
+		installed = append(installed, p)
+	}
+	require.Len(t, installed, 1)
+	require.Equal(t, ppkg.OSContainer, installed[0].OperatingSystem)
+
+	// A failing hook aborts the install.
+	mgr = newManager(func(m *ppkg.Manifest) error { return fmt.Errorf("image not present") })
+	err = mgr.Add(cmd.Out, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "image not present")
+	for range mgr.List() {
+		t.Fatal("nothing should be installed after a failed install hook")
+	}
+}
+
 func TestPkgerImporterManifestData(t *testing.T) {
 	dir := t.TempDir()
 	data := []byte("name: myplugin\nconnectors:\n  - type: importer\n    image_id: sha256:aa\n")


### PR DESCRIPTION
This adds support for pulling images or reusing local ones when pkg adding a containerized ptar.