### PR TITLE
fix: [Bug]: Fuse mounts are not backuped

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -258,6 +258,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 
 		importerOpts := ctx.ImporterOpts()
 		importerOpts.Excludes = cmd.Excludes
+		importerOpts.NoXattr = cmd.NoXattr
 
 		imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, cmdOptsCopy)
 		if err != nil {

--- a/subcommands/backup/backup_extra_test.go
+++ b/subcommands/backup/backup_extra_test.go
@@ -7,10 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/connectors/importer"
 	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
 )
@@ -82,6 +86,46 @@ func TestBackupNoXattrPropagates(t *testing.T) {
 	status, err, _, _ := runBackup(t, []string{"-no-xattr"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
+}
+
+var xattrProbeNoXattr atomic.Bool
+
+func init() {
+	importer.Register("xattrprobe", 0, func(ctx context.Context, opts *connectors.Options, name string, config map[string]string) (importer.Importer, error) {
+		xattrProbeNoXattr.Store(opts.NoXattr)
+
+		imp, err := ptesting.NewMockImporter(ctx, opts, name, config)
+		if err != nil {
+			return nil, err
+		}
+		imp.(*ptesting.MockImporter).SetFiles([]ptesting.MockFile{
+			ptesting.NewMockFile("/hello.txt", 0644, "hello"),
+		})
+		return imp, nil
+	})
+}
+
+func TestBackupNoXattrReachesImporter(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "flag set", args: []string{"-no-xattr"}, want: true},
+		{name: "flag unset", args: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			xattrProbeNoXattr.Store(!tc.want)
+
+			status, err, _, _ := runBackup(t, tc.args, func(cmd *Backup) {
+				cmd.Sources = []string{"xattrprobe://probe"}
+			})
+			require.NoError(t, err)
+			require.Equal(t, 0, status)
+			require.Equal(t, tc.want, xattrProbeNoXattr.Load(),
+				"-no-xattr must reach the importer so it does not read extended attributes")
+		})
+	}
 }
 
 func TestBackupNameAndMetadataParseFlags(t *testing.T) {


### PR DESCRIPTION
Fixes #2045

## Root cause

-no-xattr is never passed to the importer options

## Changes

- Propagate Backup.NoXattr into the importer options (connectors.Options.NoXattr) in DoBackup so the fs importer skips xattr.LList entirely when -no-xattr is given, and add a regression test that asserts the flag reaches the importer factory.