### PR TITLE
fix: [Bug]: mount has problems with windows drive letters

### DIFF
--- a/subcommands/mount/http/http.go
+++ b/subcommands/mount/http/http.go
@@ -148,7 +148,7 @@ func NewDynamicSnapshotHandler(list ListFn, open OpenFn) http.Handler {
 		}
 
 		p = strings.TrimPrefix(p, "/")
-		snap, _, _ := strings.Cut(p, "/")
+		snap, entrypath, _ := strings.Cut(p, "/")
 
 		snapFS, err := open(r.Context(), snap)
 		if err != nil {
@@ -159,6 +159,35 @@ func NewDynamicSnapshotHandler(list ListFn, open OpenFn) http.Handler {
 			http.Error(w, "failed to open snapshot", http.StatusInternalServerError)
 			return
 		}
+
+		if target, ok := absoluteDirRedirect(snapFS, r, entrypath); ok {
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+			return
+		}
+
 		http.StripPrefix("/"+snap, http.FileServer(http.FS(snapFS))).ServeHTTP(w, r)
 	})
+}
+
+func absoluteDirRedirect(snapFS fs.FS, r *http.Request, entrypath string) (string, bool) {
+	escapedPath := r.URL.EscapedPath()
+	if entrypath == "" || strings.HasSuffix(escapedPath, "/") {
+		return "", false
+	}
+	if !relativeRedirectParsesAsScheme(entrypath) {
+		return "", false
+	}
+	if info, err := fs.Stat(snapFS, entrypath); err != nil || !info.IsDir() {
+		return "", false
+	}
+
+	target := escapedPath + "/"
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
+	}
+	return target, true
+}
+
+func relativeRedirectParsesAsScheme(entrypath string) bool {
+	return strings.Contains(path.Base(entrypath), ":")
 }

--- a/subcommands/mount/http/http_test.go
+++ b/subcommands/mount/http/http_test.go
@@ -76,6 +76,57 @@ func TestDynamicHandlerServesSnapshotFile(t *testing.T) {
 	require.Contains(t, w.Body.String(), "world")
 }
 
+func driveLetterHandler(t *testing.T) func(target string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	memFS := fstest.MapFS{
+		"C:/tmp/hello.txt": &fstest.MapFile{Data: []byte("world")},
+		"plain/x.txt":      &fstest.MapFile{Data: []byte("x")},
+	}
+	h := NewDynamicSnapshotHandler(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {},
+		func(ctx context.Context, id string) (fs.FS, error) { return memFS, nil },
+	)
+
+	return func(target string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, target, nil))
+		return w
+	}
+}
+
+func TestDynamicHandlerRedirectsDriveLetterDirectoryToAbsolutePath(t *testing.T) {
+	serve := driveLetterHandler(t)
+
+	w := serve("/abc123/C:")
+	require.Equal(t, http.StatusMovedPermanently, w.Code)
+	require.Equal(t, "/abc123/C:/", w.Header().Get("Location"))
+
+	w = serve("/abc123/C:?k=v")
+	require.Equal(t, http.StatusMovedPermanently, w.Code)
+	require.Equal(t, "/abc123/C:/?k=v", w.Header().Get("Location"))
+}
+
+func TestDynamicHandlerKeepsRelativeRedirectForColonlessDirectory(t *testing.T) {
+	serve := driveLetterHandler(t)
+
+	w := serve("/abc123/plain")
+	require.Equal(t, http.StatusMovedPermanently, w.Code)
+	require.Equal(t, "plain/", w.Header().Get("Location"))
+}
+
+func TestDynamicHandlerServesDriveLetterSubtree(t *testing.T) {
+	serve := driveLetterHandler(t)
+
+	w := serve("/abc123/C:/")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "tmp/")
+
+	w = serve("/abc123/C:/tmp/hello.txt")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "world")
+}
+
 func TestDynamicHandlerNotFound(t *testing.T) {
 	h := NewDynamicSnapshotHandler(
 		func(ctx context.Context, w http.ResponseWriter, r *http.Request) {},


### PR DESCRIPTION
Fixes #2076

## Root cause

mount HTTP handler emits a scheme-ambiguous relative redirect for Windows drive-letter directories

## Changes

- NewDynamicSnapshotHandler now performs the missing trailing-slash redirect itself when the requested snapshot entry is a directory whose base name contains a colon, sending an absolute-path Location (/<snapshot>/C:/ plus any query) instead of letting net/http's localRedirect emit the ambiguous relative "C:/"; all other paths keep the stdlib behaviour. Regression tests cover the drive-letter redirect, query preservation, the unchanged colonless redirect, and serving the drive-letter subtree.