### PR TITLE
[OSS] Enable search and filtering on the integrations page

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,12 +9,15 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/kloset/snapshot"
+	"github.com/PlakarKorp/pkg"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/utils"
+	"go.omarpolo.com/ttlmap"
 )
 
 type uiserver struct {
@@ -22,6 +25,15 @@ type uiserver struct {
 	config     storage.Configuration
 	repository *repository.Repository
 	norefresh  bool
+
+	// integrationsCache used used by api_proxy.go to cache the results of
+	// pkg.Manager.Query() across requests so the /integration list and detail
+	// endpoints don't fetch the ~449 KB remote catalog from api.plakar.io on
+	// every hit.
+	// In the future, this cache should be moved to the pkg.Manager itself, and
+	// the API should call pkg.Manager.Query() directly instead of caching the
+	// results here.
+	integrationsCache *ttlmap.TTLMap[string, []*pkg.Integration]
 
 	// XXX: Adding this for transition, it needs to go away. Some
 	// places we only have Repository and out of AppContext we
@@ -149,12 +161,14 @@ func (ui *uiserver) apiInfo(w http.ResponseWriter, r *http.Request) error {
 
 func SetupRoutes(server *http.ServeMux, repo *repository.Repository, ctx *appcontext.AppContext, token string, norefresh bool) {
 	ui := uiserver{
-		store:      repo.Store(),
-		config:     repo.Configuration(),
-		repository: repo,
-		ctx:        ctx,
-		norefresh:  norefresh,
+		store:             repo.Store(),
+		config:            repo.Configuration(),
+		repository:        repo,
+		ctx:               ctx,
+		norefresh:         norefresh,
+		integrationsCache: ttlmap.New[string, []*pkg.Integration](5 * time.Minute),
 	}
+	ui.integrationsCache.AutoExpire()
 
 	authToken := TokenAuthMiddleware(token)
 	urlSigner := NewSnapshotReaderURLSigner(&ui, token)

--- a/api/api_integrations.go
+++ b/api/api_integrations.go
@@ -64,6 +64,7 @@ func (ui *uiserver) integrationsInstall(w http.ResponseWriter, r *http.Request) 
 		goto done
 	}
 
+	integrationsCache.Delete(integrationsCacheKey)
 	resp.Status = "ok"
 	resp.AddMessage(fmt.Sprintf("plugin %q installed successfully", req.Id))
 
@@ -83,6 +84,7 @@ func (ui *uiserver) integrationsUninstall(w http.ResponseWriter, r *http.Request
 		goto done
 	}
 
+	integrationsCache.Delete(integrationsCacheKey)
 	resp.Status = "ok"
 	resp.AddMessage(fmt.Sprintf("plugin %q uninstalled successfully", id))
 

--- a/api/api_integrations.go
+++ b/api/api_integrations.go
@@ -64,7 +64,7 @@ func (ui *uiserver) integrationsInstall(w http.ResponseWriter, r *http.Request) 
 		goto done
 	}
 
-	integrationsCache.Delete(integrationsCacheKey)
+	ui.integrationsCache.Delete(integrationsCacheKey)
 	resp.Status = "ok"
 	resp.AddMessage(fmt.Sprintf("plugin %q installed successfully", req.Id))
 
@@ -84,7 +84,7 @@ func (ui *uiserver) integrationsUninstall(w http.ResponseWriter, r *http.Request
 		goto done
 	}
 
-	integrationsCache.Delete(integrationsCacheKey)
+	ui.integrationsCache.Delete(integrationsCacheKey)
 	resp.Status = "ok"
 	resp.AddMessage(fmt.Sprintf("plugin %q uninstalled successfully", id))
 

--- a/api/api_params.go
+++ b/api/api_params.go
@@ -92,6 +92,23 @@ func QueryParamToString(r *http.Request, param string) (string, bool, error) {
 	return str, true, nil
 }
 
+// QueryParamToStrings returns all values for a repeatable query
+// parameter (?foo=a&foo=b), with empty entries dropped. An empty
+// result means the filter is not set.
+func QueryParamToStrings(r *http.Request, param string) []string {
+	raw := r.URL.Query()[param]
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 func QueryParamToSortKeys(r *http.Request, param, def string) ([]string, error) {
 	str := r.URL.Query().Get(param)
 	if str == "" {

--- a/api/api_params.go
+++ b/api/api_params.go
@@ -92,9 +92,6 @@ func QueryParamToString(r *http.Request, param string) (string, bool, error) {
 	return str, true, nil
 }
 
-// QueryParamToStrings returns all values for a repeatable query
-// parameter (?foo=a&foo=b), with empty entries dropped. An empty
-// result means the filter is not set.
 func QueryParamToStrings(r *http.Request, param string) []string {
 	raw := r.URL.Query()[param]
 	if len(raw) == 0 {

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -20,13 +20,7 @@ var SERVICES_ENDPOINT = "https://api.plakar.io"
 
 // integrationsCache memoizes pkg.Manager.Query() across requests so the
 // /integration list and detail endpoints don't fetch the ~449 KB remote
-// catalog from api.plakar.io on every hit. The handler runs all filters
-// (search, installation_status, type, tag) over the cached slice, so a
-// single entry under a constant key covers every call.
-//
-// TTL is short enough that catalog updates propagate without operator
-// action. install/uninstall explicitly invalidate the entry so
-// state-changing operations reflect immediately.
+// catalog from api.plakar.io on every hit.
 const integrationsCacheKey = "all"
 
 var integrationsCache = ttlmap.New[string, []*pkg.Integration](5 * time.Minute)
@@ -169,9 +163,6 @@ func (ui *uiserver) servicesSetAlertingServiceConfiguration(w http.ResponseWrite
 	return json.NewEncoder(w).Encode(alertConfig)
 }
 
-// integrationMatchesSearch reports whether the integration's Name or
-// DisplayName contains needle (case-insensitive substring). needle must
-// already be lowercased. An empty needle matches everything.
 func integrationMatchesSearch(it *pkg.Integration, needle string) bool {
 	if needle == "" {
 		return true
@@ -180,18 +171,6 @@ func integrationMatchesSearch(it *pkg.Integration, needle string) bool {
 		strings.Contains(strings.ToLower(it.DisplayName), needle)
 }
 
-// integrationMatchesInstallationStatus reports whether the integration
-// satisfies the installation_status query param. filter must be one of:
-//
-//	""             — no filter, matches everything.
-//	"installed"    — Installation.Status == "installed".
-//	"not-installed"— Installation.Status == "not-installed".
-//	"upgradable"   — installed AND Installation.Version != LatestVersion
-//	                 (plain string inequality, deliberately not
-//	                 semver-aware; mirrors the frontend "canUpgrade"
-//	                 chip and plakman).
-//
-// Any other value matches nothing (silent zero results, no 400).
 func integrationMatchesInstallationStatus(it *pkg.Integration, filter string) bool {
 	switch filter {
 	case "":
@@ -215,13 +194,6 @@ func integrationMatchesTag(it *pkg.Integration, tag string) bool {
 	return slices.Contains(it.Tags, tag)
 }
 
-// integrationMatchesTypes reports whether the integration has at least
-// one of the requested Types bools set. filter values are the plakar
-// Types-struct field names in lowercase — "storage", "source",
-// "destination", "provider". Empty filter matches everything; unknown
-// values match nothing. Any-of semantics: an integration matches if it
-// satisfies ANY of the requested types (OR within the type filter; AND
-// with the other filters).
 func integrationMatchesTypes(it *pkg.Integration, filter []string) bool {
 	if len(filter) == 0 {
 		return true
@@ -296,7 +268,7 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		return err
 	}
-	needle := strings.ToLower(search) // "" when unset — no filter
+	needle := strings.ToLower(search)
 
 	var res Items[pkg.Integration]
 	res.Items = make([]pkg.Integration, 0)

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -167,6 +167,7 @@ func integrationMatchesSearch(it *pkg.Integration, needle string) bool {
 	if needle == "" {
 		return true
 	}
+	needle = strings.ToLower(needle)
 	return strings.Contains(strings.ToLower(it.Name), needle) ||
 		strings.Contains(strings.ToLower(it.DisplayName), needle)
 }
@@ -268,7 +269,6 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		return err
 	}
-	needle := strings.ToLower(search)
 
 	var res Items[pkg.Integration]
 	res.Items = make([]pkg.Integration, 0)
@@ -280,7 +280,7 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 
 	var i int64
 	for _, integration := range integrations {
-		if !integrationMatchesSearch(integration, needle) {
+		if !integrationMatchesSearch(integration, search) {
 			continue
 		}
 		if !integrationMatchesInstallationStatus(integration, filterInstallationStatus) {

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -294,10 +294,10 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 		}
 
 		res.Total++
-		i++
-		if i > offset && i < offset+limit {
+		if i >= offset && i < offset+limit {
 			res.Items = append(res.Items, *integration)
 		}
+		i++
 	}
 
 	return json.NewEncoder(w).Encode(res)

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -9,25 +9,14 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/PlakarKorp/pkg"
 	"github.com/PlakarKorp/plakar/services"
-	"go.omarpolo.com/ttlmap"
 )
 
 var SERVICES_ENDPOINT = "https://api.plakar.io"
 
-// integrationsCache memoizes pkg.Manager.Query() across requests so the
-// /integration list and detail endpoints don't fetch the ~449 KB remote
-// catalog from api.plakar.io on every hit.
 const integrationsCacheKey = "all"
-
-var integrationsCache = ttlmap.New[string, []*pkg.Integration](5 * time.Minute)
-
-func init() {
-	integrationsCache.AutoExpire()
-}
 
 func (ui *uiserver) servicesProxy(w http.ResponseWriter, r *http.Request) error {
 	// Define target service base URL
@@ -223,14 +212,14 @@ func integrationMatchesTypes(it *pkg.Integration, filter []string) bool {
 }
 
 func (ui *uiserver) cachedIntegrations() ([]*pkg.Integration, error) {
-	if cached, ok := integrationsCache.Get(integrationsCacheKey); ok {
+	if cached, ok := ui.integrationsCache.Get(integrationsCacheKey); ok {
 		return cached, nil
 	}
 	integrations, err := ui.ctx.GetPkgManager().Query(nil)
 	if err != nil {
 		return nil, err
 	}
-	integrationsCache.Add(integrationsCacheKey, integrations)
+	ui.integrationsCache.Add(integrationsCacheKey, integrations)
 	return integrations, nil
 }
 

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -7,13 +7,33 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/PlakarKorp/pkg"
 	"github.com/PlakarKorp/plakar/services"
+	"go.omarpolo.com/ttlmap"
 )
 
 var SERVICES_ENDPOINT = "https://api.plakar.io"
+
+// integrationsCache memoizes pkg.Manager.Query() across requests so the
+// /integration list and detail endpoints don't fetch the ~449 KB remote
+// catalog from api.plakar.io on every hit. The handler runs all filters
+// (search, installation_status, type, tag) over the cached slice, so a
+// single entry under a constant key covers every call.
+//
+// TTL is short enough that catalog updates propagate without operator
+// action. install/uninstall explicitly invalidate the entry so
+// state-changing operations reflect immediately.
+const integrationsCacheKey = "all"
+
+var integrationsCache = ttlmap.New[string, []*pkg.Integration](5 * time.Minute)
+
+func init() {
+	integrationsCache.AutoExpire()
+}
 
 func (ui *uiserver) servicesProxy(w http.ResponseWriter, r *http.Request) error {
 	// Define target service base URL
@@ -188,6 +208,13 @@ func integrationMatchesInstallationStatus(it *pkg.Integration, filter string) bo
 	}
 }
 
+func integrationMatchesTag(it *pkg.Integration, tag string) bool {
+	if tag == "" {
+		return true
+	}
+	return slices.Contains(it.Tags, tag)
+}
+
 // integrationMatchesTypes reports whether the integration has at least
 // one of the requested Types bools set. filter values are the plakar
 // Types-struct field names in lowercase — "storage", "source",
@@ -220,6 +247,18 @@ func integrationMatchesTypes(it *pkg.Integration, filter []string) bool {
 		}
 	}
 	return false
+}
+
+func (ui *uiserver) cachedIntegrations() ([]*pkg.Integration, error) {
+	if cached, ok := integrationsCache.Get(integrationsCacheKey); ok {
+		return cached, nil
+	}
+	integrations, err := ui.ctx.GetPkgManager().Query(nil)
+	if err != nil {
+		return nil, err
+	}
+	integrationsCache.Add(integrationsCacheKey, integrations)
+	return integrations, nil
 }
 
 func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Request) error {
@@ -262,9 +301,7 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 	var res Items[pkg.Integration]
 	res.Items = make([]pkg.Integration, 0)
 
-	integrations, err := ui.ctx.GetPkgManager().Query(&pkg.QueryOptions{
-		Tag: filterTag,
-	})
+	integrations, err := ui.cachedIntegrations()
 	if err != nil {
 		return err
 	}
@@ -278,6 +315,9 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 		if !integrationMatchesTypes(integration, filterTypes) {
+			continue
+		}
+		if !integrationMatchesTag(integration, filterTag) {
 			continue
 		}
 
@@ -294,7 +334,7 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 func (ui *uiserver) servicesGetIntegrationId(w http.ResponseWriter, r *http.Request) error {
 	id := r.PathValue("id")
 
-	integrations, err := ui.ctx.GetPkgManager().Query(nil)
+	integrations, err := ui.cachedIntegrations()
 	if err != nil {
 		return err
 	}

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -160,6 +160,34 @@ func integrationMatchesSearch(it *pkg.Integration, needle string) bool {
 		strings.Contains(strings.ToLower(it.DisplayName), needle)
 }
 
+// integrationMatchesInstallationStatus reports whether the integration
+// satisfies the installation_status query param. filter must be one of:
+//
+//	""             — no filter, matches everything.
+//	"installed"    — Installation.Status == "installed".
+//	"not-installed"— Installation.Status == "not-installed".
+//	"upgradable"   — installed AND Installation.Version != LatestVersion
+//	                 (plain string inequality, deliberately not
+//	                 semver-aware; mirrors the frontend "canUpgrade"
+//	                 chip and plakman).
+//
+// Any other value matches nothing (silent zero results, no 400).
+func integrationMatchesInstallationStatus(it *pkg.Integration, filter string) bool {
+	switch filter {
+	case "":
+		return true
+	case "installed":
+		return it.Installation.Status == "installed"
+	case "not-installed":
+		return it.Installation.Status == "not-installed"
+	case "upgradable":
+		return it.Installation.Status == "installed" &&
+			it.Installation.Version != it.LatestVersion
+	default:
+		return false
+	}
+}
+
 func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Request) error {
 	offset, err := QueryParamToInt64(r, "offset", 0, 0)
 	if err != nil {
@@ -181,9 +209,17 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
-	filterStatus, _, err := QueryParamToString(r, "status")
+	// installation_status is the canonical param; `status` is kept as a
+	// legacy alias. If both are sent, installation_status wins.
+	filterInstallationStatus, _, err := QueryParamToString(r, "installation_status")
 	if err != nil {
 		return err
+	}
+	if filterInstallationStatus == "" {
+		filterInstallationStatus, _, err = QueryParamToString(r, "status")
+		if err != nil {
+			return err
+		}
 	}
 
 	search, _, err := QueryParamToString(r, "search")
@@ -196,9 +232,8 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 	res.Items = make([]pkg.Integration, 0)
 
 	integrations, err := ui.ctx.GetPkgManager().Query(&pkg.QueryOptions{
-		Type:   filterType,
-		Tag:    filterTag,
-		Status: filterStatus,
+		Type: filterType,
+		Tag:  filterTag,
 	})
 	if err != nil {
 		return err
@@ -207,6 +242,9 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 	var i int64
 	for _, integration := range integrations {
 		if !integrationMatchesSearch(integration, needle) {
+			continue
+		}
+		if !integrationMatchesInstallationStatus(integration, filterInstallationStatus) {
 			continue
 		}
 

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -188,6 +188,40 @@ func integrationMatchesInstallationStatus(it *pkg.Integration, filter string) bo
 	}
 }
 
+// integrationMatchesTypes reports whether the integration has at least
+// one of the requested Types bools set. filter values are the plakar
+// Types-struct field names in lowercase — "storage", "source",
+// "destination", "provider". Empty filter matches everything; unknown
+// values match nothing. Any-of semantics: an integration matches if it
+// satisfies ANY of the requested types (OR within the type filter; AND
+// with the other filters).
+func integrationMatchesTypes(it *pkg.Integration, filter []string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, t := range filter {
+		switch t {
+		case "storage":
+			if it.Types.Storage {
+				return true
+			}
+		case "source":
+			if it.Types.Source {
+				return true
+			}
+		case "destination":
+			if it.Types.Destination {
+				return true
+			}
+		case "provider":
+			if it.Types.Provider {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Request) error {
 	offset, err := QueryParamToInt64(r, "offset", 0, 0)
 	if err != nil {
@@ -199,10 +233,7 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
-	filterType, _, err := QueryParamToString(r, "type")
-	if err != nil {
-		return err
-	}
+	filterTypes := QueryParamToStrings(r, "type")
 
 	filterTag, _, err := QueryParamToString(r, "tag")
 	if err != nil {
@@ -232,8 +263,7 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 	res.Items = make([]pkg.Integration, 0)
 
 	integrations, err := ui.ctx.GetPkgManager().Query(&pkg.QueryOptions{
-		Type: filterType,
-		Tag:  filterTag,
+		Tag: filterTag,
 	})
 	if err != nil {
 		return err
@@ -245,6 +275,9 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 		if !integrationMatchesInstallationStatus(integration, filterInstallationStatus) {
+			continue
+		}
+		if !integrationMatchesTypes(integration, filterTypes) {
 			continue
 		}
 

--- a/api/api_proxy.go
+++ b/api/api_proxy.go
@@ -149,6 +149,17 @@ func (ui *uiserver) servicesSetAlertingServiceConfiguration(w http.ResponseWrite
 	return json.NewEncoder(w).Encode(alertConfig)
 }
 
+// integrationMatchesSearch reports whether the integration's Name or
+// DisplayName contains needle (case-insensitive substring). needle must
+// already be lowercased. An empty needle matches everything.
+func integrationMatchesSearch(it *pkg.Integration, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(it.Name), needle) ||
+		strings.Contains(strings.ToLower(it.DisplayName), needle)
+}
+
 func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Request) error {
 	offset, err := QueryParamToInt64(r, "offset", 0, 0)
 	if err != nil {
@@ -175,24 +186,34 @@ func (ui *uiserver) servicesGetIntegration(w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
+	search, _, err := QueryParamToString(r, "search")
+	if err != nil {
+		return err
+	}
+	needle := strings.ToLower(search) // "" when unset — no filter
+
 	var res Items[pkg.Integration]
 	res.Items = make([]pkg.Integration, 0)
 
-	var i int64
 	integrations, err := ui.ctx.GetPkgManager().Query(&pkg.QueryOptions{
 		Type:   filterType,
 		Tag:    filterTag,
 		Status: filterStatus,
 	})
-	for _, int := range integrations {
-		if err != nil {
-			return err
+	if err != nil {
+		return err
+	}
+
+	var i int64
+	for _, integration := range integrations {
+		if !integrationMatchesSearch(integration, needle) {
+			continue
 		}
 
 		res.Total++
 		i++
 		if i > offset && i < offset+limit {
-			res.Items = append(res.Items, *int)
+			res.Items = append(res.Items, *integration)
 		}
 	}
 

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/PlakarKorp/pkg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +64,30 @@ func TestProxy(t *testing.T) {
 		w := get(t, mux, "/api/proxy/v1/account/me")
 		require.Equal(t, http.StatusInternalServerError, w.Code, "body=%s", w.Body.String())
 	})
+}
+
+// TestIntegrationMatchesSearch pins the search filter used by
+// servicesGetIntegration: case-insensitive substring over Name OR
+// DisplayName; empty needle matches everything.
+func TestIntegrationMatchesSearch(t *testing.T) {
+	cases := []struct {
+		name, needle string
+		it           pkg.Integration
+		want         bool
+	}{
+		{"empty needle matches", "", pkg.Integration{Name: "aws-s3"}, true},
+		{"name substring, lowercase", "aws", pkg.Integration{Name: "aws-s3"}, true},
+		{"name substring, mixed case in field", "s3", pkg.Integration{Name: "aws-S3", DisplayName: "Amazon S3"}, true},
+		{"display name substring", "amazon", pkg.Integration{Name: "aws-s3", DisplayName: "Amazon S3"}, true},
+		{"no match", "gcp", pkg.Integration{Name: "aws-s3", DisplayName: "Amazon S3"}, false},
+		{"empty display name doesn't panic", "aws", pkg.Integration{Name: "aws-s3", DisplayName: ""}, true},
+		{"empty name doesn't panic", "amazon", pkg.Integration{Name: "", DisplayName: "Amazon S3"}, true},
+		{"unicode passthrough", "π", pkg.Integration{Name: "geo-π-service"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := integrationMatchesSearch(&tc.it, tc.needle)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -91,3 +91,55 @@ func TestIntegrationMatchesSearch(t *testing.T) {
 		})
 	}
 }
+
+// TestIntegrationMatchesInstallationStatus pins the installation_status
+// filter used by servicesGetIntegration: empty filter matches
+// everything; "installed"/"not-installed" match on Installation.Status;
+// "upgradable" requires installed AND Installation.Version !=
+// LatestVersion (plain string inequality, matches plakman); any unknown
+// value matches nothing.
+func TestIntegrationMatchesInstallationStatus(t *testing.T) {
+	installed := func(ver, latest string) pkg.Integration {
+		return pkg.Integration{
+			Installation:  pkg.IntegrationInstallation{Status: "installed", Version: ver},
+			LatestVersion: latest,
+		}
+	}
+	notInstalled := func(latest string) pkg.Integration {
+		return pkg.Integration{
+			Installation:  pkg.IntegrationInstallation{Status: "not-installed"},
+			LatestVersion: latest,
+		}
+	}
+
+	cases := []struct {
+		name   string
+		filter string
+		it     pkg.Integration
+		want   bool
+	}{
+		{"empty filter matches installed", "", installed("1.0.0", "1.0.0"), true},
+		{"empty filter matches not-installed", "", notInstalled("1.0.0"), true},
+
+		{"installed matches installed row", "installed", installed("1.0.0", "1.0.0"), true},
+		{"installed rejects not-installed row", "installed", notInstalled("1.0.0"), false},
+		{"not-installed matches not-installed row", "not-installed", notInstalled("1.0.0"), true},
+		{"not-installed rejects installed row", "not-installed", installed("1.0.0", "1.0.0"), false},
+
+		{"upgradable when installed version differs", "upgradable", installed("1.0.0", "1.1.0"), true},
+		{"upgradable rejects matching versions", "upgradable", installed("1.0.0", "1.0.0"), false},
+		{"upgradable rejects not-installed row", "upgradable", notInstalled("1.1.0"), false},
+		{"upgradable with empty installed version", "upgradable", installed("", "1.0.0"), true},
+		{"upgradable with both versions empty", "upgradable", installed("", ""), false},
+
+		{"unknown filter rejects installed", "garbage", installed("1.0.0", "1.0.0"), false},
+		{"unknown filter rejects not-installed", "garbage", notInstalled("1.0.0"), false},
+		{"case-sensitive: 'Installed' rejects all", "Installed", installed("1.0.0", "1.0.0"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := integrationMatchesInstallationStatus(&tc.it, tc.filter)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -201,3 +201,35 @@ func TestIntegrationMatchesTypes(t *testing.T) {
 		})
 	}
 }
+
+// TestIntegrationMatchesTag pins the tag filter used by
+// servicesGetIntegration: empty tag matches everything; a non-empty tag
+// must appear in the integration's Tags slice (case-sensitive
+// slices.Contains match, unchanged from the pkg-side filter it
+// replaces).
+func TestIntegrationMatchesTag(t *testing.T) {
+	withTags := func(tags ...string) pkg.Integration {
+		return pkg.Integration{Tags: tags}
+	}
+
+	cases := []struct {
+		name string
+		tag  string
+		it   pkg.Integration
+		want bool
+	}{
+		{"empty tag matches everything", "", withTags(), true},
+		{"empty tag matches integration with tags", "", withTags("backup", "daily"), true},
+		{"exact tag match", "backup", withTags("backup"), true},
+		{"one of multiple tags matches", "daily", withTags("backup", "daily"), true},
+		{"no match", "weekly", withTags("backup", "daily"), false},
+		{"case-sensitive: 'Backup' rejects", "Backup", withTags("backup"), false},
+		{"empty Tags slice rejects non-empty tag", "backup", withTags(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := integrationMatchesTag(&tc.it, tc.tag)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/api/api_proxy_test.go
+++ b/api/api_proxy_test.go
@@ -143,3 +143,61 @@ func TestIntegrationMatchesInstallationStatus(t *testing.T) {
 		})
 	}
 }
+
+// TestIntegrationMatchesTypes pins the multi-value type filter used by
+// servicesGetIntegration: empty filter matches everything; any-of
+// semantics — an integration matches if it satisfies AT LEAST ONE of
+// the requested Types bools; unknown values are ignored (match nothing
+// on their own).
+func TestIntegrationMatchesTypes(t *testing.T) {
+	mk := func(storage, source, destination, provider bool) pkg.Integration {
+		return pkg.Integration{
+			Types: pkg.IntegrationTypes{
+				Storage:     storage,
+				Source:      source,
+				Destination: destination,
+				Provider:    provider,
+			},
+		}
+	}
+
+	storageOnly := mk(true, false, false, false)
+	sourceOnly := mk(false, true, false, false)
+	destOnly := mk(false, false, true, false)
+	providerOnly := mk(false, false, false, true)
+	sourceAndDest := mk(false, true, true, false)
+	nothing := mk(false, false, false, false)
+
+	cases := []struct {
+		name   string
+		filter []string
+		it     pkg.Integration
+		want   bool
+	}{
+		{"empty filter matches storage", nil, storageOnly, true},
+		{"empty filter matches nothing-typed", nil, nothing, true},
+
+		{"single value matches", []string{"storage"}, storageOnly, true},
+		{"single value rejects wrong type", []string{"storage"}, sourceOnly, false},
+
+		{"multi-value: first value matches", []string{"storage", "source"}, storageOnly, true},
+		{"multi-value: second value matches", []string{"storage", "source"}, sourceOnly, true},
+		{"multi-value: neither matches", []string{"storage", "source"}, destOnly, false},
+		{"multi-value: both bools true = any-of", []string{"storage", "source"}, sourceAndDest, true}, // source matches
+		{"all four values matches multi-typed", []string{"storage", "source", "destination", "provider"}, sourceAndDest, true},
+		{"all four values rejects nothing-typed", []string{"storage", "source", "destination", "provider"}, nothing, false},
+
+		{"provider matches provider row", []string{"provider"}, providerOnly, true},
+		{"provider rejects non-provider row", []string{"provider"}, storageOnly, false},
+
+		{"unknown value alone rejects", []string{"garbage"}, storageOnly, false},
+		{"unknown mixed with valid still ORs", []string{"garbage", "storage"}, storageOnly, true},
+		{"case-sensitive: 'Storage' rejects", []string{"Storage"}, storageOnly, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := integrationMatchesTypes(&tc.it, tc.filter)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Update the endpoint `/api/proxy/v1/integration` 
* add `search` capabilities (by name or display name)
* add filter by `installation_status: "installed" | "not-installed" | "upgradable"`
* add filter by `type: "storage" | "source" | "destination" | "provider"`

A cache from `go.omarpolo.com/ttlmap` was added to avoid re-fetching a remote catalog of 449 KB on every request

AI was used for this PR. It was guided to use the existing patterns and conventions, but it might still need a more careful review 