### PR TITLE
pkg add: accept @latest as the default version

### DIFF
--- a/subcommands/help/docs/plakar-pkg-add.md
+++ b/subcommands/help/docs/plakar-pkg-add.md
@@ -33,6 +33,10 @@ it locally
 To install a specific version of a plugin, use the
 *name*@*version*
 syntax.
+*version*
+may be
+**latest**,
+which is also what is used when no version is given.
 
 The options are as follows:
 

--- a/subcommands/pkg/add.go
+++ b/subcommands/pkg/add.go
@@ -95,6 +95,12 @@ func (cmd *PkgAdd) Execute(ctx *appcontext.AppContext, _ *repository.Repository)
 
 	for _, plugin := range cmd.Args {
 		plugin, version, _ := strings.Cut(plugin, "@")
+		if version == "latest" {
+			// "latest" spells out the default: leave the version empty so
+			// the manager picks it from the recipe instead of looking for
+			// a release named "latest".
+			version = ""
+		}
 		addopts := pkg.AddOptions{
 			ImplicitFetch: true,
 			Version:       version,

--- a/subcommands/pkg/pkg_test.go
+++ b/subcommands/pkg/pkg_test.go
@@ -2,9 +2,15 @@ package pkg
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	ppkg "github.com/PlakarKorp/pkg"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/stretchr/testify/require"
@@ -88,4 +94,48 @@ func TestPkgAddParse(t *testing.T) {
 	ctx := newCtx(t)
 	// add with no package name should error.
 	require.Error(t, (&PkgAdd{}).Parse(ctx, []string{}))
+}
+
+// TestPkgAddLatestResolvesThroughRecipe checks that the "@latest" suffix is the
+// explicit spelling of the default version: it must let the package manager
+// resolve the version from the recipe, not be forwarded as a literal version.
+func TestPkgAddLatestResolvesThroughRecipe(t *testing.T) {
+	var mu sync.Mutex
+	var requested []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requested = append(requested, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path == path.Join("/", ppkg.PLUGIN_API_VERSION, "s3", "recipe.yaml") {
+			w.Write([]byte("name: s3\nversion: v2.0.0\nrepository: https://example.com/s3\n"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ctx := newCtx(t)
+	backend, err := ppkg.NewFlatBackend(ctx.GetInner(),
+		filepath.Join(ctx.CWD, "plugins"), filepath.Join(ctx.CWD, "cache"),
+		&ppkg.FlatBackendOptions{})
+	require.NoError(t, err)
+
+	manager, err := ppkg.New(backend, &ppkg.Options{InstallURL: srv.URL})
+	require.NoError(t, err)
+	ctx.SetPkgManager(manager)
+
+	cmd := &PkgAdd{}
+	require.NoError(t, cmd.Parse(ctx, []string{"s3@latest"}))
+	// The download itself cannot succeed against this stub server; what matters
+	// is which artifact the manager was asked for.
+	_, _ = cmd.Execute(ctx, nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, requested)
+	require.Equal(t, path.Join("/", ppkg.PLUGIN_API_VERSION, "s3", "recipe.yaml"), requested[0])
+	for _, p := range requested {
+		require.NotContains(t, p, "latest",
+			"@latest must not be forwarded as a literal version")
+	}
 }

--- a/subcommands/pkg/plakar-pkg-add.1
+++ b/subcommands/pkg/plakar-pkg-add.1
@@ -30,6 +30,10 @@ it locally
 To install a specific version of a plugin, use the
 .Ar name Ns @ Ns Ar version
 syntax.
+.Ar version
+may be
+.Cm latest ,
+which is also what is used when no version is given.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds


### PR DESCRIPTION
## Problem

`plakar pkg add <name>@<version>` already resolves an explicit release, but the
`@latest` spelling that issue #1599 asks for did not work.

`Execute` cut the `name@version` pair and handed the version straight to the
package manager. In `github.com/PlakarKorp/pkg`, a non-empty `AddOptions.Version`
means "you already know the release", so `Manager.Add` skips `FetchRecipe` and
goes directly to `fetchbinary(name, version)`. The module has no notion of
`latest`, so the literal string ended up in the artifact name and the plugin
server was asked for a release that does not exist:

```
plakar pkg add s3@latest   ->  GET /v1.1.0/s3/s3_latest_linux_amd64.ptar   (404)
plakar pkg add s3@v1.0.0   ->  GET /v1.1.0/s3/s3_v1.0.0_linux_amd64.ptar   (ok)
plakar pkg add s3          ->  GET /v1.1.0/s3/recipe.yaml                  (ok)
```

## Fix

`latest` is just the explicit spelling of the default, so it is normalised to the
empty version and the manager resolves it through the recipe like a bare
`plakar pkg add s3`. This stays in the CLI because that is where the `@` syntax
is parsed; the library keeps its existing "empty means resolve from the recipe"
contract, so no other `pkg` consumer changes behaviour.

The manpage and its generated markdown are updated in the same change. The
`.md` was regenerated with `subcommands/sync-man.sh` (`mandoc -T markdown`),
not hand-edited, and `mandoc -Tlint -Wstyle` passes.

Fixes #1599

## Test verification (RED → GREEN)

RED — unmodified `origin/main` (9f09645) with only the new test applied:

```
$ go test ./subcommands/pkg -run TestPkgAddLatestResolvesThroughRecipe -v -count=1
=== RUN   TestPkgAddLatestResolvesThroughRecipe
    pkg_test.go:136:
        	Error:      	Not equal:
        	            	expected: "/v1.1.0/s3/recipe.yaml"
        	            	actual  : "/v1.1.0/s3/s3_latest_linux_amd64.ptar"
        	Test:       	TestPkgAddLatestResolvesThroughRecipe
--- FAIL: TestPkgAddLatestResolvesThroughRecipe (0.00s)
FAIL	github.com/PlakarKorp/plakar/subcommands/pkg	0.011s
```

GREEN — with the fix:

```
$ go test ./subcommands/pkg -run TestPkgAddLatestResolvesThroughRecipe -v -count=1
=== RUN   TestPkgAddLatestResolvesThroughRecipe
--- PASS: TestPkgAddLatestResolvesThroughRecipe (0.00s)
ok  	github.com/PlakarKorp/plakar/subcommands/pkg	0.012s
```

Regression check — fix reverted from `add.go`, test kept, fails again with the
same `s3_latest_linux_amd64.ptar` mismatch.

## Local CI replay

`go build -v ./...`, `go build tool`, `GOOS=windows GOARCH=amd64 go build -v .`,
`go vet ./...` and `mandoc -Tlint -Wstyle` are all clean. `gofmt -l` reports
nothing for the touched files.

Full suite, same command on both sides:

| | `go test -p 4 -covermode=atomic ./...` |
|---|---|
| `origin/main` @ 9f09645 | 51 packages ok, 0 failures |
| this branch | 51 packages ok, 0 failures |
