### PR TITLE
improve server interface

### DIFF
--- a/server/httpd/httpd.go
+++ b/server/httpd/httpd.go
@@ -1,7 +1,6 @@
 package httpd
 
 import (
-	"context"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/objects"
-	"github.com/PlakarKorp/kloset/repository"
 )
 
 var ErrInvalidResourceType = fmt.Errorf("invalid resource type")
@@ -168,9 +166,9 @@ func logging(next http.Handler) http.Handler {
 	})
 }
 
-func Server(ctx context.Context, repo *repository.Repository, addr string, noDelete bool, token, cert, key string) error {
+func Mux(store storage.Store, noDelete bool, token string) http.Handler {
 	s := server{
-		store:    repo.Store(),
+		store:    store,
 		noDelete: noDelete,
 	}
 
@@ -183,16 +181,7 @@ func Server(ctx context.Context, repo *repository.Repository, addr string, noDel
 	mux.HandleFunc("PUT /resources/{resource}/{mac}", s.putResource)
 	mux.HandleFunc("DELETE /resources/{resource}/{mac}", s.deleteResource)
 
-	server := &http.Server{Addr: addr, Handler: logging(auth(token, mux))}
-	go func() {
-		<-repo.AppContext().Done()
-		server.Shutdown(repo.AppContext().Context)
-	}()
-
-	if cert != "" && key != "" {
-		return server.ListenAndServeTLS(cert, key)
-	}
-	return server.ListenAndServe()
+	return logging(auth(token, mux))
 }
 
 func getResource(r *http.Request) (storage.StorageResource, error) {

--- a/server/httpd/httpd.go
+++ b/server/httpd/httpd.go
@@ -139,7 +139,7 @@ func (s *server) deleteResource(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func auth(token string, next http.Handler) http.Handler {
+func Auth(token string, next http.Handler) http.Handler {
 	if token == "" {
 		return next
 	}
@@ -156,7 +156,7 @@ func auth(token string, next http.Handler) http.Handler {
 	})
 }
 
-func logging(next http.Handler) http.Handler {
+func Logging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sr := &statusRecorder{ResponseWriter: w, status: 200}
 
@@ -166,7 +166,7 @@ func logging(next http.Handler) http.Handler {
 	})
 }
 
-func Mux(store storage.Store, noDelete bool, token string) http.Handler {
+func Mux(store storage.Store, noDelete bool) http.Handler {
 	s := server{
 		store:    store,
 		noDelete: noDelete,
@@ -181,7 +181,7 @@ func Mux(store storage.Store, noDelete bool, token string) http.Handler {
 	mux.HandleFunc("PUT /resources/{resource}/{mac}", s.putResource)
 	mux.HandleFunc("DELETE /resources/{resource}/{mac}", s.deleteResource)
 
-	return logging(auth(token, mux))
+	return mux
 }
 
 func getResource(r *http.Request) (storage.StorageResource, error) {

--- a/server/httpd/httpd_test.go
+++ b/server/httpd/httpd_test.go
@@ -118,12 +118,8 @@ func TestGetResource_KnownTypes(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/resources/"+name, nil)
 			req.SetPathValue("resource", name)
 			got, err := getResource(req)
-			if err != nil {
-				t.Fatalf("err = %v", err)
-			}
-			if got != want {
-				t.Fatalf("got %v, want %v", got, want)
-			}
+			require.NoError(t, err)
+			require.Equal(t, want, got)
 		})
 	}
 }
@@ -141,12 +137,8 @@ func TestGetMac_ValidHex(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/x", nil)
 	req.SetPathValue("mac", hex.EncodeToString(mac[:]))
 	got, err := getMac(req)
-	if err != nil {
-		t.Fatalf("err = %v", err)
-	}
-	if got != mac {
-		t.Fatalf("got %x, want %x", got, mac)
-	}
+	require.NoError(t, err)
+	require.Equal(t, mac, got)
 }
 
 func TestGetMac_NonHex(t *testing.T) {
@@ -168,24 +160,18 @@ func TestGetMac_WrongLength(t *testing.T) {
 func TestGetRange_Empty(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/x", nil)
 	rng, err := getRange(req)
-	if err != nil {
-		t.Fatalf("err = %v", err)
-	}
-	if rng != nil {
-		t.Fatalf("range should be nil when Range header is absent, got %+v", rng)
-	}
+	require.NoError(t, err)
+	require.Nil(t, rng, "range should be nil when Range header is absent")
 }
 
 func TestGetRange_Valid(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/x", nil)
 	req.Header.Set("Range", "bytes=10-30")
 	rng, err := getRange(req)
-	if err != nil {
-		t.Fatalf("err = %v", err)
-	}
-	if rng == nil || rng.Offset != 10 || rng.Length != 20 {
-		t.Fatalf("got %+v, want offset=10 length=20", rng)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, rng)
+	require.Equal(t, uint64(10), rng.Offset)
+	require.Equal(t, uint32(20), rng.Length)
 }
 
 func TestGetRange_InvalidPrefix(t *testing.T) {
@@ -255,15 +241,9 @@ func TestOpenRepository_Ok(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", rec.Code)
-	}
-	if got := rec.Header().Get("Content-Type"); got != "application/octet-stream" {
-		t.Fatalf("Content-Type = %q", got)
-	}
-	if rec.Body.String() != "wrapped-config-bytes" {
-		t.Fatalf("body = %q", rec.Body.String())
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/octet-stream", rec.Header().Get("Content-Type"))
+	require.Equal(t, "wrapped-config-bytes", rec.Body.String())
 }
 
 func TestOpenRepository_StoreError(t *testing.T) {
@@ -274,12 +254,8 @@ func TestOpenRepository_StoreError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500", rec.Code)
-	}
-	if !strings.Contains(rec.Body.String(), "disk on fire") {
-		t.Fatalf("body should include error, got %q", rec.Body.String())
-	}
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "disk on fire")
 }
 
 func TestListResource_Ok(t *testing.T) {
@@ -295,16 +271,12 @@ func TestListResource_Ok(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
 	var got []objects.MAC
-	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if len(got) != 1 || got[0] != mac {
-		t.Fatalf("got %v, want [%v]", got, mac)
-	}
+	err := json.NewDecoder(rec.Body).Decode(&got)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got), "got %v, want [%v]", got, mac)
+	require.Equal(t, mac, got[0])
 }
 
 func TestListResource_BadType(t *testing.T) {
@@ -315,9 +287,7 @@ func TestListResource_BadType(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestListResource_StoreError(t *testing.T) {
@@ -328,9 +298,7 @@ func TestListResource_StoreError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500", rec.Code)
-	}
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestGetResourceHandler_Ok(t *testing.T) {
@@ -346,15 +314,10 @@ func TestGetResourceHandler_Ok(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
-	}
-	if rec.Body.String() != "payload" {
-		t.Fatalf("body = %q", rec.Body.String())
-	}
-	if store.lastGetType != storage.StorageResourcePackfile || store.lastGetMAC != mac {
-		t.Fatalf("store call args wrong: type=%v mac=%v", store.lastGetType, store.lastGetMAC)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "payload", rec.Body.String())
+	require.Equal(t, storage.StorageResourcePackfile, store.lastGetType)
+	require.Equal(t, mac, store.lastGetMAC)
 }
 
 func TestGetResourceHandler_WithRange(t *testing.T) {
@@ -371,12 +334,10 @@ func TestGetResourceHandler_WithRange(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
-	}
-	if store.lastGetRng == nil || store.lastGetRng.Offset != 2 || store.lastGetRng.Length != 3 {
-		t.Fatalf("range wrong: %+v", store.lastGetRng)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, store.lastGetRng)
+	require.Equal(t, uint64(2), store.lastGetRng.Offset)
+	require.Equal(t, uint32(3), store.lastGetRng.Length)
 }
 
 func TestGetResourceHandler_BadType(t *testing.T) {
@@ -388,9 +349,7 @@ func TestGetResourceHandler_BadType(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestGetResourceHandler_BadMAC(t *testing.T) {
@@ -401,9 +360,7 @@ func TestGetResourceHandler_BadMAC(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestGetResourceHandler_BadRange(t *testing.T) {
@@ -416,9 +373,7 @@ func TestGetResourceHandler_BadRange(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestGetResourceHandler_StoreError(t *testing.T) {
@@ -430,9 +385,7 @@ func TestGetResourceHandler_StoreError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 // errReadCloser fails on Read so io.ReadAll in getResource returns an error.
@@ -450,9 +403,7 @@ func TestGetResourceHandler_ReadError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500", rec.Code)
-	}
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestPutResource_Ok(t *testing.T) {
@@ -465,12 +416,8 @@ func TestPutResource_Ok(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
-	}
-	if string(store.lastPutData) != "body-bytes" {
-		t.Fatalf("put data = %q", store.lastPutData)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []byte("body-bytes"), store.lastPutData)
 }
 
 func TestPutResource_BadType(t *testing.T) {
@@ -482,9 +429,7 @@ func TestPutResource_BadType(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestPutResource_BadMAC(t *testing.T) {
@@ -495,9 +440,7 @@ func TestPutResource_BadMAC(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestPutResource_StoreError(t *testing.T) {
@@ -509,9 +452,7 @@ func TestPutResource_StoreError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestDeleteResource_Ok(t *testing.T) {
@@ -523,12 +464,9 @@ func TestDeleteResource_Ok(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
-	}
-	if store.lastDelType != storage.StorageResourcePackfile || store.lastDelMAC != mac {
-		t.Fatalf("delete call args wrong: type=%v mac=%v", store.lastDelType, store.lastDelMAC)
-	}
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, storage.StorageResourcePackfile, store.lastDelType)
+	require.Equal(t, mac, store.lastDelMAC)
 }
 
 func TestDeleteResource_Forbidden(t *testing.T) {
@@ -540,9 +478,7 @@ func TestDeleteResource_Forbidden(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", rec.Code)
-	}
+	require.Equal(t, http.StatusForbidden, rec.Code)
 }
 
 func TestDeleteResource_BadType(t *testing.T) {
@@ -554,9 +490,7 @@ func TestDeleteResource_BadType(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestDeleteResource_BadMAC(t *testing.T) {
@@ -566,9 +500,7 @@ func TestDeleteResource_BadMAC(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestDeleteResource_StoreError(t *testing.T) {
@@ -580,9 +512,7 @@ func TestDeleteResource_StoreError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d", rec.Code)
-	}
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestAuth(t *testing.T) {

--- a/server/httpd/httpd_test.go
+++ b/server/httpd/httpd_test.go
@@ -249,7 +249,7 @@ func TestGetRange_LengthOverflowsUint32(t *testing.T) {
 
 func TestOpenRepository_Ok(t *testing.T) {
 	store := &fakeStore{openConfig: []byte("wrapped-config-bytes")}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -268,7 +268,7 @@ func TestOpenRepository_Ok(t *testing.T) {
 
 func TestOpenRepository_StoreError(t *testing.T) {
 	store := &fakeStore{openErr: errors.New("disk on fire")}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -289,7 +289,7 @@ func TestListResource_Ok(t *testing.T) {
 			storage.StorageResourcePackfile: {mac},
 		},
 	}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles", nil)
 	rec := httptest.NewRecorder()
@@ -309,7 +309,7 @@ func TestListResource_Ok(t *testing.T) {
 
 func TestListResource_BadType(t *testing.T) {
 	store := &fakeStore{}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/bogus", nil)
 	rec := httptest.NewRecorder()
@@ -322,7 +322,7 @@ func TestListResource_BadType(t *testing.T) {
 
 func TestListResource_StoreError(t *testing.T) {
 	store := &fakeStore{listErr: errors.New("list failed")}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles", nil)
 	rec := httptest.NewRecorder()
@@ -340,7 +340,7 @@ func TestGetResourceHandler_Ok(t *testing.T) {
 			storage.StorageResourcePackfile: {mac: []byte("payload")},
 		},
 	}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -364,7 +364,7 @@ func TestGetResourceHandler_WithRange(t *testing.T) {
 			storage.StorageResourcePackfile: {mac: []byte("payload")},
 		},
 	}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	req.Header.Set("Range", "bytes=2-5")
@@ -382,7 +382,7 @@ func TestGetResourceHandler_WithRange(t *testing.T) {
 func TestGetResourceHandler_BadType(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/bogus/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -395,7 +395,7 @@ func TestGetResourceHandler_BadType(t *testing.T) {
 
 func TestGetResourceHandler_BadMAC(t *testing.T) {
 	store := &fakeStore{}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/short", nil)
 	rec := httptest.NewRecorder()
@@ -409,7 +409,7 @@ func TestGetResourceHandler_BadMAC(t *testing.T) {
 func TestGetResourceHandler_BadRange(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	req.Header.Set("Range", "items=garbage")
@@ -424,7 +424,7 @@ func TestGetResourceHandler_BadRange(t *testing.T) {
 func TestGetResourceHandler_StoreError(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{getErr: errors.New("missing")}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -444,7 +444,7 @@ func (errReadCloser) Close() error             { return nil }
 func TestGetResourceHandler_ReadError(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{getReader: errReadCloser{}}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -458,7 +458,7 @@ func TestGetResourceHandler_ReadError(t *testing.T) {
 func TestPutResource_Ok(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := Mux(store, false, "")
+	mux := Mux(store, false)
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), strings.NewReader("body-bytes"))
@@ -475,7 +475,7 @@ func TestPutResource_Ok(t *testing.T) {
 
 func TestPutResource_BadType(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := Mux(&fakeStore{}, false, "")
+	mux := Mux(&fakeStore{}, false)
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/bogus/"+hex.EncodeToString(mac[:]), strings.NewReader("x"))
@@ -488,7 +488,7 @@ func TestPutResource_BadType(t *testing.T) {
 }
 
 func TestPutResource_BadMAC(t *testing.T) {
-	mux := Mux(&fakeStore{}, false, "")
+	mux := Mux(&fakeStore{}, false)
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/packfiles/short", strings.NewReader("x"))
@@ -502,7 +502,7 @@ func TestPutResource_BadMAC(t *testing.T) {
 
 func TestPutResource_StoreError(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := Mux(&fakeStore{putErr: errors.New("write failed")}, false, "")
+	mux := Mux(&fakeStore{putErr: errors.New("write failed")}, false)
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), strings.NewReader("x"))
@@ -517,8 +517,7 @@ func TestPutResource_StoreError(t *testing.T) {
 func TestDeleteResource_Ok(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := Mux(store, false, "")
-
+	mux := Mux(store, false)
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -534,7 +533,7 @@ func TestDeleteResource_Ok(t *testing.T) {
 
 func TestDeleteResource_Forbidden(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := Mux(&fakeStore{}, true, "") // noDelete=true
+	mux := Mux(&fakeStore{}, true) // noDelete=true
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
@@ -548,7 +547,7 @@ func TestDeleteResource_Forbidden(t *testing.T) {
 
 func TestDeleteResource_BadType(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := Mux(&fakeStore{}, false, "")
+	mux := Mux(&fakeStore{}, false)
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/bogus/"+hex.EncodeToString(mac[:]), nil)
@@ -561,7 +560,7 @@ func TestDeleteResource_BadType(t *testing.T) {
 }
 
 func TestDeleteResource_BadMAC(t *testing.T) {
-	mux := Mux(&fakeStore{}, false, "")
+	mux := Mux(&fakeStore{}, false)
 
 	req := httptest.NewRequest(http.MethodDelete, "/resources/packfiles/short", nil)
 	rec := httptest.NewRecorder()
@@ -574,7 +573,7 @@ func TestDeleteResource_BadMAC(t *testing.T) {
 
 func TestDeleteResource_StoreError(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := Mux(&fakeStore{deleteErr: errors.New("nope")}, false, "")
+	mux := Mux(&fakeStore{deleteErr: errors.New("nope")}, false)
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
@@ -586,8 +585,9 @@ func TestDeleteResource_StoreError(t *testing.T) {
 	}
 }
 
-func TestServerToken(t *testing.T) {
-	mux := Mux(&fakeStore{}, false, "nestor")
+func TestAuth(t *testing.T) {
+	token := "nestor"
+	mux := Auth(token, Mux(&fakeStore{}, false))
 
 	var req *http.Request
 	var rec *httptest.ResponseRecorder
@@ -606,7 +606,7 @@ func TestServerToken(t *testing.T) {
 		"expected 401 with a bad token")
 
 	req = httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("Authorization", "Bearer nestor")
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code,

--- a/server/httpd/httpd_test.go
+++ b/server/httpd/httpd_test.go
@@ -6,19 +6,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/location"
 	"github.com/PlakarKorp/kloset/objects"
-	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,20 +101,6 @@ func makeMAC(first byte) objects.MAC {
 	var m objects.MAC
 	m[0] = first
 	return m
-}
-
-// newTestMux wires up the same routes as Server() but against the supplied
-// fakeStore so we can drive every handler via httptest without spinning up
-// a real http.Server.
-func newTestMux(store *fakeStore, noDelete bool) *http.ServeMux {
-	s := &server{store: store, noDelete: noDelete}
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /", s.openRepository)
-	mux.HandleFunc("GET /resources/{resource}", s.listResource)
-	mux.HandleFunc("GET /resources/{resource}/{mac}", s.getResource)
-	mux.HandleFunc("PUT /resources/{resource}/{mac}", s.putResource)
-	mux.HandleFunc("DELETE /resources/{resource}/{mac}", s.deleteResource)
-	return mux
 }
 
 // ---------- pure parser helpers ----------
@@ -267,7 +249,7 @@ func TestGetRange_LengthOverflowsUint32(t *testing.T) {
 
 func TestOpenRepository_Ok(t *testing.T) {
 	store := &fakeStore{openConfig: []byte("wrapped-config-bytes")}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -286,7 +268,7 @@ func TestOpenRepository_Ok(t *testing.T) {
 
 func TestOpenRepository_StoreError(t *testing.T) {
 	store := &fakeStore{openErr: errors.New("disk on fire")}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -307,7 +289,7 @@ func TestListResource_Ok(t *testing.T) {
 			storage.StorageResourcePackfile: {mac},
 		},
 	}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles", nil)
 	rec := httptest.NewRecorder()
@@ -327,7 +309,7 @@ func TestListResource_Ok(t *testing.T) {
 
 func TestListResource_BadType(t *testing.T) {
 	store := &fakeStore{}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/bogus", nil)
 	rec := httptest.NewRecorder()
@@ -340,7 +322,7 @@ func TestListResource_BadType(t *testing.T) {
 
 func TestListResource_StoreError(t *testing.T) {
 	store := &fakeStore{listErr: errors.New("list failed")}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles", nil)
 	rec := httptest.NewRecorder()
@@ -358,7 +340,7 @@ func TestGetResourceHandler_Ok(t *testing.T) {
 			storage.StorageResourcePackfile: {mac: []byte("payload")},
 		},
 	}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -382,7 +364,7 @@ func TestGetResourceHandler_WithRange(t *testing.T) {
 			storage.StorageResourcePackfile: {mac: []byte("payload")},
 		},
 	}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	req.Header.Set("Range", "bytes=2-5")
@@ -400,7 +382,7 @@ func TestGetResourceHandler_WithRange(t *testing.T) {
 func TestGetResourceHandler_BadType(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/bogus/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -413,7 +395,7 @@ func TestGetResourceHandler_BadType(t *testing.T) {
 
 func TestGetResourceHandler_BadMAC(t *testing.T) {
 	store := &fakeStore{}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/short", nil)
 	rec := httptest.NewRecorder()
@@ -427,7 +409,7 @@ func TestGetResourceHandler_BadMAC(t *testing.T) {
 func TestGetResourceHandler_BadRange(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	req.Header.Set("Range", "items=garbage")
@@ -442,7 +424,7 @@ func TestGetResourceHandler_BadRange(t *testing.T) {
 func TestGetResourceHandler_StoreError(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{getErr: errors.New("missing")}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -462,7 +444,7 @@ func (errReadCloser) Close() error             { return nil }
 func TestGetResourceHandler_ReadError(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{getReader: errReadCloser{}}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
 	rec := httptest.NewRecorder()
@@ -476,7 +458,7 @@ func TestGetResourceHandler_ReadError(t *testing.T) {
 func TestPutResource_Ok(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), strings.NewReader("body-bytes"))
@@ -493,7 +475,7 @@ func TestPutResource_Ok(t *testing.T) {
 
 func TestPutResource_BadType(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := newTestMux(&fakeStore{}, false)
+	mux := Mux(&fakeStore{}, false, "")
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/bogus/"+hex.EncodeToString(mac[:]), strings.NewReader("x"))
@@ -506,7 +488,7 @@ func TestPutResource_BadType(t *testing.T) {
 }
 
 func TestPutResource_BadMAC(t *testing.T) {
-	mux := newTestMux(&fakeStore{}, false)
+	mux := Mux(&fakeStore{}, false, "")
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/packfiles/short", strings.NewReader("x"))
@@ -520,7 +502,7 @@ func TestPutResource_BadMAC(t *testing.T) {
 
 func TestPutResource_StoreError(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := newTestMux(&fakeStore{putErr: errors.New("write failed")}, false)
+	mux := Mux(&fakeStore{putErr: errors.New("write failed")}, false, "")
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), strings.NewReader("x"))
@@ -535,7 +517,7 @@ func TestPutResource_StoreError(t *testing.T) {
 func TestDeleteResource_Ok(t *testing.T) {
 	mac := makeMAC(0x42)
 	store := &fakeStore{}
-	mux := newTestMux(store, false)
+	mux := Mux(store, false, "")
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
@@ -552,7 +534,7 @@ func TestDeleteResource_Ok(t *testing.T) {
 
 func TestDeleteResource_Forbidden(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := newTestMux(&fakeStore{}, true) // noDelete=true
+	mux := Mux(&fakeStore{}, true, "") // noDelete=true
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
@@ -566,7 +548,7 @@ func TestDeleteResource_Forbidden(t *testing.T) {
 
 func TestDeleteResource_BadType(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := newTestMux(&fakeStore{}, false)
+	mux := Mux(&fakeStore{}, false, "")
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/bogus/"+hex.EncodeToString(mac[:]), nil)
@@ -579,7 +561,7 @@ func TestDeleteResource_BadType(t *testing.T) {
 }
 
 func TestDeleteResource_BadMAC(t *testing.T) {
-	mux := newTestMux(&fakeStore{}, false)
+	mux := Mux(&fakeStore{}, false, "")
 
 	req := httptest.NewRequest(http.MethodDelete, "/resources/packfiles/short", nil)
 	rec := httptest.NewRecorder()
@@ -592,7 +574,7 @@ func TestDeleteResource_BadMAC(t *testing.T) {
 
 func TestDeleteResource_StoreError(t *testing.T) {
 	mac := makeMAC(0x42)
-	mux := newTestMux(&fakeStore{deleteErr: errors.New("nope")}, false)
+	mux := Mux(&fakeStore{deleteErr: errors.New("nope")}, false, "")
 
 	req := httptest.NewRequest(http.MethodDelete,
 		"/resources/packfiles/"+hex.EncodeToString(mac[:]), nil)
@@ -604,124 +586,29 @@ func TestDeleteResource_StoreError(t *testing.T) {
 	}
 }
 
-// freePort asks the kernel for an unused TCP port and returns it as a string.
-func freePort(t *testing.T) string {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	addr := l.Addr().(*net.TCPAddr)
-	_ = l.Close()
-	return fmt.Sprintf("127.0.0.1:%d", addr.Port)
-}
-
-func TestServer_StartServeAndShutdown(t *testing.T) {
-	repo, ctx := ptesting.GenerateRepository(t, nil, nil, nil)
-
-	addr := freePort(t)
-	errCh := make(chan error, 1)
-	go func() {
-		// noDelete=false, no TLS — exercises the plain ListenAndServe path.
-		errCh <- Server(ctx, repo, addr, false, "", "", "")
-	}()
-
-	// Wait until the server accepts connections, then make one request so the
-	// wired routes are exercised through a real listener.
-	base := "http://" + addr
-	var resp *http.Response
-	deadline := 2 * time.Second
-	for waited := time.Duration(0); waited < deadline; waited += 20 * time.Millisecond {
-		r, err := http.Get(base + "/")
-		if err == nil {
-			resp = r
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if resp == nil {
-		t.Fatal("server never became reachable")
-	}
-	_ = resp.Body.Close()
-
-	// Cancelling the context triggers the goroutine inside Server() to call
-	// Shutdown, which makes ListenAndServe return.
-	ctx.GetInner().Cancel(nil)
-
-	select {
-	case err := <-errCh:
-		// http.ErrServerClosed is the expected return after a graceful Shutdown.
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			t.Fatalf("Server returned %v, want ErrServerClosed or nil", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Server did not return after context cancellation")
-	}
-}
-
-func TestServer_TLSConfigErrors(t *testing.T) {
-	// With cert/key set but pointing at nonexistent files, ListenAndServeTLS
-	// returns an error immediately — this covers the TLS branch of Server().
-	repo, ctx := ptesting.GenerateRepository(t, nil, nil, nil)
-
-	addr := freePort(t)
-	err := Server(ctx, repo, addr, false, "", "/nonexistent/cert.pem", "/nonexistent/key.pem")
-	if err == nil {
-		t.Fatal("expected error from ListenAndServeTLS with missing cert/key")
-	}
-}
-
 func TestServerToken(t *testing.T) {
-	repo, ctx := ptesting.GenerateRepository(t, nil, nil, nil)
+	mux := Mux(&fakeStore{}, false, "nestor")
 
-	token := "nestor"
+	var req *http.Request
+	var rec *httptest.ResponseRecorder
 
-	addr := freePort(t)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- Server(ctx, repo, addr, false, token, "", "")
-	}()
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code,
+		"expected 401 without token")
 
-	// Wait until the server accepts connections, then make one request so the
-	// wired routes are exercised through a real listener.
-	base := "http://" + addr
-	var resp *http.Response
-	deadline := 2 * time.Second
-	for waited := time.Duration(0); waited < deadline; waited += 20 * time.Millisecond {
-		r, err := http.Get(base + "/")
-		if err == nil {
-			resp = r
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if resp == nil {
-		t.Fatal("server never became reachable")
-	}
-	_ = resp.Body.Close()
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer flan")
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code,
+		"expected 401 with a bad token")
 
-	require.Equal(t, 401, resp.StatusCode)
-
-	req, err := http.NewRequest("GET", base+"/", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode)
-
-	// Cancelling the context triggers the goroutine inside Server() to call
-	// Shutdown, which makes ListenAndServe return.
-	ctx.GetInner().Cancel(nil)
-
-	select {
-	case err := <-errCh:
-		// http.ErrServerClosed is the expected return after a graceful Shutdown.
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			t.Fatalf("Server returned %v, want ErrServerClosed or nil", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Server did not return after context cancellation")
-	}
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer nestor")
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code,
+		"expected 200 with the right token")
 }

--- a/subcommands/server/server.go
+++ b/subcommands/server/server.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
 	"github.com/PlakarKorp/plakar/server/httpd"
@@ -71,7 +73,24 @@ func (cmd *Server) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 		protocol = "http"
 	}
 	ctx.GetLogger().Info("listening on %s://%s", protocol, cmd.ListenAddr)
-	err := httpd.Server(ctx, repo, cmd.ListenAddr, cmd.NoDelete, cmd.Token, cmd.Cert, cmd.Key)
+	mux := httpd.Mux(repo.Store(), cmd.NoDelete, cmd.Token)
+
+	server := &http.Server{
+		Addr:    cmd.ListenAddr,
+		Handler: mux,
+	}
+	go func() {
+		<-ctx.Done()
+		server.Shutdown(ctx)
+	}()
+
+	var err error
+	if cmd.Cert != "" && cmd.Key != "" {
+		err = server.ListenAndServeTLS(cmd.Cert, cmd.Key)
+	} else {
+		err = server.ListenAndServe()
+	}
+
 	if err != nil {
 		return 1, err
 	}

--- a/subcommands/server/server.go
+++ b/subcommands/server/server.go
@@ -73,11 +73,11 @@ func (cmd *Server) Execute(ctx *appcontext.AppContext, repo *repository.Reposito
 		protocol = "http"
 	}
 	ctx.GetLogger().Info("listening on %s://%s", protocol, cmd.ListenAddr)
-	mux := httpd.Mux(repo.Store(), cmd.NoDelete, cmd.Token)
+	mux := httpd.Mux(repo.Store(), cmd.NoDelete)
 
 	server := &http.Server{
 		Addr:    cmd.ListenAddr,
-		Handler: mux,
+		Handler: httpd.Logging(httpd.Auth(cmd.Token, mux)),
 	}
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
The idea here is that it's a bit ugly for the `server/httpd` plugin to automagically run the server IMHO.  Let's leave the caller to deal with the `ListenAndServe` and just have `server/http` return a mux.  Makes testing easier, too.

Otherwise, I can re-introduce Server(), but killing the mock server and keeping instead Mux is an improvement IMHO.