### PR TITLE
backup: don't scan the source twice when nothing displays the summary

### DIFF
--- a/appcontext/appcontext.go
+++ b/appcontext/appcontext.go
@@ -27,6 +27,10 @@ type AppContext struct {
 
 	Quiet  bool
 	Silent bool
+
+	// ProgressSummary is set when the selected renderer consumes fs.summary,
+	// which costs backup an extra scan of the source.
+	ProgressSummary bool
 }
 
 func NewAppContext() *AppContext {

--- a/main.go
+++ b/main.go
@@ -195,8 +195,11 @@ func entryPoint() int {
 	ctx := appcontext.NewAppContext()
 	defer ctx.Close()
 
+	plainOutput := opt_silent || opt_stdio || opt_quiet || opt_trace != "" || !isTerminal()
+	ctx.ProgressSummary = !plainOutput
+
 	var renderer ui.UI
-	if opt_silent || opt_stdio || opt_quiet || opt_trace != "" || !isTerminal() {
+	if plainOutput {
 		renderer = stdio.New(ctx)
 	} else if opt_json {
 		renderer = jsonui.New(ctx)

--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -188,6 +188,12 @@ func (cmd *Backup) Parse(ctx *appcontext.AppContext, args []string) error {
 	return nil
 }
 
+// computing the filesystem summary walks the whole source a second time,
+// so only do it when something will display it.
+func (cmd *Backup) wantsFilesystemSummary(ctx *appcontext.AppContext, flags location.Flags) bool {
+	return !cmd.NoProgress && ctx.ProgressSummary && (flags&location.FLAG_STREAM) == 0
+}
+
 func (cmd *Backup) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
 	ret, err, _, _ := cmd.DoBackup(ctx, repo)
 	return ret, err
@@ -273,7 +279,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		importerKey := typ + ":" + orig
 		sourcesPerOrig[importerKey] = append(sourcesPerOrig[importerKey], imp)
 
-		if !cmd.NoProgress && (imp.Flags()&location.FLAG_STREAM) == 0 {
+		if cmd.wantsFilesystemSummary(ctx, imp.Flags()) {
 			imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, cmdOptsCopy)
 			if err != nil {
 				return 1, fmt.Errorf("failed to create an importer for %s: %s", scanDir, err), objects.MAC{}, nil
@@ -370,7 +376,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		}
 		snap.WithVFSCache(parentVFS)
 
-		if !cmd.NoProgress && (source.Flags()&location.FLAG_STREAM) == 0 {
+		if cmd.wantsFilesystemSummary(ctx, source.Flags()) {
 			source, err := snapshot.NewSource(repo.AppContext(), sourcesPerOrigForStats[key]...)
 			if err != nil {
 				return 1, err, objects.NilMac, nil

--- a/subcommands/backup/backup_summary_test.go
+++ b/subcommands/backup/backup_summary_test.go
@@ -1,0 +1,93 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/connectors/importer"
+	"github.com/PlakarKorp/kloset/repository"
+	"github.com/PlakarKorp/plakar/appcontext"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/PlakarKorp/plakar/ui/stdio"
+	"github.com/stretchr/testify/require"
+)
+
+type countingImporter struct {
+	importer.Importer
+	scans *atomic.Int64
+}
+
+func (c *countingImporter) Import(ctx context.Context, records chan<- *connectors.Record, results <-chan *connectors.Result) error {
+	c.scans.Add(1)
+	return c.Importer.Import(ctx, records, results)
+}
+
+func setupCountingBackup(t *testing.T, proto string) (*repository.Repository, *appcontext.AppContext, *atomic.Int64) {
+	t.Helper()
+
+	scans := &atomic.Int64{}
+	err := importer.Register(proto, 0, func(ctx context.Context, opts *connectors.Options, name string, config map[string]string) (importer.Importer, error) {
+		inner, err := ptesting.NewMockImporter(ctx, opts, name, config)
+		if err != nil {
+			return nil, err
+		}
+		inner.(*ptesting.MockImporter).SetFiles([]ptesting.MockFile{
+			ptesting.NewMockFile("/subdir/dummy.txt", 0644, "hello dummy"),
+		})
+		return &countingImporter{Importer: inner, scans: scans}, nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, importer.Unregister(proto)) })
+
+	repo, _, ctx := generateFixtures(t, bytes.NewBuffer(nil), bytes.NewBuffer(nil))
+
+	renderer := stdio.New(ctx)
+	require.NoError(t, renderer.Run())
+	t.Cleanup(func() { _ = renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	return repo, ctx, scans
+}
+
+func runCountingBackup(t *testing.T, repo *repository.Repository, ctx *appcontext.AppContext, args ...string) {
+	t.Helper()
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, args))
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+}
+
+func TestBackupSkipsFilesystemSummaryWhenNothingConsumesIt(t *testing.T) {
+	repo, ctx, scans := setupCountingBackup(t, "countsummaryoff")
+
+	runCountingBackup(t, repo, ctx, "countsummaryoff://tree")
+
+	require.Equal(t, int64(1), scans.Load(),
+		"backup must walk the source once when no renderer consumes the filesystem summary")
+}
+
+func TestBackupComputesFilesystemSummaryForProgressRenderer(t *testing.T) {
+	repo, ctx, scans := setupCountingBackup(t, "countsummaryon")
+	ctx.ProgressSummary = true
+
+	runCountingBackup(t, repo, ctx, "countsummaryon://tree")
+
+	require.Equal(t, int64(2), scans.Load(),
+		"backup must still gather the filesystem summary for a renderer that displays it")
+}
+
+func TestBackupSkipsFilesystemSummaryWithNoProgress(t *testing.T) {
+	repo, ctx, scans := setupCountingBackup(t, "countsummarynoprogress")
+	ctx.ProgressSummary = true
+
+	runCountingBackup(t, repo, ctx, "-no-progress", "countsummarynoprogress://tree")
+
+	require.Equal(t, int64(1), scans.Load(),
+		"-no-progress must keep the source from being walked twice")
+}


### PR DESCRIPTION
`backup` builds a second importer for the same source and walks the whole tree
through it just to produce the filesystem summary, on every run. Only the TUI
displays that summary and the JSON stream forwards it — the stdio renderer,
which `main` selects for `-quiet`, `-silent`, `-stdio`, `-trace` and every
non-interactive run, drops it. This records on the app context whether the
renderer consumes the summary and lets `backup` skip the pre-scan when it does
not; on a 30000-file source that halves the stat calls on the source, 60517 →
30310 `newfstatat`.

Refs #2338 but does not fix it: the store-side cost that issue reports (parent
VFS/btree blobs re-read per run) lives in `kloset`, not here.
