### PR TITLE
all: Make usage of a plaintext repo explicit.

### DIFF
--- a/main.go
+++ b/main.go
@@ -441,6 +441,11 @@ func entryPoint() int {
 			return exitcodes.RepoIncompatible
 		}
 
+		if err := utils.CheckPlaintext(storeConfig["location"], repoConfig.Encryption != nil); err != nil {
+			logger.Stderr("%s: %s\n", progName(), err)
+			return exitcodes.AuthFailure
+		}
+
 		if err := setupEncryption(ctx, repoConfig); err != nil {
 			logger.Stderr("%s: %s\n", progName(), err)
 			return exitcodes.AuthFailure

--- a/main_cov80_test.go
+++ b/main_cov80_test.go
@@ -111,6 +111,7 @@ func writeStoresYmlCov80(t *testing.T, configDir, name, location string) {
 // This drives the `def != ""` branch and a successful GetRepository lookup.
 func TestEntryPointDefaultRepositoryFromConfigCov80(t *testing.T) {
 	repoDir := filepath.Join(t.TempDir(), "repo")
+	t.Setenv(plaintextEnv, "1") // the repository below is plaintext
 
 	// First create the repository at an explicit location.
 	status, _, stderr := runEntryPointCov80(t, nil, "at", repoDir, "create", "-plaintext")
@@ -148,6 +149,7 @@ func TestEntryPointDefaultRepositoryUnknownAliasCov80(t *testing.T) {
 // plaintext repo the secret is simply ignored, so the command still succeeds.
 func TestEntryPointEnvPassphraseWithPlaintextRepoCov80(t *testing.T) {
 	repoDir := filepath.Join(t.TempDir(), "repo")
+	t.Setenv(plaintextEnv, "1") // the repository below is plaintext
 	status, _, stderr := runEntryPointCov80(t, nil, "at", repoDir, "create", "-plaintext")
 	require.Equalf(t, 0, status, "create stderr: %s", stderr)
 

--- a/main_coverage_test.go
+++ b/main_coverage_test.go
@@ -167,6 +167,7 @@ func TestEntryPoint_MissingKeyfile(t *testing.T) {
 
 func TestEntryPoint_CreateThenInfo(t *testing.T) {
 	repoDir := filepath.Join(t.TempDir(), "repo")
+	t.Setenv(plaintextEnv, "1") // the repository below is plaintext
 
 	// Create a plaintext repository at an explicit location.
 	status, _, stderr := runEntryPoint(t, "at", repoDir, "create", "-plaintext")
@@ -207,6 +208,7 @@ func TestEntryPoint_KeyfileWithPlaintextRepo(t *testing.T) {
 	// A keyfile is supplied but the repo is plaintext: setupEncryption sees a
 	// nil Encryption config and the keyfile secret is simply ignored.
 	repoDir := filepath.Join(t.TempDir(), "repo")
+	t.Setenv(plaintextEnv, "1") // the repository below is plaintext
 	status, _, stderr := runEntryPoint(t, "at", repoDir, "create", "-plaintext")
 	require.Equalf(t, 0, status, "create stderr: %s", stderr)
 

--- a/main_plaintext_test.go
+++ b/main_plaintext_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/exitcodes"
+	"github.com/stretchr/testify/require"
+)
+
+const plaintextEnv = "PLAKAR_INSECURE_PLAINTEXT"
+
+// consent is the variable being present, so it has to be removed rather than
+// blanked
+func withoutPlaintextConsent(t *testing.T) {
+	t.Helper()
+	if v, ok := os.LookupEnv(plaintextEnv); ok {
+		t.Setenv(plaintextEnv, v) // restored on cleanup
+		os.Unsetenv(plaintextEnv)
+	}
+}
+
+// a plaintext CONFIG dropped over an encrypted one would silently turn every
+// later backup into cleartext, so opening such a repository has to stop
+func TestEntryPointPlaintextRepositoryRefused(t *testing.T) {
+	withoutPlaintextConsent(t)
+	repoDir := filepath.Join(t.TempDir(), "repo")
+
+	// creating one is not gated: -plaintext already says it out loud
+	status, _, stderr := runEntryPoint(t, "at", repoDir, "create", "-plaintext")
+	require.Equalf(t, 0, status, "create stderr: %s", stderr)
+
+	status, _, stderr = runEntryPoint(t, "at", repoDir, "info")
+	require.Equal(t, exitcodes.AuthFailure, status)
+	require.Contains(t, stderr, "refusing to open a plaintext repository")
+
+	t.Setenv(plaintextEnv, "1")
+	status, _, stderr = runEntryPoint(t, "at", repoDir, "info")
+	require.Equalf(t, 0, status, "info stderr: %s", stderr)
+}
+
+func TestEntryPointEncryptedRepositoryNeedsNoConsent(t *testing.T) {
+	withoutPlaintextConsent(t)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	keyfile := filepath.Join(t.TempDir(), "key")
+	require.NoError(t, os.WriteFile(keyfile, []byte("aZeRtY123456$#@!@\n"), 0600))
+
+	status, _, stderr := runEntryPoint(t, "-keyfile", keyfile, "at", repoDir, "create")
+	require.Equalf(t, 0, status, "create stderr: %s", stderr)
+
+	status, _, stderr = runEntryPoint(t, "-keyfile", keyfile, "at", repoDir, "info")
+	require.Equalf(t, 0, status, "info stderr: %s", stderr)
+}

--- a/plakar.1
+++ b/plakar.1
@@ -208,6 +208,10 @@ List installed plugins, refer to
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
+.It Ev PLAKAR_INSECURE_PLAINTEXT
+Must be set to work with a Kloset store that is not encrypted.
+Without it, every command that would read from or write to an unencrypted
+store refuses to run.
 .It Ev PLAKAR_PASSPHRASE
 Passphrase to unlock the Kloset store; overrides the one from the configuration.
 If set,
@@ -250,7 +254,9 @@ Data integrity check failed (corrupted chunks, verification mismatch).
 .It 66 (EX_NOINPUT)
 The repository could not be opened or located.
 .It 77 (EX_NOPERM)
-Authentication or decryption failure (wrong passphrase, missing keyfile).
+Authentication or decryption failure (wrong passphrase, missing keyfile), or
+an unencrypted store used without
+.Ev PLAKAR_INSECURE_PLAINTEXT .
 .It 78 (EX_CONFIG)
 Incompatible repository version.
 .El

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -414,4 +414,4 @@ Remove snapshots older than 30 days:
 
 	$ plakar rm -before 30d
 
-Plakar - May 5, 2026
+Plakar - May 5, 2026 - PLAKAR(1)

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -299,6 +299,12 @@ The following options are available:
 
 # ENVIRONMENT
 
+`PLAKAR_INSECURE_PLAINTEXT`
+
+> Must be set to work with a Kloset store that is not encrypted.
+> Without it, every command that would read from or write to an unencrypted
+> store refuses to run.
+
 `PLAKAR_PASSPHRASE`
 
 > Passphrase to unlock the Kloset store; overrides the one from the configuration.
@@ -367,7 +373,9 @@ where applicable:
 
 77 (EX\_NOPERM)
 
-> Authentication or decryption failure (wrong passphrase, missing keyfile).
+> Authentication or decryption failure (wrong passphrase, missing keyfile), or
+> an unencrypted store used without
+> `PLAKAR_INSECURE_PLAINTEXT`.
 
 78 (EX\_CONFIG)
 
@@ -406,4 +414,4 @@ Remove snapshots older than 30 days:
 
 	$ plakar rm -before 30d
 
-Plakar - May 5, 2026 - PLAKAR(1)
+Plakar - May 5, 2026

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -155,6 +155,10 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 			return err
 		}
 
+		if err := utils.CheckPlaintext(storeConfig["location"], peerStoreConfig.Encryption != nil); err != nil {
+			return err
+		}
+
 		if peerStoreConfig.Encryption != nil {
 			if pass, ok := storeConfig["passphrase"]; ok {
 				key, err := encryption.DeriveKey(peerStoreConfig.Encryption.KDFParams, []byte(pass))

--- a/subcommands/ptar/ptar_test.go
+++ b/subcommands/ptar/ptar_test.go
@@ -19,6 +19,8 @@ import (
 
 func init() {
 	os.Setenv("TZ", "UTC")
+	// several fixtures below use a plaintext -k source on purpose
+	os.Setenv("PLAKAR_INSECURE_PLAINTEXT", "1")
 }
 
 func TestExecuteCmdPtarDefault(t *testing.T) {

--- a/subcommands/sync/sync.go
+++ b/subcommands/sync/sync.go
@@ -112,6 +112,10 @@ func (cmd *Sync) Parse(ctx *appcontext.AppContext, args []string) error {
 		return err
 	}
 
+	if err := utils.CheckPlaintext(storeConfig["location"], peerStoreConfig.Encryption != nil); err != nil {
+		return err
+	}
+
 	var peerSecret []byte
 	if peerStoreConfig.Encryption != nil {
 		if pass, ok := storeConfig["passphrase"]; ok {

--- a/subcommands/sync/sync_test.go
+++ b/subcommands/sync/sync_test.go
@@ -16,6 +16,8 @@ import (
 
 func init() {
 	os.Setenv("TZ", "UTC")
+	// several fixtures below use a plaintext peer on purpose
+	os.Setenv("PLAKAR_INSECURE_PLAINTEXT", "1")
 }
 
 var mockFiles = []ptesting.MockFile{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -405,3 +405,12 @@ func ValidateEmail(email string) (string, error) {
 	}
 	return mail.Address, nil
 }
+
+func CheckPlaintext(location string, encrypted bool) error {
+	_, ok := os.LookupEnv("PLAKAR_INSECURE_PLAINTEXT")
+	if !encrypted && !ok {
+		return fmt.Errorf("refusing to open a plaintext repository without explicit consent")
+	}
+
+	return nil
+}


### PR DESCRIPTION
* This adds an env var, required to exist to have any command work with a plaintext repo.

* This is a security strategy, because it makes it obvious if someone is attempting to override your repo with a plaintext config rather than silently pushing cleartext backups.