### PR TITLE
Add web API for diag chunkmap

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -226,6 +226,7 @@ func SetupRoutes(server *http.ServeMux, repo *repository.Repository, ctx *appcon
 	server.Handle("GET /api/snapshot/vfs/{snapshot_path...}", authToken(JSONAPIView(ui.snapshotVFSBrowse)))
 	server.Handle("GET /api/snapshot/vfs/children/{snapshot_path...}", authToken(JSONAPIView(ui.snapshotVFSChildren)))
 	server.Handle("GET /api/snapshot/vfs/chunks/{snapshot_path...}", authToken(JSONAPIView(ui.snapshotVFSChunks)))
+	server.Handle("GET /api/snapshot/chunkmap", authToken(JSONAPIView(ui.snapshotChunkmap)))
 	server.Handle("GET /api/snapshot/vfs/search/{snapshot_path...}", authToken(JSONAPIView(ui.snapshotVFSSearch)))
 	server.Handle("GET /api/snapshot/vfs/errors/{snapshot_path...}", authToken(JSONAPIView(ui.snapshotVFSErrors)))
 

--- a/api/api_chunkmap.go
+++ b/api/api_chunkmap.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/PlakarKorp/plakar/chunkmap"
+)
+
+// maxChunkmapPaths bounds how many snapshot:path pairs a single request may
+// compare. Each pair costs a snapshot-prefix lookup plus a filesystem walk and
+// holds its chunk list in memory, so the count must be capped to keep an
+// authenticated caller from amplifying one request into arbitrary work. 64 is
+// generous for the real use case (one file across a retention window).
+const maxChunkmapPaths = 64
+
+// snapshotChunkmap compares one file across several snapshots and reports, per
+// chunk, how many of the requested files share it. It is the API analogue of
+// the `diag chunkmap` command: the snapshot:path pairs are passed as repeated
+// `path` query parameters. The share ratio and its colour are left to the
+// frontend: for total > 1, ratio = (share_count-1)/(total-1); for total <= 1,
+// ratio is 1.0 (everything is shared with itself). total is the top-level item
+// count. This mirrors chunkmap.ShareRatio.
+func (ui *uiserver) snapshotChunkmap(w http.ResponseWriter, r *http.Request) error {
+	raws := QueryParamToStrings(r, "path")
+	if len(raws) == 0 {
+		return parameterError("path", MissingArgument, ErrMissingField)
+	}
+	if len(raws) > maxChunkmapPaths {
+		return parameterError("path", InvalidArgument,
+			fmt.Errorf("too many paths, at most %d may be compared", maxChunkmapPaths))
+	}
+
+	files := make([]chunkmap.File, 0, len(raws))
+	for _, raw := range raws {
+		mac, path, err := resolveSnapshotPath(ui.repository, raw, "path")
+		if err != nil {
+			return err
+		}
+
+		snap, err := loadsnap(ui.repository, mac)
+		if err != nil {
+			return err
+		}
+
+		fs, err := snap.Filesystem()
+		if err != nil {
+			return err
+		}
+
+		entry, err := fs.GetEntry(path)
+		if err != nil {
+			return fmt.Errorf("chunkmap: %q: %w", raw, err)
+		}
+
+		if entry.ResolvedObject == nil {
+			return parameterError("path", InvalidArgument,
+				fmt.Errorf("%q has no content (directory or empty object)", raw))
+		}
+
+		files = append(files, chunkmap.File{
+			Label:  raw,
+			Chunks: entry.ResolvedObject.Chunks,
+		})
+	}
+
+	res := chunkmap.Compute(files)
+	return json.NewEncoder(w).Encode(Items[chunkmap.FileShare]{Total: res.Total, Items: res.Files})
+}

--- a/api/api_chunkmap_test.go
+++ b/api/api_chunkmap_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PlakarKorp/plakar/chunkmap"
+	ptesting "github.com/PlakarKorp/plakar/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotChunkmap(t *testing.T) {
+	mux, repo, snap1, _ := server(t, "")
+	defer snap1.Close()
+
+	// A second snapshot with identical content: the shared files hash to the
+	// same chunk MACs, so they show up as fully shared across the two.
+	snap2 := ptesting.GenerateSnapshot(t, repo, []ptesting.MockFile{
+		ptesting.NewMockDir("subdir"),
+		ptesting.NewMockFile("subdir/dummy.txt", 0644, "hello dummy"),
+		ptesting.NewMockFile("top.txt", 0644, "top level"),
+	})
+	defer snap2.Close()
+
+	id1 := snapid(snap1)
+	id2 := snapid(snap2)
+
+	t.Run("fully shared across snapshots", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap?path="+id1+":/top.txt&path="+id2+":/top.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		// Wire format the frontend depends on: snake_case keys, hex MAC.
+		body := w.Body.String()
+		require.Contains(t, body, `"share_count"`)
+		require.Contains(t, body, `"content_mac"`)
+		require.Contains(t, body, `"fully_shared"`)
+
+		var resp Items[chunkmap.FileShare]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 2, resp.Total)
+		require.Len(t, resp.Items, 2)
+
+		for _, f := range resp.Items {
+			require.Greater(t, f.Stats.NChunks, 0)
+			require.Equal(t, f.Stats.NChunks, f.Stats.FullyShared)
+			require.Equal(t, 0, f.Stats.Unique)
+			require.Equal(t, 0, f.Stats.PartiallyShared)
+			require.Len(t, f.Chunks, f.Stats.NChunks)
+			for _, c := range f.Chunks {
+				require.Equal(t, 2, c.ShareCount)
+				require.Len(t, c.ContentMAC.FormatHex(), 64)
+			}
+		}
+	})
+
+	t.Run("all unique across distinct files", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap?path="+id1+":/top.txt&path="+id1+":/subdir/dummy.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var resp Items[chunkmap.FileShare]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 2, resp.Total)
+		require.Len(t, resp.Items, 2)
+
+		for _, f := range resp.Items {
+			require.Greater(t, f.Stats.NChunks, 0)
+			require.Equal(t, f.Stats.NChunks, f.Stats.Unique)
+			require.Equal(t, 0, f.Stats.FullyShared)
+			for _, c := range f.Chunks {
+				require.Equal(t, 1, c.ShareCount)
+			}
+		}
+	})
+
+	t.Run("single path is fully shared with itself", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap?path="+id1+":/top.txt")
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var resp Items[chunkmap.FileShare]
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, 1, resp.Total)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, id1+":/top.txt", resp.Items[0].Label)
+		require.Equal(t, resp.Items[0].Stats.NChunks, resp.Items[0].Stats.FullyShared)
+	})
+
+	t.Run("missing path parameter", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("too many paths", func(t *testing.T) {
+		url := "/api/snapshot/chunkmap?path=" + id1 + ":/top.txt"
+		for i := 0; i < maxChunkmapPaths; i++ {
+			url += "&path=" + id1 + ":/top.txt"
+		}
+		w := get(t, mux, url)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("bad snapshot prefix", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap?path=ffffffff:/top.txt")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap?path="+id1+":/no-such-file.txt")
+		require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	})
+
+	t.Run("directory has no content", func(t *testing.T) {
+		w := get(t, mux, "/api/snapshot/chunkmap?path="+id1+":/subdir")
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	})
+}

--- a/api/api_params.go
+++ b/api/api_params.go
@@ -12,19 +12,26 @@ import (
 	"github.com/PlakarKorp/plakar/utils"
 )
 
-// Parse a URL parameter with the format "snapshotID:path".
-func SnapshotPathParam(r *http.Request, repo *repository.Repository, param string) (objects.MAC, string, error) {
-	idstr, path := utils.ParseSnapshotID(r.PathValue(param))
+// Resolve a "snapshotID:path" string into a snapshot MAC and its path. The
+// field name is used to attribute parameter errors. Shared by SnapshotPathParam
+// (URL path values) and handlers that read such strings from the query string.
+func resolveSnapshotPath(repo *repository.Repository, raw, field string) (objects.MAC, string, error) {
+	idstr, path := utils.ParseSnapshotID(raw)
 
 	if idstr == "" {
-		return objects.MAC{}, "", parameterError(param, MissingArgument, ErrMissingField)
+		return objects.MAC{}, "", parameterError(field, MissingArgument, ErrMissingField)
 	}
 
 	mac, err := locate.LocateSnapshotByPrefix(repo, idstr)
 	if err != nil {
-		return objects.MAC{}, "", parameterError(param, InvalidArgument, err)
+		return objects.MAC{}, "", parameterError(field, InvalidArgument, err)
 	}
 	return mac, path, nil
+}
+
+// Parse a URL parameter with the format "snapshotID:path".
+func SnapshotPathParam(r *http.Request, repo *repository.Repository, param string) (objects.MAC, string, error) {
+	return resolveSnapshotPath(repo, r.PathValue(param), param)
 }
 
 func PathParamToID(r *http.Request, param string) (id [32]byte, err error) {

--- a/chunkmap/chunkmap.go
+++ b/chunkmap/chunkmap.go
@@ -1,0 +1,104 @@
+// Package chunkmap computes how the chunks of a file are shared across several
+// snapshots: for each chunk, how many of the compared files contain it. It is
+// the shared core behind the `diag chunkmap` command and the chunkmap API
+// endpoint, so both agree on what "fully shared", "partially shared" and
+// "unique" mean for the same repository.
+package chunkmap
+
+import "github.com/PlakarKorp/kloset/objects"
+
+// File is one labeled file's chunk sequence, the input to Compute.
+type File struct {
+	Label  string
+	Chunks []objects.Chunk
+}
+
+// ChunkShare reports, for a single chunk, how many of the compared files share
+// it. Index is the chunk's position within its file; ShareCount counts each
+// file once (a chunk repeated within one file still counts as that one file).
+type ChunkShare struct {
+	Index      int         `json:"index"`
+	ShareCount int         `json:"share_count"`
+	ContentMAC objects.MAC `json:"content_mac"`
+}
+
+// Stats summarizes one file's chunks by sharing bucket.
+type Stats struct {
+	NChunks         int `json:"n_chunks"`
+	FullyShared     int `json:"fully_shared"`
+	PartiallyShared int `json:"partially_shared"`
+	Unique          int `json:"unique"`
+}
+
+// FileShare is the per-file result: its label, bucket counts, and per-chunk
+// share data in original order.
+type FileShare struct {
+	Label  string       `json:"label"`
+	Stats  Stats        `json:"stats"`
+	Chunks []ChunkShare `json:"chunks"`
+}
+
+// Result is the outcome of comparing Total files.
+type Result struct {
+	Total int
+	Files []FileShare
+}
+
+// Compute counts, for every distinct chunk MAC, how many of the given files
+// contain it (once per file), then classifies each file's chunks as fully
+// shared (present in all files), unique (present in exactly one), or partially
+// shared. With a single file every chunk is reported as fully shared, since it
+// is present in all (one) of the compared files.
+func Compute(files []File) Result {
+	total := len(files)
+
+	shareCount := make(map[objects.MAC]int)
+	for _, f := range files {
+		seen := make(map[objects.MAC]struct{})
+		for _, chunk := range f.Chunks {
+			if _, ok := seen[chunk.ContentMAC]; !ok {
+				seen[chunk.ContentMAC] = struct{}{}
+				shareCount[chunk.ContentMAC]++
+			}
+		}
+	}
+
+	res := Result{Total: total, Files: make([]FileShare, 0, total)}
+	for _, f := range files {
+		fs := FileShare{
+			Label:  f.Label,
+			Chunks: make([]ChunkShare, len(f.Chunks)),
+		}
+		fs.Stats.NChunks = len(f.Chunks)
+		for i, chunk := range f.Chunks {
+			sc := shareCount[chunk.ContentMAC]
+			// Order matters: when total == 1, `case total` wins over `case 1`,
+			// so a lone file's chunks are fully shared, not unique.
+			switch sc {
+			case total:
+				fs.Stats.FullyShared++
+			case 1:
+				fs.Stats.Unique++
+			default:
+				fs.Stats.PartiallyShared++
+			}
+			fs.Chunks[i] = ChunkShare{
+				Index:      i,
+				ShareCount: sc,
+				ContentMAC: chunk.ContentMAC,
+			}
+		}
+		res.Files = append(res.Files, fs)
+	}
+	return res
+}
+
+// ShareRatio maps a chunk's share count to 0.0 (unique to its file) .. 1.0
+// (present in all files). shareCount includes the file itself; total is the
+// number of files compared.
+func ShareRatio(shareCount, total int) float64 {
+	if total <= 1 {
+		return 1.0
+	}
+	return float64(shareCount-1) / float64(total-1)
+}

--- a/chunkmap/chunkmap_test.go
+++ b/chunkmap/chunkmap_test.go
@@ -1,0 +1,128 @@
+package chunkmap
+
+import (
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/stretchr/testify/require"
+)
+
+// mac builds a distinct MAC from a single byte, enough to key chunks in tests.
+func mac(b byte) objects.MAC {
+	var m objects.MAC
+	m[0] = b
+	return m
+}
+
+func chunk(b byte) objects.Chunk {
+	return objects.Chunk{ContentMAC: mac(b)}
+}
+
+func TestComputeAllUnique(t *testing.T) {
+	res := Compute([]File{
+		{Label: "a", Chunks: []objects.Chunk{chunk(1), chunk(2)}},
+		{Label: "b", Chunks: []objects.Chunk{chunk(3), chunk(4)}},
+	})
+
+	require.Equal(t, 2, res.Total)
+	require.Len(t, res.Files, 2)
+	for _, f := range res.Files {
+		require.Equal(t, Stats{NChunks: 2, Unique: 2}, f.Stats)
+		for _, c := range f.Chunks {
+			require.Equal(t, 1, c.ShareCount)
+		}
+	}
+}
+
+func TestComputeAllFullyShared(t *testing.T) {
+	res := Compute([]File{
+		{Label: "a", Chunks: []objects.Chunk{chunk(1), chunk(2)}},
+		{Label: "b", Chunks: []objects.Chunk{chunk(1), chunk(2)}},
+	})
+
+	require.Equal(t, 2, res.Total)
+	for _, f := range res.Files {
+		require.Equal(t, Stats{NChunks: 2, FullyShared: 2}, f.Stats)
+		for _, c := range f.Chunks {
+			require.Equal(t, 2, c.ShareCount)
+		}
+	}
+}
+
+func TestComputeMixed(t *testing.T) {
+	// A in all 3 files, B in 2 of 3, C in 1.
+	res := Compute([]File{
+		{Label: "a", Chunks: []objects.Chunk{chunk('A'), chunk('B'), chunk('C')}},
+		{Label: "b", Chunks: []objects.Chunk{chunk('A'), chunk('B')}},
+		{Label: "c", Chunks: []objects.Chunk{chunk('A')}},
+	})
+
+	require.Equal(t, 3, res.Total)
+	require.Equal(t, Stats{NChunks: 3, FullyShared: 1, PartiallyShared: 1, Unique: 1}, res.Files[0].Stats)
+	require.Equal(t, Stats{NChunks: 2, FullyShared: 1, PartiallyShared: 1}, res.Files[1].Stats)
+	require.Equal(t, Stats{NChunks: 1, FullyShared: 1}, res.Files[2].Stats)
+
+	// Per-chunk share counts and index ordering.
+	require.Equal(t, []int{3, 2, 1}, shareCounts(res.Files[0]))
+	require.Equal(t, []int{3, 2}, shareCounts(res.Files[1]))
+	require.Equal(t, []int{3}, shareCounts(res.Files[2]))
+	for _, f := range res.Files {
+		for i, c := range f.Chunks {
+			require.Equal(t, i, c.Index)
+		}
+	}
+}
+
+func TestComputeSingleFileIsFullyShared(t *testing.T) {
+	// With one file, every chunk is present in all (one) compared files.
+	res := Compute([]File{
+		{Label: "solo", Chunks: []objects.Chunk{chunk(1), chunk(2), chunk(3)}},
+	})
+
+	require.Equal(t, 1, res.Total)
+	require.Equal(t, Stats{NChunks: 3, FullyShared: 3}, res.Files[0].Stats)
+	for _, c := range res.Files[0].Chunks {
+		require.Equal(t, 1, c.ShareCount)
+	}
+}
+
+func TestComputeRepeatedMACCountedOncePerFile(t *testing.T) {
+	// The same MAC appears twice within file "a" but must count as one file.
+	res := Compute([]File{
+		{Label: "a", Chunks: []objects.Chunk{chunk(1), chunk(1)}},
+		{Label: "b", Chunks: []objects.Chunk{chunk(1)}},
+	})
+
+	require.Equal(t, 2, res.Total)
+	// Share count is 2 (both files), not 3 (total chunk occurrences).
+	require.Equal(t, Stats{NChunks: 2, FullyShared: 2}, res.Files[0].Stats)
+	require.Equal(t, Stats{NChunks: 1, FullyShared: 1}, res.Files[1].Stats)
+	for _, c := range res.Files[0].Chunks {
+		require.Equal(t, 2, c.ShareCount)
+	}
+}
+
+func TestComputeEmpty(t *testing.T) {
+	res := Compute(nil)
+	require.Equal(t, 0, res.Total)
+	require.Empty(t, res.Files)
+}
+
+func TestShareRatio(t *testing.T) {
+	// total <= 1 short-circuits to 1.0.
+	require.Equal(t, 1.0, ShareRatio(1, 1))
+	require.Equal(t, 1.0, ShareRatio(0, 0))
+
+	// unique -> 0, all -> 1, midpoint -> 0.5.
+	require.Equal(t, 0.0, ShareRatio(1, 3))
+	require.Equal(t, 1.0, ShareRatio(3, 3))
+	require.Equal(t, 0.5, ShareRatio(2, 3))
+}
+
+func shareCounts(f FileShare) []int {
+	out := make([]int, len(f.Chunks))
+	for i, c := range f.Chunks {
+		out[i] = c.ShareCount
+	}
+	return out
+}

--- a/subcommands/diag/chunkmap.go
+++ b/subcommands/diag/chunkmap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/PlakarKorp/kloset/objects"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/chunkmap"
 	"github.com/PlakarKorp/plakar/subcommands"
 	"github.com/spf13/cobra"
 )
@@ -46,14 +47,8 @@ func (cmd *DiagChunkmap) Parse(ctx *appcontext.AppContext, args []string) error 
 	return nil
 }
 
-type chunkmapFile struct {
-	label  string
-	chunks []objects.Chunk
-}
-
 func (cmd *DiagChunkmap) Execute(ctx *appcontext.AppContext, repo *repository.Repository) (int, error) {
-	chunksCount := make(map[objects.MAC]int)
-	files := make([]chunkmapFile, 0, len(cmd.SnapshotPaths))
+	files := make([]chunkmap.File, 0, len(cmd.SnapshotPaths))
 
 	for _, snapshotPath := range cmd.SnapshotPaths {
 		err := func() error {
@@ -77,17 +72,9 @@ func (cmd *DiagChunkmap) Execute(ctx *appcontext.AppContext, repo *repository.Re
 				return fmt.Errorf("no object found for entry %s in snapshot %s", pathname, snapshotPath)
 			}
 
-			seen := make(map[objects.MAC]struct{})
-			for _, chunk := range entry.ResolvedObject.Chunks {
-				if _, ok := seen[chunk.ContentMAC]; !ok {
-					seen[chunk.ContentMAC] = struct{}{}
-					chunksCount[chunk.ContentMAC]++
-				}
-			}
-
-			files = append(files, chunkmapFile{
-				label:  snapshotPath,
-				chunks: entry.ResolvedObject.Chunks,
+			files = append(files, chunkmap.File{
+				Label:  snapshotPath,
+				Chunks: entry.ResolvedObject.Chunks,
 			})
 			return nil
 		}()
@@ -96,20 +83,13 @@ func (cmd *DiagChunkmap) Execute(ctx *appcontext.AppContext, repo *repository.Re
 		}
 	}
 
+	res := chunkmap.Compute(files)
+
 	if cmd.HTMLOutput != "" {
-		return writeChunkmapHTML(cmd.HTMLOutput, files, chunksCount)
+		return writeChunkmapHTML(cmd.HTMLOutput, res)
 	}
 
-	return writeChunkmapText(ctx, files, chunksCount)
-}
-
-// shareRatio returns 0.0 (unique) to 1.0 (present in all files).
-// shareCount includes the file itself; total is the number of files provided.
-func shareRatio(shareCount, total int) float64 {
-	if total <= 1 {
-		return 1.0
-	}
-	return float64(shareCount-1) / float64(total-1)
+	return writeChunkmapText(ctx, res)
 }
 
 // ansiColorForRatio returns an ANSI 256-color escape for a red→green gradient.
@@ -135,63 +115,26 @@ const (
 	blockChar = "█"
 )
 
-func writeChunkmapText(ctx *appcontext.AppContext, files []chunkmapFile, chunksCount map[objects.MAC]int) (int, error) {
-	total := len(files)
-	for _, f := range files {
-		fullyShared, partiallyShared, unique := 0, 0, 0
+func writeChunkmapText(ctx *appcontext.AppContext, res chunkmap.Result) (int, error) {
+	for _, f := range res.Files {
 		var sb strings.Builder
-
-		for _, chunk := range f.chunks {
-			sc := chunksCount[chunk.ContentMAC]
-
-			switch sc {
-			case total:
-				fullyShared++
-			case 1:
-				unique++
-			default:
-				partiallyShared++
-			}
-			sb.WriteString(ansiColorForRatio(shareRatio(sc, total)))
+		for _, c := range f.Chunks {
+			sb.WriteString(ansiColorForRatio(chunkmap.ShareRatio(c.ShareCount, res.Total)))
 			sb.WriteString(blockChar)
 		}
 		sb.WriteString(ansiReset)
 
 		fmt.Fprintf(ctx.Stdout, "%s: %d chunks, %d in all (%d partial, %d unique)\n",
-			f.label, len(f.chunks), fullyShared, partiallyShared, unique)
+			f.Label, f.Stats.NChunks, f.Stats.FullyShared, f.Stats.PartiallyShared, f.Stats.Unique)
 		fmt.Fprintln(ctx.Stdout, sb.String())
 		fmt.Fprintln(ctx.Stdout)
 	}
 	return 0, nil
 }
 
-type chunkmapChunkData struct {
-	Index      int
-	ShareCount int
-	Total      int
-	MAC        objects.MAC
-}
-
-type chunkmapStats struct {
-	NChunks         int
-	FullyShared     int
-	PartiallyShared int
-	Unique          int
-}
-
-type chunkmapFileData struct {
-	Label  string
-	Stats  chunkmapStats
-	Chunks []chunkmapChunkData
-}
-
-type chunkmapTemplateData struct {
-	Files []chunkmapFileData
-}
-
 var chunkmapTemplate = template.Must(template.New("chunkmap").Funcs(template.FuncMap{
 	"hslColor": func(shareCount, total int) template.CSS {
-		return htmlColorForRatio(shareRatio(shareCount, total))
+		return htmlColorForRatio(chunkmap.ShareRatio(shareCount, total))
 	},
 	"macHex": func(mac objects.MAC) string {
 		return fmt.Sprintf("%x", mac)
@@ -230,7 +173,7 @@ h1 { color: #fff; }
   <div class="summary">{{.Stats.NChunks}} chunks &mdash; {{.Stats.FullyShared}} in all files, {{.Stats.PartiallyShared}} partial, {{.Stats.Unique}} unique</div>
   <div class="chunks">
     {{range .Chunks -}}
-    <div class="chunk" style="background:{{hslColor .ShareCount .Total}}" title="chunk {{.Index}}: {{.ShareCount}}/{{.Total}} files, {{macHex .MAC}}"></div>
+    <div class="chunk" style="background:{{hslColor .ShareCount $.Total}}" title="chunk {{.Index}}: {{.ShareCount}}/{{$.Total}} files, {{macHex .ContentMAC}}"></div>
     {{end -}}
   </div>
 </div>
@@ -239,46 +182,15 @@ h1 { color: #fff; }
 </html>
 `))
 
-func writeChunkmapHTML(outputPath string, files []chunkmapFile, chunksCount map[objects.MAC]int) (int, error) {
+func writeChunkmapHTML(outputPath string, res chunkmap.Result) (int, error) {
 	f, err := os.Create(outputPath)
 	if err != nil {
 		return 1, fmt.Errorf("cannot create HTML file: %w", err)
 	}
 	defer f.Close()
 
-	total := len(files)
-	data := chunkmapTemplateData{Files: make([]chunkmapFileData, 0, len(files))}
-
-	for _, file := range files {
-		chunks := make([]chunkmapChunkData, len(file.chunks))
-		var s chunkmapStats
-		s.NChunks = len(file.chunks)
-		for i, chunk := range file.chunks {
-			sc := chunksCount[chunk.ContentMAC]
-			switch sc {
-			case total:
-				s.FullyShared++
-			case 1:
-				s.Unique++
-			default:
-				s.PartiallyShared++
-			}
-			chunks[i] = chunkmapChunkData{
-				Index:      i,
-				ShareCount: sc,
-				Total:      total,
-				MAC:        chunk.ContentMAC,
-			}
-		}
-		data.Files = append(data.Files, chunkmapFileData{
-			Label:  file.label,
-			Stats:  s,
-			Chunks: chunks,
-		})
-	}
-
 	bw := bufio.NewWriter(f)
-	if err := chunkmapTemplate.Execute(bw, data); err != nil {
+	if err := chunkmapTemplate.Execute(bw, res); err != nil {
 		return 1, fmt.Errorf("failed to render HTML: %w", err)
 	}
 	if err := bw.Flush(); err != nil {

--- a/subcommands/diag/chunkmap_test.go
+++ b/subcommands/diag/chunkmap_test.go
@@ -1,0 +1,54 @@
+package diag
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/objects"
+	"github.com/PlakarKorp/plakar/chunkmap"
+	"github.com/stretchr/testify/require"
+)
+
+func macFromByte(b byte) objects.MAC {
+	var m objects.MAC
+	m[0] = b
+	return m
+}
+
+// TestWriteChunkmapHTML pins the HTML rendering so the shared-package refactor
+// (and future edits) keep the byte format the `--html` output had: the template
+// resolves $.Total to the file count and macHex to the chunk's ContentMAC.
+func TestWriteChunkmapHTML(t *testing.T) {
+	shared := objects.Chunk{ContentMAC: macFromByte(0xAB)} // in both files
+	uniqA := objects.Chunk{ContentMAC: macFromByte(0x01)}  // only in file a
+	uniqB := objects.Chunk{ContentMAC: macFromByte(0x02)}  // only in file b
+
+	res := chunkmap.Compute([]chunkmap.File{
+		{Label: "aaaa:plakar", Chunks: []objects.Chunk{shared, uniqA}},
+		{Label: "bbbb:plakar", Chunks: []objects.Chunk{shared, uniqB}},
+	})
+
+	path := filepath.Join(t.TempDir(), "out.html")
+	code, err := writeChunkmapHTML(path, res)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	html := string(data)
+
+	sharedHex := "ab" + strings.Repeat("0", 62)
+	uniqAHex := "01" + strings.Repeat("0", 62)
+
+	// $.Total resolves to the file count (2); tooltip and macHex are correct.
+	require.Contains(t, html, "chunk 0: 2/2 files, "+sharedHex)
+	require.Contains(t, html, "chunk 1: 1/2 files, "+uniqAHex)
+	// Colour: fully shared -> ratio 1.0 -> hsl 120.0; unique -> ratio 0.0 -> 0.0.
+	require.Contains(t, html, "hsl(120.0,70%,45%)")
+	require.Contains(t, html, "hsl(0.0,70%,45%)")
+	// Per-file summary line and label.
+	require.Contains(t, html, "aaaa:plakar")
+	require.Contains(t, html, "2 chunks &mdash; 1 in all files, 0 partial, 1 unique")
+}


### PR DESCRIPTION
Add a new `GET /api/snapshot/chunkmap` endpoint with `?path=` query params to mirror the CLI API `plakar at @mystore diag chunkmap snapId:path1 snapId2:path2 snapId3:path3`

This API will be used by a new OSS UI page displaying chunkmaps. Example usage:
<img width="1512" height="778" alt="Screenshot 2026-09-07 at 10 57 55" src="https://github.com/user-attachments/assets/230327c8-61b9-424d-86c2-e6ca12398bcd" />

Extra careful consideration might be needed regarding memory usage on heavy files. (But the PR reuses the CLI implementation for that, so nothing new is introduced)


(Created with AI, using PlakarKorp Standards)