### PR TITLE
config: support repository passphrase env

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -191,9 +191,17 @@ func completionRepository() (*appcontext.AppContext, *repository.Repository, fun
 	ctx.SetCache(caching.NewManager(pebble.Constructor(cacheDir)))
 	nop = func() { ctx.GetCache().Close(); ctx.Close() }
 
-	storeConfig, err := ctx.Config.GetRepository(completionRepositoryPath(ctx))
+	repositoryPath := completionRepositoryPath(ctx)
+	storeConfig, err := ctx.Config.GetRepository(repositoryPath)
 	if err != nil {
 		return nil, nil, nop, err
+	}
+	passphrase, err := getPassphraseFromEnv(ctx, storeConfig, repositoryPath)
+	if err != nil {
+		return nil, nil, nop, err
+	}
+	if passphrase != "" {
+		ctx.KeyFromFile = passphrase
 	}
 
 	store, serialized, err := storage.Open(ctx.GetInner(), storeConfig)

--- a/config/config.go
+++ b/config/config.go
@@ -3,11 +3,14 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
 	"maps"
 )
+
+const repositoryEnvPrefix = "PLAKAR_REPOSITORIES_"
 
 type Config struct {
 	DefaultRepository string
@@ -40,23 +43,65 @@ func (c *Config) GetRepository(name string) (map[string]string, error) {
 
 	name, rootOverride := resolveRootOverride(name)
 
-	kv, ok := c.Repositories[name[1:]]
+	repositoryName := name[1:]
+	kv, ok := c.Repositories[repositoryName]
 	if !ok {
 		return nil, fmt.Errorf("could not resolve repository: %s", name)
 	}
-	if _, ok := kv["location"]; !ok {
-		return nil, fmt.Errorf("repository %s has no location", name)
-	} else {
-		res := make(map[string]string)
-		maps.Copy(res, kv)
 
-		location, err := applyRootOverride(res["location"], rootOverride)
-		if err != nil {
-			return nil, err
-		}
-		res["location"] = location
-		return res, nil
+	res := make(map[string]string)
+	maps.Copy(res, kv)
+
+	if _, ok := res["location"]; !ok {
+		return nil, fmt.Errorf("repository %s has no location", name)
 	}
+
+	location, err := applyRootOverride(res["location"], rootOverride)
+	if err != nil {
+		return nil, err
+	}
+	res["location"] = location
+	return res, nil
+}
+
+func (c *Config) GetRepositoryPassphrase(name string) (string, bool, error) {
+	return c.repositoryEnvironmentValue(name, "PASSPHRASE")
+}
+
+func (c *Config) GetRepositoryPassphraseCommand(name string) (string, bool, error) {
+	return c.repositoryEnvironmentValue(name, "PASSPHRASE_CMD")
+}
+
+func (c *Config) repositoryEnvironmentValue(name string, key string) (string, bool, error) {
+	if !strings.HasPrefix(name, "@") {
+		return "", false, nil
+	}
+
+	name, _ = resolveRootOverride(name)
+	repositoryName := name[1:]
+	envKey := repositoryEnvPrefix + encodeRepositoryEnvironmentName(repositoryName) + "_" + key
+	value, ok := os.LookupEnv(envKey)
+	if !ok {
+		return "", false, nil
+	}
+	if c.repositoryEnvironmentNameAmbiguous(repositoryName) {
+		return "", false, fmt.Errorf("ambiguous environment override for repository %q", repositoryName)
+	}
+	return value, ok, nil
+}
+
+func (c *Config) repositoryEnvironmentNameAmbiguous(name string) bool {
+	envName := encodeRepositoryEnvironmentName(name)
+	for other := range c.Repositories {
+		if other != name && encodeRepositoryEnvironmentName(other) == envName {
+			return true
+		}
+	}
+	return false
+}
+
+func encodeRepositoryEnvironmentName(name string) string {
+	return strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 }
 
 func (c *Config) HasSource(name string) bool {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -57,6 +57,159 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLoadAppliesRepositoryEnvironmentOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfg := NewConfig()
+	cfg.Repositories["remote-store"] = map[string]string{
+		"location": "sftp://backup.example/store",
+	}
+
+	if err := Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	t.Setenv("PLAKAR_REPOSITORIES_REMOTE_STORE_PASSPHRASE", "from-env")
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	repo, err := loaded.GetRepository("@remote-store")
+	if err != nil {
+		t.Fatalf("GetRepository: %v", err)
+	}
+	if repo["location"] != "sftp://backup.example/store" {
+		t.Fatalf("location = %q, want original location", repo["location"])
+	}
+	if _, ok := repo["passphrase"]; ok {
+		t.Fatal("environment passphrase was returned in repository storage config")
+	}
+	passphrase, ok, err := loaded.GetRepositoryPassphrase("@remote-store")
+	if err != nil {
+		t.Fatalf("GetRepositoryPassphrase: %v", err)
+	}
+	if !ok || passphrase != "from-env" {
+		t.Fatalf("passphrase = %q, %v; want from-env, true", passphrase, ok)
+	}
+	if _, ok := loaded.Repositories["remote-store"]["passphrase"]; ok {
+		t.Fatal("environment passphrase was stored in loaded config")
+	}
+
+	if err := Save(dir, loaded); err != nil {
+		t.Fatalf("Save after env override: %v", err)
+	}
+	stores, err := os.ReadFile(filepath.Join(dir, "stores.yml"))
+	if err != nil {
+		t.Fatalf("read stores.yml: %v", err)
+	}
+	if strings.Contains(string(stores), "from-env") {
+		t.Fatal("environment passphrase was persisted to stores.yml")
+	}
+}
+
+func TestGetRepositoryEnvironmentOverrideNilEntryDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	mustWrite("sources.yml", "version: v1.0.0\nsources: {}\n")
+	mustWrite("destinations.yml", "version: v1.0.0\ndestinations: {}\n")
+	mustWrite("stores.yml", "version: v1.0.0\nstores:\n  peer:\n")
+
+	t.Setenv("PLAKAR_REPOSITORIES_PEER_PASSPHRASE", "from-env")
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if _, err := cfg.GetRepository("@peer"); err == nil {
+		t.Fatal("expected missing location error")
+	}
+}
+
+func TestGetRepositoryEnvironmentOverrideRejectsAmbiguousAlias(t *testing.T) {
+	cfg := NewConfig()
+	cfg.Repositories["remote-store"] = map[string]string{"location": "/remote-store"}
+	cfg.Repositories["remote_store"] = map[string]string{"location": "/remote_store"}
+
+	t.Setenv("PLAKAR_REPOSITORIES_REMOTE_STORE_PASSPHRASE", "from-env")
+
+	if _, _, err := cfg.GetRepositoryPassphrase("@remote-store"); err == nil {
+		t.Fatal("expected ambiguous environment override error")
+	}
+	if _, _, err := cfg.GetRepositoryPassphrase("@remote_store"); err == nil {
+		t.Fatal("expected ambiguous environment override error")
+	}
+}
+
+func TestGetRepositoryEnvironmentOverrideUsesLongestAlias(t *testing.T) {
+	cfg := NewConfig()
+	cfg.Repositories["remote"] = map[string]string{"location": "/remote"}
+	cfg.Repositories["remote-store"] = map[string]string{"location": "/remote-store"}
+
+	t.Setenv("PLAKAR_REPOSITORIES_REMOTE_STORE_PASSPHRASE", "from-env")
+
+	shortRepo, err := cfg.GetRepository("@remote")
+	if err != nil {
+		t.Fatalf("GetRepository short alias: %v", err)
+	}
+	if _, ok := shortRepo["store_passphrase"]; ok {
+		t.Fatal("longer repository environment override leaked into shorter alias")
+	}
+
+	longRepo, err := cfg.GetRepository("@remote-store")
+	if err != nil {
+		t.Fatalf("GetRepository long alias: %v", err)
+	}
+	if _, ok := longRepo["passphrase"]; ok {
+		t.Fatal("environment passphrase was returned in repository storage config")
+	}
+	passphrase, ok, err := cfg.GetRepositoryPassphrase("@remote-store")
+	if err != nil {
+		t.Fatalf("GetRepositoryPassphrase long alias: %v", err)
+	}
+	if !ok || passphrase != "from-env" {
+		t.Fatalf("passphrase = %q, %v; want from-env, true", passphrase, ok)
+	}
+}
+
+func TestGetRepositoryEnvironmentOverrideLongestAliasWithAmbiguousPrefix(t *testing.T) {
+	cfg := NewConfig()
+	cfg.Repositories["remote-store"] = map[string]string{"location": "/remote-store"}
+	cfg.Repositories["remote_store"] = map[string]string{"location": "/remote_store"}
+	cfg.Repositories["remote-store-extra"] = map[string]string{"location": "/remote-store-extra"}
+
+	t.Setenv("PLAKAR_REPOSITORIES_REMOTE_STORE_EXTRA_PASSPHRASE", "from-env")
+
+	shortRepo, err := cfg.GetRepository("@remote-store")
+	if err != nil {
+		t.Fatalf("GetRepository short alias: %v", err)
+	}
+	if _, ok := shortRepo["extra_passphrase"]; ok {
+		t.Fatal("longer repository environment override leaked into shorter alias")
+	}
+
+	longRepo, err := cfg.GetRepository("@remote-store-extra")
+	if err != nil {
+		t.Fatalf("GetRepository long alias: %v", err)
+	}
+	if _, ok := longRepo["passphrase"]; ok {
+		t.Fatal("environment passphrase was returned in repository storage config")
+	}
+	passphrase, ok, err := cfg.GetRepositoryPassphrase("@remote-store-extra")
+	if err != nil {
+		t.Fatalf("GetRepositoryPassphrase long alias: %v", err)
+	}
+	if !ok || passphrase != "from-env" {
+		t.Fatalf("passphrase = %q, %v; want from-env, true", passphrase, ok)
+	}
+}
+
 func TestSaveConfigMkdirFails(t *testing.T) {
 	// Point ConfigDir at a path whose parent is a regular file -> MkdirAll fails.
 	f := filepath.Join(t.TempDir(), "afile")
@@ -85,6 +238,7 @@ default-repo: legacy
 repositories:
   legacy:
     location: /tmp/legacy
+    passphrase: from-file
 remotes:
   src:
     location: fs:///var/src
@@ -92,6 +246,7 @@ remotes:
 	if err := os.WriteFile(filepath.Join(dir, "plakar.yml"), []byte(old), 0o600); err != nil {
 		t.Fatalf("write old config: %v", err)
 	}
+	t.Setenv("PLAKAR_REPOSITORIES_LEGACY_PASSPHRASE", "from-env")
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -102,6 +257,23 @@ remotes:
 	}
 	if cfg.Repositories["legacy"]["location"] != "/tmp/legacy" {
 		t.Fatalf("legacy location = %q", cfg.Repositories["legacy"]["location"])
+	}
+	repo, err := cfg.GetRepository("@legacy")
+	if err != nil {
+		t.Fatalf("GetRepository: %v", err)
+	}
+	if repo["passphrase"] != "from-file" {
+		t.Fatalf("repository passphrase = %q, want from-file", repo["passphrase"])
+	}
+	passphrase, ok, err := cfg.GetRepositoryPassphrase("@legacy")
+	if err != nil {
+		t.Fatalf("GetRepositoryPassphrase: %v", err)
+	}
+	if !ok || passphrase != "from-env" {
+		t.Fatalf("legacy passphrase = %q, %v; want from-env, true", passphrase, ok)
+	}
+	if cfg.Repositories["legacy"]["passphrase"] != "from-file" {
+		t.Fatalf("stored legacy passphrase = %q, want from-file", cfg.Repositories["legacy"]["passphrase"])
 	}
 	// LoadFallback also rewrites the config in new format.
 	for _, name := range []string{"sources.yml", "destinations.yml", "stores.yml"} {

--- a/main.go
+++ b/main.go
@@ -403,7 +403,7 @@ func entryPoint() int {
 
 	// try to get the passphrase from env and store config so that it's
 	// available to subcommands like create.
-	passphrase, err := getPassphraseFromEnv(ctx, storeConfig)
+	passphrase, err := getPassphraseFromEnv(ctx, storeConfig, repositoryPath)
 	if err != nil {
 		logger.Stderr("%s: %s\n", progName(), err)
 		return 1
@@ -601,18 +601,35 @@ func checkUpdate(ctx *appcontext.AppContext, disableSecurityCheck bool) {
 		concerns, rus.Latest, rus.FoundCount)
 }
 
-func getPassphraseFromEnv(ctx *appcontext.AppContext, params map[string]string) (string, error) {
+func getPassphraseFromEnv(ctx *appcontext.AppContext, params map[string]string, repositoryPath ...string) (string, error) {
+	pass, hasPass := params["passphrase"]
+	delete(params, "passphrase")
+	cmd, hasCmd := params["passphrase_cmd"]
+	delete(params, "passphrase_cmd")
+
 	if ctx.KeyFromFile != "" {
 		return ctx.KeyFromFile, nil
 	}
 
-	if pass, ok := params["passphrase"]; ok {
-		delete(params, "passphrase")
+	if len(repositoryPath) > 0 && ctx.Config != nil {
+		if pass, ok, err := ctx.Config.GetRepositoryPassphrase(repositoryPath[0]); err != nil {
+			return "", err
+		} else if ok {
+			return pass, nil
+		}
+
+		if cmd, ok, err := ctx.Config.GetRepositoryPassphraseCommand(repositoryPath[0]); err != nil {
+			return "", err
+		} else if ok {
+			return utils.GetPassphraseFromCommand(cmd)
+		}
+	}
+
+	if hasPass {
 		return pass, nil
 	}
 
-	if cmd, ok := params["passphrase_cmd"]; ok {
-		delete(params, "passphrase_cmd")
+	if hasCmd {
 		return utils.GetPassphraseFromCommand(cmd)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/pkg"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
 	"github.com/PlakarKorp/plakar/cookies"
 )
 
@@ -32,14 +33,18 @@ func newTestCtx(t *testing.T) *appcontext.AppContext {
 func TestGetPassphraseFromEnv_KeyFromFileWins(t *testing.T) {
 	ctx := newTestCtx(t)
 	ctx.KeyFromFile = "secret-from-keyfile"
+	params := map[string]string{"passphrase": "ignored-too"}
 	t.Setenv("PLAKAR_PASSPHRASE", "ignored")
 
-	got, err := getPassphraseFromEnv(ctx, map[string]string{"passphrase": "ignored-too"})
+	got, err := getPassphraseFromEnv(ctx, params)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	if got != "secret-from-keyfile" {
 		t.Fatalf("got %q, want secret-from-keyfile", got)
+	}
+	if _, present := params["passphrase"]; present {
+		t.Fatal("passphrase key should have been deleted from params")
 	}
 }
 
@@ -59,6 +64,25 @@ func TestGetPassphraseFromEnv_ParamsPassphraseConsumed(t *testing.T) {
 	}
 	if params["other"] != "keep" {
 		t.Fatal("unrelated params keys must be preserved")
+	}
+}
+
+func TestGetPassphraseFromEnv_RepositoryEnvWinsAndScrubsParams(t *testing.T) {
+	ctx := newTestCtx(t)
+	ctx.Config = config.NewConfig()
+	ctx.Config.Repositories["remote-store"] = map[string]string{"location": "/repo"}
+	params := map[string]string{"passphrase": "from-config", "location": "/repo"}
+	t.Setenv("PLAKAR_REPOSITORIES_REMOTE_STORE_PASSPHRASE", "from-env")
+
+	got, err := getPassphraseFromEnv(ctx, params, "@remote-store")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got != "from-env" {
+		t.Fatalf("got %q, want from-env", got)
+	}
+	if _, present := params["passphrase"]; present {
+		t.Fatal("passphrase key should have been deleted from params")
 	}
 }
 

--- a/plakar.1
+++ b/plakar.1
@@ -222,6 +222,17 @@ The option
 overrides this environment variable.
 .It Ev PLAKAR_REPOSITORY
 Reference to the Kloset store.
+.It Ev PLAKAR_REPOSITORIES_<NAME>_PASSPHRASE
+Passphrase for an existing repository configuration entry.
+The repository name is uppercased, with hyphens written as underscores.
+For example,
+.Ev PLAKAR_REPOSITORIES_REMOTE_STORE_PASSPHRASE
+supplies the passphrase for the
+.Cm remote-store
+repository.
+.It Ev PLAKAR_REPOSITORIES_<NAME>_PASSPHRASE_CMD
+Command that prints the passphrase for an existing repository configuration
+entry.
 .It Ev PLAKAR_TOKEN
 Token to authenticate for Plakar services.
 .El

--- a/subcommands/help/docs/plakar.md
+++ b/subcommands/help/docs/plakar.md
@@ -319,6 +319,20 @@ The following options are available:
 
 > Reference to the Kloset store.
 
+`PLAKAR_REPOSITORIES_<NAME>_PASSPHRASE`
+
+> Passphrase for an existing repository configuration entry.
+> The repository name is uppercased, with hyphens written as underscores.
+> For example,
+> `PLAKAR_REPOSITORIES_REMOTE_STORE_PASSPHRASE`
+> supplies the passphrase for the
+> **remote-store**
+> repository.
+
+`PLAKAR_REPOSITORIES_<NAME>_PASSPHRASE_CMD`
+
+> Command that prints the passphrase for an existing repository configuration entry.
+
 `PLAKAR_TOKEN`
 
 > Token to authenticate for Plakar services.

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -144,6 +144,10 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 		if err != nil {
 			return fmt.Errorf("peer repository: %w", err)
 		}
+		pass, hasPass, passCmd, hasPassCmd, err := cmd.repositorySecrets(ctx, syncTarget, storeConfig)
+		if err != nil {
+			return err
+		}
 
 		peerStore, peerStoreSerializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
 		if err != nil {
@@ -160,8 +164,21 @@ func (cmd *Ptar) Parse(ctx *appcontext.AppContext, args []string) error {
 		}
 
 		if peerStoreConfig.Encryption != nil {
-			if pass, ok := storeConfig["passphrase"]; ok {
+			if hasPass {
 				key, err := encryption.DeriveKey(peerStoreConfig.Encryption.KDFParams, []byte(pass))
+				if err != nil {
+					return err
+				}
+				if !encryption.VerifyCanary(peerStoreConfig.Encryption, key) {
+					return fmt.Errorf("invalid passphrase")
+				}
+				peerSecret = key
+			} else if hasPassCmd {
+				passphrase, err := utils.GetPassphraseFromCommand(passCmd)
+				if err != nil {
+					return fmt.Errorf("failed to read passphrase from command: %w", err)
+				}
+				key, err := encryption.DeriveKey(peerStoreConfig.Encryption.KDFParams, []byte(passphrase))
 				if err != nil {
 					return err
 				}
@@ -327,6 +344,7 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (
 		if err != nil {
 			return 1, fmt.Errorf("source repository: %w", err)
 		}
+		scrubRepositorySecrets(storeConfig)
 
 		peerStore, peerStoreSerializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
 		if err != nil {
@@ -359,6 +377,32 @@ func (cmd *Ptar) Execute(ctx *appcontext.AppContext, _ *repository.Repository) (
 	}
 
 	return 0, nil
+}
+
+func (cmd *Ptar) repositorySecrets(ctx *appcontext.AppContext, syncTarget string, storeConfig map[string]string) (string, bool, string, bool, error) {
+	pass, hasPass := storeConfig["passphrase"]
+	delete(storeConfig, "passphrase")
+	passCmd, hasPassCmd := storeConfig["passphrase_cmd"]
+	delete(storeConfig, "passphrase_cmd")
+
+	if envPass, ok, err := ctx.Config.GetRepositoryPassphrase(syncTarget); err != nil {
+		return "", false, "", false, err
+	} else if ok {
+		pass = envPass
+		hasPass = true
+		hasPassCmd = false
+	} else if envPassCmd, ok, err := ctx.Config.GetRepositoryPassphraseCommand(syncTarget); err != nil {
+		return "", false, "", false, err
+	} else if ok {
+		passCmd = envPassCmd
+		hasPassCmd = true
+	}
+	return pass, hasPass, passCmd, hasPassCmd, nil
+}
+
+func scrubRepositorySecrets(storeConfig map[string]string) {
+	delete(storeConfig, "passphrase")
+	delete(storeConfig, "passphrase_cmd")
 }
 
 func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryWriter) error {

--- a/subcommands/ptar/ptar_test.go
+++ b/subcommands/ptar/ptar_test.go
@@ -2,25 +2,39 @@ package ptar
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	bfs "github.com/PlakarKorp/integrations/fs/storage"
 	_ "github.com/PlakarKorp/integrations/ptar/storage"
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
 	lscmd "github.com/PlakarKorp/plakar/subcommands/ls"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
 )
 
+var capturedPtarSyncStoreConfigs []map[string]string
+
 func init() {
 	os.Setenv("TZ", "UTC")
 	// several fixtures below use a plaintext -k source on purpose
 	os.Setenv("PLAKAR_INSECURE_PLAINTEXT", "1")
+
+	storage.Register("ptartestfs", 0, func(ctx context.Context, proto string, storeConfig map[string]string) (storage.Store, error) {
+		capturedPtarSyncStoreConfigs = append(capturedPtarSyncStoreConfigs, maps.Clone(storeConfig))
+
+		fsConfig := maps.Clone(storeConfig)
+		fsConfig["location"] = "fs://" + storeConfig["location"][len("ptartestfs://"):]
+		return bfs.NewStore(ctx, "fs", fsConfig)
+	})
 }
 
 func TestExecuteCmdPtarDefault(t *testing.T) {
@@ -118,6 +132,41 @@ func TestExecuteCmdPtarWithSync(t *testing.T) {
 	status, err := subcommand.Execute(ctx, dstRepo)
 	require.NoError(t, err)
 	require.Equal(t, 0, status)
+}
+
+func TestPtarSyncPassphraseNeverReachesTheBackend(t *testing.T) {
+	capturedPtarSyncStoreConfigs = nil
+
+	passphrase := []byte("QsDfG654321&^%*%!")
+	srcRepo, _ := ptesting.GenerateRepository(t, nil, nil, &passphrase)
+	snap := ptesting.GenerateSnapshot(t, srcRepo, []ptesting.MockFile{
+		ptesting.NewMockFile("file.txt", 0644, "hello"),
+	})
+	defer snap.Close()
+
+	dstRepo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	ctx.Config = config.NewConfig()
+	ctx.Config.Repositories["peer"] = map[string]string{
+		"location": "ptartestfs://" + srcRepo.Root(),
+	}
+	t.Setenv("PLAKAR_REPOSITORIES_PEER_PASSPHRASE", string(passphrase))
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{
+		"-plaintext", "-o", filepath.Join(t.TempDir(), "test.ptar"), "-k", "@peer",
+	}))
+
+	status, err := cmd.Execute(ctx, dstRepo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	require.NotEmpty(t, capturedPtarSyncStoreConfigs, "the sync source store was never opened")
+	for i, cfg := range capturedPtarSyncStoreConfigs {
+		_, hasPass := cfg["passphrase"]
+		_, hasPassCmd := cfg["passphrase_cmd"]
+		require.False(t, hasPass, "call #%d: backend received the peer passphrase in cleartext", i)
+		require.False(t, hasPassCmd, "call #%d: backend received passphrase_cmd", i)
+	}
 }
 
 func TestExecuteCmdPtarSyncFiltersSnapshots(t *testing.T) {

--- a/subcommands/sync/sync.go
+++ b/subcommands/sync/sync.go
@@ -106,6 +106,18 @@ func (cmd *Sync) Parse(ctx *appcontext.AppContext, args []string) error {
 	delete(storeConfig, "passphrase")
 	passCmd, hasPassCmd := storeConfig["passphrase_cmd"]
 	delete(storeConfig, "passphrase_cmd")
+	if envPass, ok, err := ctx.Config.GetRepositoryPassphrase(peerRepositoryPath); err != nil {
+		return err
+	} else if ok {
+		pass = envPass
+		hasPass = true
+		hasPassCmd = false
+	} else if envPassCmd, ok, err := ctx.Config.GetRepositoryPassphraseCommand(peerRepositoryPath); err != nil {
+		return err
+	} else if ok {
+		passCmd = envPassCmd
+		hasPassCmd = true
+	}
 
 	peerStore, peerStoreSerializedConfig, err := storage.Open(ctx.GetInner(), storeConfig)
 	if err != nil {


### PR DESCRIPTION
Fix #1263.

Adds PLAKAR_REPOSITORIES_<NAME>_PASSPHRASE and _PASSPHRASE_CMD for named repository configs, with lookup kept separate from storage backend configuration so secrets are not persisted or passed through connector maps. This covers the main, completion, sync, and ptar repository-open paths, including ambiguous-name rejection when an exact env override is present.

## Test verification (RED to GREEN)
RED: with the production patch reverted, focused config/main tests failed to compile because the new repository passphrase APIs/signature were absent; the ptar regression entered the old noninteractive prompt loop and was interrupted.
GREEN: focused config/main/ptar regression tests passed, and the full local suite passed via ./run-ci.sh.
