### PR TITLE
backup,ptar: apply the ignore rules configured on a source

### DIFF
--- a/subcommands/backup/backup.go
+++ b/subcommands/backup/backup.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -219,6 +220,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 	}
 
 	sourcesPerOrig := make(map[string][]importer.Importer)
+	excludesPerOrig := make(map[string][]string)
 	// If we are doing a fake run for statistics instantiate separate importers,
 	// otherwise it makes plugin development harder than needed.
 	sourcesPerOrigForStats := make(map[string][]importer.Importer)
@@ -233,6 +235,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		cmdOptsCopy := make(map[string]string)
 		maps.Copy(cmdOptsCopy, cmd.Opts)
 
+		sourceExcludes := cmd.Excludes
 		if strings.HasPrefix(scanDir, "@") {
 			remote, ok := ctx.Config.GetSource(scanDir[1:])
 			if !ok {
@@ -250,6 +253,14 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 					}
 				}
 			}
+
+			rules, err := utils.SourceIgnoreRules(remote)
+			if err != nil {
+				return 1, fmt.Errorf("source %s: %w", scanDir, err), objects.MAC{}, nil
+			}
+			// Command line last: gitignore is last-match-wins and
+			// it takes precedence, as for the options above.
+			sourceExcludes = append(rules, cmd.Excludes...)
 		}
 
 		// Now that we have resolved the possible @ syntax let's apply the scandir.
@@ -258,12 +269,12 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		}
 
 		excludes := exclude.NewRuleSet()
-		if err := excludes.AddRulesFromArray(cmd.Excludes); err != nil {
+		if err := excludes.AddRulesFromArray(sourceExcludes); err != nil {
 			return 1, fmt.Errorf("failed to setup exclude rules: %w", err), objects.MAC{}, nil
 		}
 
 		importerOpts := ctx.ImporterOpts()
-		importerOpts.Excludes = cmd.Excludes
+		importerOpts.Excludes = sourceExcludes
 
 		imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, cmdOptsCopy)
 		if err != nil {
@@ -277,6 +288,12 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 		)
 
 		importerKey := typ + ":" + orig
+		// Sources sharing an origin are imported through a single
+		// exclude set, so differing rules cannot be honoured.
+		if previous, seen := excludesPerOrig[importerKey]; seen && !slices.Equal(previous, sourceExcludes) {
+			return 1, fmt.Errorf("%s: ignore rules differ from another source of the same origin, back them up separately", scanDir), objects.MAC{}, nil
+		}
+		excludesPerOrig[importerKey] = sourceExcludes
 		sourcesPerOrig[importerKey] = append(sourcesPerOrig[importerKey], imp)
 
 		if cmd.wantsFilesystemSummary(ctx, imp.Flags()) {
@@ -328,7 +345,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 			return 1, err, objects.NilMac, nil
 		}
 
-		if err := source.SetExcludes(cmd.Excludes); err != nil {
+		if err := source.SetExcludes(excludesPerOrig[key]); err != nil {
 			return 1, err, objects.MAC{}, nil
 		}
 
@@ -382,7 +399,7 @@ func (cmd *Backup) DoBackup(ctx *appcontext.AppContext, repo *repository.Reposit
 				return 1, err, objects.NilMac, nil
 			}
 
-			if err := source.SetExcludes(cmd.Excludes); err != nil {
+			if err := source.SetExcludes(excludesPerOrig[key]); err != nil {
 				return 1, err, objects.MAC{}, nil
 			}
 

--- a/subcommands/backup/backup_test.go
+++ b/subcommands/backup/backup_test.go
@@ -1,15 +1,19 @@
 package backup
 
 import (
+	"archive/tar"
 	"bytes"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	_ "github.com/PlakarKorp/integrations/fs/importer"
 	bfs "github.com/PlakarKorp/integrations/fs/storage"
+	_ "github.com/PlakarKorp/integrations/tar/importer"
 	"github.com/PlakarKorp/kloset/caching"
 	"github.com/PlakarKorp/kloset/caching/pebble"
 	"github.com/PlakarKorp/kloset/connectors/storage"
@@ -20,6 +24,7 @@ import (
 	"github.com/PlakarKorp/kloset/resources"
 	"github.com/PlakarKorp/kloset/versioning"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
 	"github.com/PlakarKorp/plakar/ui/stdio"
 	"github.com/stretchr/testify/require"
 )
@@ -393,4 +398,171 @@ func TestExecuteCmdCreateDefaultWithIgnores(t *testing.T) {
 
 	output := bufOut.String()
 	require.NotContains(t, output, "/subdir")
+}
+
+func TestBackupSourceIgnoreRules(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		options func(t *testing.T) map[string]string
+		args    []string
+		absent  []string
+		present string
+	}{
+		{
+			name: "ignore pattern",
+			options: func(*testing.T) map[string]string {
+				return map[string]string{"ignore": "**/subdir"}
+			},
+			absent:  []string{"/subdir/"},
+			present: "/another_subdir/",
+		},
+		{
+			name: "ignore list",
+			options: func(*testing.T) map[string]string {
+				return map[string]string{"ignore": "**/nothing,**/subdir"}
+			},
+			absent:  []string{"/subdir/"},
+			present: "/another_subdir/",
+		},
+		{
+			name: "ignore file",
+			options: func(t *testing.T) map[string]string {
+				path := filepath.Join(t.TempDir(), "ignores")
+				require.NoError(t, os.WriteFile(path, []byte("# comment\n\n**/subdir\n"), 0o600))
+				return map[string]string{"ignore-file": path}
+			},
+			absent:  []string{"/subdir/"},
+			present: "/another_subdir/",
+		},
+		{
+			name: "command line rules apply on top",
+			options: func(*testing.T) map[string]string {
+				return map[string]string{"ignore": "**/another_subdir"}
+			},
+			args:    []string{"-ignore", "**/subdir"},
+			absent:  []string{"/subdir/", "/another_subdir/"},
+			present: "backup completed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bufOut := bytes.NewBuffer(nil)
+			bufErr := bytes.NewBuffer(nil)
+			repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+
+			renderer := stdio.New(ctx)
+			renderer.Run()
+			t.Cleanup(func() { renderer.Wait() })
+			t.Cleanup(ctx.Close)
+			ctx.MaxConcurrency = 1
+
+			ctx.Config = config.NewConfig()
+			source := map[string]string{"location": "fs:" + tmpBackupDir}
+			maps.Copy(source, tc.options(t))
+			ctx.Config.Sources["configured"] = source
+
+			cmd := &Backup{}
+			require.NoError(t, cmd.Parse(ctx, append(tc.args, "@configured")))
+
+			status, err := cmd.Execute(ctx, repo)
+			require.NoError(t, err)
+			require.Equal(t, 0, status)
+
+			out := bufOut.String()
+			for _, absent := range tc.absent {
+				require.NotContains(t, out, absent, "the configured ignore rules were not applied")
+			}
+			require.Contains(t, out, tc.present)
+		})
+	}
+}
+
+func TestBackupSourceIgnoreFileMissing(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["configured"] = map[string]string{
+		"location":    "fs:" + tmpBackupDir,
+		"ignore-file": filepath.Join(t.TempDir(), "does-not-exist"),
+	}
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"@configured"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "source @configured")
+}
+
+func TestBackupSourceIgnoreRulesReachNonFsImporter(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, _, ctx := generateFixtures(t, bufOut, bufErr)
+
+	renderer := stdio.New(ctx)
+	renderer.Run()
+	t.Cleanup(func() { renderer.Wait() })
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	archive := filepath.Join(t.TempDir(), "src.tar")
+	fp, err := os.Create(archive)
+	require.NoError(t, err)
+	tw := tar.NewWriter(fp)
+	for _, name := range []string{"keepme.txt", "skipme.txt"} {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o644, Size: int64(len(name)), Typeflag: tar.TypeReg,
+		}))
+		_, err = tw.Write([]byte(name))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, fp.Close())
+
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["archive"] = map[string]string{
+		"location": "tar:" + archive,
+		"ignore":   "**/skipme.txt",
+	}
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"@archive"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	out := bufOut.String()
+	require.Contains(t, out, "keepme.txt")
+	require.NotContains(t, out, "skipme.txt")
+}
+
+func TestBackupSourceIgnoreRulesConflictInSameOrigin(t *testing.T) {
+	bufOut := bytes.NewBuffer(nil)
+	bufErr := bytes.NewBuffer(nil)
+	repo, tmpBackupDir, ctx := generateFixtures(t, bufOut, bufErr)
+	t.Cleanup(ctx.Close)
+	ctx.MaxConcurrency = 1
+
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["first"] = map[string]string{
+		"location": "fs:" + filepath.Join(tmpBackupDir, "subdir"),
+		"ignore":   "**/dummy.txt",
+	}
+	ctx.Config.Sources["second"] = map[string]string{
+		"location": "fs:" + filepath.Join(tmpBackupDir, "another_subdir"),
+		"ignore":   "**/bar",
+	}
+
+	cmd := &Backup{}
+	require.NoError(t, cmd.Parse(ctx, []string{"@first", "@second"}))
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "ignore rules differ from another source of the same origin")
 }

--- a/subcommands/backup/plakar-backup.1
+++ b/subcommands/backup/plakar-backup.1
@@ -37,6 +37,11 @@ can be either a path, an URI, or a label with the form
 .Dq @ Ns Ar name
 to reference a source connector configured with
 .Xr plakar-source 1 .
+Such a source can carry its own
+.Cm ignore
+and
+.Cm ignore-file
+rules; the ones given below are applied after them and take precedence.
 .Pp
 The alias can also be in the form of
 .Dq @ Ns Ar name Ns Op : Ns path-override
@@ -55,6 +60,12 @@ on the same remote, e.g. different files or different prefixes
 on the same bucket.
 Not all importer connectors support this feature, refer to their
 documentation for more information.
+They are backed up through a single set of exclusion rules, so a run in
+which two of them carry different
+.Cm ignore
+or
+.Cm ignore-file
+rules is refused.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds

--- a/subcommands/config/plakar-source.1
+++ b/subcommands/config/plakar-source.1
@@ -18,6 +18,30 @@ describing a source for a backup operation.
 A source is defined by at least a location, specifying the importer
 to use, and some importer-specific parameters.
 .Pp
+Two options are interpreted by Plakar itself:
+.Bl -tag -width Ds
+.It Cm ignore Ns = Ns Ar patterns
+A comma-separated list of gitignore-style patterns excluded when
+backing up this source.
+.It Cm ignore-file Ns = Ns Ar files
+A comma-separated list of files holding newline-separated gitignore-style
+patterns, treated as
+.Cm ignore .
+.El
+.Pp
+They apply to
+.Xr plakar-backup 1
+and
+.Xr plakar-ptar 1 .
+The rules given on the command line are applied after them and,
+gitignore matching being last-match-wins, take precedence.
+.Pp
+Sources sharing an importer type and an origin are backed up through a
+single set of exclusion rules.
+.Xr plakar-backup 1
+refuses a run in which two of them carry different rules rather than
+apply one source's rules to the other.
+.Pp
 The subcommands are as follows:
 .Bl -tag -width Ds
 .It Cm add Ar name Ar location Op Ar option Ns No = Ns Ar value ...
@@ -98,4 +122,6 @@ for the source entry identified by
 .Sh EXIT STATUS
 .Ex -std
 .Sh SEE ALSO
-.Xr plakar 1
+.Xr plakar 1 ,
+.Xr plakar-backup 1 ,
+.Xr plakar-ptar 1

--- a/subcommands/help/docs/plakar-backup.md
+++ b/subcommands/help/docs/plakar-backup.md
@@ -40,6 +40,11 @@ can be either a path, an URI, or a label with the form
 "@*name*"
 to reference a source connector configured with
 plakar-source(1).
+Such a source can carry its own
+**ignore**
+and
+**ignore-file**
+rules; the ones given below are applied after them and take precedence.
 
 The alias can also be in the form of
 "@*name*\[:path-override]"
@@ -58,6 +63,12 @@ on the same remote, e.g. different files or different prefixes
 on the same bucket.
 Not all importer connectors support this feature, refer to their
 documentation for more information.
+They are backed up through a single set of exclusion rules, so a run in
+which two of them carry different
+**ignore**
+or
+**ignore-file**
+rules is refused.
 
 The options are as follows:
 

--- a/subcommands/help/docs/plakar-ptar.md
+++ b/subcommands/help/docs/plakar-ptar.md
@@ -36,6 +36,17 @@ options naming remote or local kloset repositories, and/or one or more
 arguments identifying files or directories to back up.
 The destination archive name is mandatory and supplied with
 **-o**.
+A
+*path*
+of the form
+"@*name*"
+references a source connector configured with
+plakar-source(1),
+whose own
+**ignore**
+and
+**ignore-file**
+rules are applied before, and overridden by, the flags below.
 
 Unless the
 **-overwrite**
@@ -116,6 +127,7 @@ The **plakar-ptar** utility exits&#160;0 on success, and&#160;&gt;0 if an error 
 
 plakar(1),
 plakar-backup(1),
-plakar-create(1)
+plakar-create(1),
+plakar-source(1)
 
 Plakar - May 5, 2026 - PLAKAR-PTAR(1)

--- a/subcommands/help/docs/plakar-source.md
+++ b/subcommands/help/docs/plakar-source.md
@@ -21,6 +21,32 @@ describing a source for a backup operation.
 A source is defined by at least a location, specifying the importer
 to use, and some importer-specific parameters.
 
+Two options are interpreted by Plakar itself:
+
+**ignore**=*patterns*
+
+> A comma-separated list of gitignore-style patterns excluded when
+> backing up this source.
+
+**ignore-file**=*files*
+
+> A comma-separated list of files holding newline-separated gitignore-style
+> patterns, treated as
+> **ignore**.
+
+They apply to
+plakar-backup(1)
+and
+plakar-ptar(1).
+The rules given on the command line are applied after them and,
+gitignore matching being last-match-wins, take precedence.
+
+Sources sharing an importer type and an origin are backed up through a
+single set of exclusion rules.
+plakar-backup(1)
+refuses a run in which two of them carry different rules rather than
+apply one source's rules to the other.
+
 The subcommands are as follows:
 
 **add** *name* *location* \[*option*=*value ...*]
@@ -117,6 +143,8 @@ The **plakar-source** utility exits&#160;0 on success, and&#160;&gt;0 if an erro
 
 # SEE ALSO
 
-plakar(1)
+plakar(1),
+plakar-backup(1),
+plakar-ptar(1)
 
 Plakar - September 11, 2025 - PLAKAR-SOURCE(1)

--- a/subcommands/ptar/plakar-ptar.1
+++ b/subcommands/ptar/plakar-ptar.1
@@ -33,6 +33,17 @@ options naming remote or local kloset repositories, and/or one or more
 arguments identifying files or directories to back up.
 The destination archive name is mandatory and supplied with
 .Fl o .
+A
+.Ar path
+of the form
+.Dq @ Ns Ar name
+references a source connector configured with
+.Xr plakar-source 1 ,
+whose own
+.Cm ignore
+and
+.Cm ignore-file
+rules are applied before, and overridden by, the flags below.
 .Pp
 Unless the
 .Fl overwrite
@@ -96,4 +107,5 @@ enabled.
 .Sh SEE ALSO
 .Xr plakar 1 ,
 .Xr plakar-backup 1 ,
-.Xr plakar-create 1
+.Xr plakar-create 1 ,
+.Xr plakar-source 1

--- a/subcommands/ptar/ptar.go
+++ b/subcommands/ptar/ptar.go
@@ -366,6 +366,7 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 		opts := map[string]string{
 			"location": loc,
 		}
+		excludes := cmd.Excludes
 		if strings.HasPrefix(loc, "@") {
 			remote, ok := ctx.Config.GetSource(loc[1:])
 			if !ok {
@@ -375,10 +376,18 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 				return fmt.Errorf("could not resolve importer location: %s", loc)
 			}
 			opts = remote
+
+			rules, err := utils.SourceIgnoreRules(remote)
+			if err != nil {
+				return fmt.Errorf("source %s: %w", loc, err)
+			}
+			// Command line last: gitignore is last-match-wins and it
+			// takes precedence over the source configuration.
+			excludes = append(rules, cmd.Excludes...)
 		}
 
 		importerOpts := ctx.ImporterOpts()
-		importerOpts.Excludes = cmd.Excludes
+		importerOpts.Excludes = excludes
 		imp, err := importer.NewImporter(ctx.GetInner(), importerOpts, opts)
 		if err != nil {
 			return err
@@ -394,7 +403,7 @@ func (cmd *Ptar) backup(ctx *appcontext.AppContext, repo *repository.RepositoryW
 			return err
 		}
 
-		if err := source.SetExcludes(cmd.Excludes); err != nil {
+		if err := source.SetExcludes(excludes); err != nil {
 			return err
 		}
 

--- a/subcommands/ptar/ptar_test.go
+++ b/subcommands/ptar/ptar_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/PlakarKorp/kloset/connectors/storage"
 	"github.com/PlakarKorp/kloset/repository"
 	"github.com/PlakarKorp/plakar/appcontext"
+	"github.com/PlakarKorp/plakar/config"
 	lscmd "github.com/PlakarKorp/plakar/subcommands/ls"
 	ptesting "github.com/PlakarKorp/plakar/testing"
 	"github.com/stretchr/testify/require"
@@ -253,4 +254,64 @@ func listPtarContents(t *testing.T, ctx *appcontext.AppContext, path string) str
 	require.Empty(t, strings.TrimSpace(stderr.String()))
 
 	return stdout.String()
+}
+
+func TestExecuteCmdPtarSourceIgnoreRules(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpSourceDir := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("project"),
+		ptesting.NewMockDir("project/.git"),
+		ptesting.NewMockDir("project/.venv"),
+		ptesting.NewMockFile("project/readme.md", 0644, "hello"),
+		ptesting.NewMockFile("project/.git/config", 0644, "hidden"),
+		ptesting.NewMockFile("project/.venv/site.py", 0644, "hidden"),
+	})
+	tmpDir := t.TempDir()
+	out := filepath.Join(tmpDir, "source-ignored.ptar")
+	ignoreFile := filepath.Join(tmpDir, "ptar-ignore")
+	require.NoError(t, os.WriteFile(ignoreFile, []byte(".venv\n"), 0600))
+
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["project"] = map[string]string{
+		"location":    "fs:" + filepath.Join(tmpSourceDir, "project"),
+		"ignore":      ".git",
+		"ignore-file": ignoreFile,
+	}
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", out}))
+	cmd.BackupTargets = listFlag{"@project"}
+
+	status, err := cmd.Execute(ctx, repo)
+	require.NoError(t, err)
+	require.Equal(t, 0, status)
+
+	output := listPtarContents(t, ctx, out)
+	require.Contains(t, output, "/project/readme.md")
+	require.NotContains(t, output, ".git")
+	require.NotContains(t, output, ".venv")
+}
+
+func TestExecuteCmdPtarSourceIgnoreFileMissing(t *testing.T) {
+	repo, ctx := ptesting.GenerateRepositoryWithoutConfig(t, nil, nil, nil)
+	tmpSourceDir := ptesting.GenerateFiles(t, []ptesting.MockFile{
+		ptesting.NewMockDir("project"),
+		ptesting.NewMockFile("project/readme.md", 0644, "hello"),
+	})
+	tmpDir := t.TempDir()
+
+	ctx.Config = config.NewConfig()
+	ctx.Config.Sources["project"] = map[string]string{
+		"location":    "fs:" + filepath.Join(tmpSourceDir, "project"),
+		"ignore-file": filepath.Join(tmpDir, "does-not-exist"),
+	}
+
+	cmd := &Ptar{}
+	require.NoError(t, cmd.Parse(ctx, []string{"-plaintext", "-o", filepath.Join(tmpDir, "missing.ptar")}))
+	cmd.BackupTargets = listFlag{"@project"}
+
+	status, err := cmd.Execute(ctx, repo)
+	require.Error(t, err)
+	require.Equal(t, 1, status)
+	require.Contains(t, err.Error(), "source @project")
 }

--- a/utils/ignore_file.go
+++ b/utils/ignore_file.go
@@ -33,3 +33,27 @@ func LoadIgnoreFile(filename string) ([]string, error) {
 	}
 	return lines, nil
 }
+
+// SourceIgnoreRules returns the exclude rules a configured source carries in
+// its "ignore" and "ignore-file" keys, each a comma-separated list.
+func SourceIgnoreRules(source map[string]string) ([]string, error) {
+	var rules []string
+	for _, filename := range splitCommaList(source["ignore-file"]) {
+		lines, err := LoadIgnoreFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, lines...)
+	}
+	return append(rules, splitCommaList(source["ignore"])...), nil
+}
+
+func splitCommaList(value string) []string {
+	var items []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}

--- a/utils/ignore_file_test.go
+++ b/utils/ignore_file_test.go
@@ -32,3 +32,46 @@ func TestLoadIgnoreFileMissing(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), unableToOpenErrorMarker)
 }
+
+func TestSourceIgnoreRules(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ignoreFileName)
+	require.NoError(t, os.WriteFile(path, []byte("# header\n\nfrom-file\n"), ignoreFileMode))
+
+	for _, tc := range []struct {
+		name   string
+		source map[string]string
+		want   []string
+	}{
+		{
+			name:   "no rules",
+			source: map[string]string{"location": "fs:/tmp"},
+		},
+		{
+			name:   "comma separated list is trimmed",
+			source: map[string]string{"ignore": " *.tmp , , *.log "},
+			want:   []string{"*.tmp", "*.log"},
+		},
+		{
+			name:   "ignore file",
+			source: map[string]string{"ignore-file": path},
+			want:   []string{"from-file"},
+		},
+		{
+			name:   "file rules come before inline ones",
+			source: map[string]string{"ignore-file": path, "ignore": "*.tmp"},
+			want:   []string{"from-file", "*.tmp"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rules, err := SourceIgnoreRules(tc.source)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, rules)
+		})
+	}
+}
+
+func TestSourceIgnoreRulesMissingFile(t *testing.T) {
+	_, err := SourceIgnoreRules(map[string]string{"ignore-file": missingIgnoreFilePath})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), unableToOpenErrorMarker)
+}


### PR DESCRIPTION
A source can carry `ignore` and `ignore-file` options, but only the command line
flags ever reached the exclusion engine, so those rules were silently dropped by
`backup` and `ptar`. Both now read them, with the command line applied last so it
keeps precedence.

Sources sharing an importer type and an origin are imported through a single
`snapshot.Source`, which holds one rule set, so a run mixing different rules for
one origin is refused rather than applying one source's rules to another's files.

The new tests are red on main and green here, including one over a non-fs
importer since only the fs one prunes on `Options.Excludes`; the full local suite
stays green with no regressions.

Refs #1609
