### PR TITLE
login: harden sign-ins with a completion code

### DIFF
--- a/login/completion_code_test.go
+++ b/login/completion_code_test.go
@@ -1,0 +1,123 @@
+package login
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// gatedServer answers the poll with 401 until the expected code arrives on the
+// X-Completion-Code header, then 200. The 401 body is caller-supplied so a test
+// can drive either the new `code` discriminator or the old prose fallback.
+func gatedServer(t *testing.T, wantCode, unauthorizedBody string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Completion-Code") == wantCode {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"tok-ok"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(unauthorizedBody))
+	}))
+}
+
+// pollWithPrompt runs the internal poll with a prompt that feeds answers in
+// order and records how many times it was asked.
+func pollWithPrompt(t *testing.T, flow *loginFlow, answers ...string) (string, error, *int32) {
+	t.Helper()
+	var calls int32
+	i := 0
+	prompt := func(retry bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		a := answers[i]
+		if i < len(answers)-1 {
+			i++
+		}
+		return a, nil
+	}
+	tok, err := flow.poll("abc", 20, time.Millisecond, func() {}, prompt)
+	return tok, err, &calls
+}
+
+// TestCompletionCodeGateNewServer: the api sends the stable `code`, the flow
+// prompts and retries with the header, and gets the token.
+func TestCompletionCodeGateNewServer(t *testing.T) {
+	srv := gatedServer(t, "GOOD-CODE", `{"code":"completion_code_required","error":"invalid completion code"}`)
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	tok, err, calls := pollWithPrompt(t, flow, "GOOD-CODE")
+	if err != nil {
+		t.Fatalf("poll err = %v", err)
+	}
+	if tok != "tok-ok" {
+		t.Fatalf("token = %q, want tok-ok", tok)
+	}
+	if *calls == 0 {
+		t.Fatal("prompt was never called")
+	}
+}
+
+// TestCompletionCodeGateOldServer: an api with no `code` field is still
+// recognized via the prose fallback.
+func TestCompletionCodeGateOldServer(t *testing.T) {
+	srv := gatedServer(t, "GOOD-CODE", `{"error":"invalid completion code"}`)
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	tok, _, _ := pollWithPrompt(t, flow, "wrong", "GOOD-CODE")
+	if tok != "tok-ok" {
+		t.Fatalf("token = %q, want tok-ok (prose fallback + retry)", tok)
+	}
+}
+
+// TestPollSecretMismatchIsFatal: a 401 that is NOT the completion-code gate
+// (here a poll-secret mismatch) must not prompt — it ends the poll with an
+// error.
+func TestPollSecretMismatchIsFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"code":"poll_secret_required","error":"invalid poll secret"}`))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	var prompted int32
+	_, err := flow.poll("abc", 3, time.Millisecond, func() {}, func(retry bool) (string, error) {
+		atomic.AddInt32(&prompted, 1)
+		return "irrelevant", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("err = %v, want a 401 failure", err)
+	}
+	if prompted != 0 {
+		t.Fatal("prompted on a poll-secret 401; that 401 is not recoverable")
+	}
+}
+
+// TestUnauthorizedWithoutPromptIsFatal: the legacy poll path (promptCode nil)
+// treats any 401 as fatal, unchanged.
+func TestUnauthorizedWithoutPromptIsFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"code":"completion_code_required","error":"invalid completion code"}`))
+	}))
+	defer srv.Close()
+
+	flow := newTestFlow(t)
+	flow.baseURL = srv.URL
+
+	if _, err := flow.Poll("abc", 3, time.Millisecond, func() {}); err == nil {
+		t.Fatal("Poll (no prompt) should fail on 401, not prompt")
+	}
+}

--- a/login/login.go
+++ b/login/login.go
@@ -127,8 +127,12 @@ func (flow *loginFlow) poll(pollID string, iterations int, delay time.Duration, 
 	return "", fmt.Errorf("could not obtain token after %d iterations", iterations)
 }
 
+// maxErrorBodySize bounds how much of an error response body is read;
+// the expected content is a small JSON error envelope.
+const maxErrorBodySize = 4096
+
 func isCompletionCodeRequired(body io.Reader) bool {
-	data, _ := io.ReadAll(io.LimitReader(body, 4096))
+	data, _ := io.ReadAll(io.LimitReader(body, maxErrorBodySize))
 	var env struct{ Code string }
 	if json.Unmarshal(data, &env) == nil && env.Code != "" {
 		return env.Code == "completion_code_required"

--- a/login/login.go
+++ b/login/login.go
@@ -17,6 +17,7 @@
 package login
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -25,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/PlakarKorp/plakar/appcontext"
@@ -60,6 +62,13 @@ func NewLoginFlow(appCtx *appcontext.AppContext, noSpawn bool) (*loginFlow, erro
 }
 
 func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, progressCb func()) (string, error) {
+	return flow.poll(pollID, iterations, delay, progressCb, nil)
+}
+
+func (flow *loginFlow) poll(pollID string, iterations int, delay time.Duration, progressCb func(), promptCode func(retry bool) (string, error)) (string, error) {
+	var completionCode string
+	prompted := false
+
 	tick := time.After(0)
 	for range iterations {
 		select {
@@ -70,6 +79,9 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 			req, err := http.NewRequestWithContext(flow.appCtx, "POST", reqUrl, nil)
 			if err != nil {
 				return "", fmt.Errorf("the /auth/login/github/poll API endpoint failed: %w", err)
+			}
+			if completionCode != "" {
+				req.Header.Set("X-Completion-Code", completionCode)
 			}
 
 			client := http.DefaultClient
@@ -94,6 +106,17 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 				progressCb()
 			case http.StatusTooManyRequests:
 				return "", ErrRateLimited
+			case http.StatusUnauthorized:
+				recoverable := isCompletionCodeRequired(resp.Body)
+				resp.Body.Close()
+				if promptCode == nil || !recoverable {
+					return "", fmt.Errorf("unexpected status code: %d", http.StatusUnauthorized)
+				}
+				completionCode, err = promptCode(prompted)
+				if err != nil {
+					return "", err
+				}
+				prompted = true
 			default:
 				resp.Body.Close()
 				return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
@@ -102,6 +125,15 @@ func (flow *loginFlow) Poll(pollID string, iterations int, delay time.Duration, 
 		tick = time.After(delay)
 	}
 	return "", fmt.Errorf("could not obtain token after %d iterations", iterations)
+}
+
+func isCompletionCodeRequired(body io.Reader) bool {
+	data, _ := io.ReadAll(body)
+	var env struct{ Code string }
+	if json.Unmarshal(data, &env) == nil && env.Code != "" {
+		return env.Code == "completion_code_required"
+	}
+	return bytes.Contains(data, []byte("invalid completion code"))
 }
 
 func (flow *loginFlow) Run(provider string, parameters map[string]string) (string, error) {
@@ -117,7 +149,13 @@ func (flow *loginFlow) Run(provider string, parameters map[string]string) (strin
 		return "", fmt.Errorf("unsupported provider: %s", provider)
 	}
 
-	if bodyBytes, err := json.Marshal(parameters); err != nil {
+	// parameters is map[string]string; completion_code is a JSON bool, so the
+	// request body is an any-valued copy with the flag added.
+	payload := map[string]any{"completion_code": true}
+	for k, v := range parameters {
+		payload[k] = v
+	}
+	if bodyBytes, err := json.Marshal(payload); err != nil {
 		return "", fmt.Errorf("failed to marshal JSON: %v", err)
 	} else {
 		body = bytes.NewBuffer(bodyBytes)
@@ -148,8 +186,9 @@ func (flow *loginFlow) Run(provider string, parameters map[string]string) (strin
 
 func (flow *loginFlow) handleGithubResponse(resp *http.Response) (string, error) {
 	var respData struct {
-		URL    string `json:"URL"`
-		PollID string `json:"poll_id"`
+		URL            string `json:"URL"`
+		PollID         string `json:"poll_id"`
+		CompletionCode bool   `json:"completion_code"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
 		return "", fmt.Errorf("failed to decode response JSON: %v", err)
@@ -167,12 +206,14 @@ func (flow *loginFlow) handleGithubResponse(resp *http.Response) (string, error)
 	// Wait for the token to be received
 	fmt.Printf("Waiting for your browser to complete the login")
 	defer fmt.Printf("\n")
-	return flow.Poll(respData.PollID, 300, time.Second, func() { fmt.Printf(".") })
+	return flow.poll(respData.PollID, 300, time.Second, func() { fmt.Printf(".") },
+		flow.completionCodePrompt(respData.CompletionCode))
 }
 
 func (flow *loginFlow) handleEmailResponse(resp *http.Response) (string, error) {
 	var respData struct {
-		PollID string `json:"poll_id"`
+		PollID         string `json:"poll_id"`
+		CompletionCode bool   `json:"completion_code"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
 		return "", fmt.Errorf("failed to decode response JSON: %v", err)
@@ -180,7 +221,27 @@ func (flow *loginFlow) handleEmailResponse(resp *http.Response) (string, error) 
 
 	fmt.Printf("\nCheck your email for the login link. Do not close this window until you have logged in.\n")
 	defer fmt.Printf("\n")
-	return flow.Poll(respData.PollID, 300, time.Second, func() { fmt.Printf(".") })
+	return flow.poll(respData.PollID, 300, time.Second, func() { fmt.Printf(".") },
+		flow.completionCodePrompt(respData.CompletionCode))
+}
+
+func (flow *loginFlow) completionCodePrompt(enabled bool) func(retry bool) (string, error) {
+	if !enabled {
+		return nil
+	}
+	reader := bufio.NewReader(flow.appCtx.Stdin)
+	return func(retry bool) (string, error) {
+		if retry {
+			fmt.Printf("That code didn't match, try again: ")
+		} else {
+			fmt.Printf("\nEnter the code shown in your browser to finish signing in: ")
+		}
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("failed to read completion code: %w", err)
+		}
+		return strings.TrimSpace(line), nil
+	}
 }
 
 func (flow *loginFlow) RunUI(provider string, parameters map[string]string) (string, error) {

--- a/login/login.go
+++ b/login/login.go
@@ -128,7 +128,7 @@ func (flow *loginFlow) poll(pollID string, iterations int, delay time.Duration, 
 }
 
 func isCompletionCodeRequired(body io.Reader) bool {
-	data, _ := io.ReadAll(body)
+	data, _ := io.ReadAll(io.LimitReader(body, 4096))
 	var env struct{ Code string }
 	if json.Unmarshal(data, &env) == nil && env.Code != "" {
 		return env.Code == "completion_code_required"


### PR DESCRIPTION
* Makes phishing a login link much harder: the api (>= v1.0.17) shows a short code on the post-sign-in success page and only releases the token to the client that presents it. Whoever completes the sign-in hands the code to the device that started it, confirming both ends belong to the same person.

* plakar login now requests the code (github and email alike): when the api echoes the opt-in, the poll prompts for the code shown in the browser and retries with the X-Completion-Code header. A mistyped code simply re-prompts.

* The poll answers 401 for two reasons — a missing completion code (recoverable: prompt and retry) and a poll-secret mismatch (fatal). It tells them apart on the api's stable "code" field (completion_code_required / poll_secret_required, api >= v1.0.19), falling back to the error prose for older apis.

* An older api ignores the field and never echoes it, so the flow behaves as before against it. RunUI (the local ui's flow) is untouched.